### PR TITLE
Update configuration options and methods sections in agent and backend references

### DIFF
--- a/content/sensu-go/6.4/api/_index.md
+++ b/content/sensu-go/6.4/api/_index.md
@@ -85,7 +85,7 @@ Beta APIs are more stable than alpha versions, but they offer similarly short-li
 ## Request size limit
 
 The default limit for API request body size is 0.512 MB.
-Use the [`--api-request-limit` backend configuration flag][21] to customize the API request body size limit if needed.
+Use the [`api-request-limit` backend configuration option][21] to customize the API request body size limit if needed.
 
 ## Access control
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -1787,7 +1787,7 @@ status: Ss
 [31]: ../#agent-entities
 [32]: ../#proxy-entities
 [33]: ../../../web-ui/view-manage-resources/#manage-entities
-[34]: ../../observe-schedule/agent/#ephemeral-agent-configuration-flags
+[34]: ../../observe-schedule/agent/#ephemeral-agent-configuration
 [35]: ../../observe-schedule/agent/#config-file
 [36]: ../../../api/core/entities/
 [37]: ../../../sensuctl/create-manage-resources/#update-resources

--- a/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-entities/entities.md
@@ -222,9 +222,9 @@ If you change an agent entity's class to `proxy`, the backend will revert the ch
 ### Manage agent entities via the agent
 
 If you prefer, you can manage agent entities via the agent rather than the backend.
-To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
+To do this, add the [`agent-managed-entity`][16] configuration option when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
 
-When you start an agent with the `--agent-managed-entity` flag or set `agent-managed-entity: true` in `agent.yml`, the agent becomes responsible for managing its entity configuration.
+When you start an agent with the `agent-managed-entity` configuration option set to `true`, the agent becomes responsible for managing its entity configuration.
 An entity managed by this agent will include the label `sensu.io/managed_by: sensu-agent`.
 You cannot update these agent-managed entities via the Sensu backend REST API.
 To change an agent's configuration, restart the agent.
@@ -1233,7 +1233,7 @@ arm_version: 7
 
 cloud_provider | 
 ---------------|------ 
-description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
+description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`detect-cloud-provider`][25] configuration option is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
 **NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
 {{% /notice %}}
 required       | false 
@@ -1594,7 +1594,7 @@ name: eth0
 ### Processes attributes
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag](../../observe-schedule/agent/#discover-processes) in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes`](../../observe-schedule/agent/#discover-processes) configuration option in the packaged Sensu Go distribution.
 For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -37,7 +37,7 @@ Instead, you must configure event handlers to send the data to a storage solutio
 
 ## Configure the StatsD listener
 
-Use flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
+Use configuration flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
 
 The following flags allow you to configure event handlers, flush interval, address, and port:
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-process/handlers.md
@@ -275,8 +275,8 @@ spec:
 
 {{< /language-toggle >}}
 
-You can also use the [`keepalive-handlers`][19] flag to send keepalive events to any handler you have configured.
-If you do not specify a keepalive handler with the `keepalive-handlers` flag, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+You can also use the [`keepalive-handlers`][19] configuration option to send keepalive events to any handler you have configured.
+If you do not specify a keepalive handler with the `keepalive-handlers` configuration option, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 
 ## Handler specification
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -124,7 +124,7 @@ read the [entities reference][3] and [Monitor external resources][33] for more i
 ## Create observability events using the agent API
 
 The Sensu agent API allows external sources to send monitoring data to Sensu without requiring the external sources to know anything about Sensu's internal implementation.
-The agent API listens on the address and port specified by the [API configuration flags][18].
+The agent API listens on the address and port specified with the agent [API configuration options][18].
 Only unsecured HTTP (no HTTPS) is supported at this time.
 Any requests for unknown endpoints result in an HTTP `404 Not Found` response.
 
@@ -136,7 +136,7 @@ In case of a loss of connection with the backend or agent shutdown, the agent pr
 When the connection is reestablished, the agent sends the queued events to the backend.
 
 The agent API `/events` endpoint uses a configurable burst limit and rate limit for relaying events to the backend.
-Read [API configuration flags](#api-configuration-flags) to configure the `events-burst-limit` and `events-rate-limit` flags.
+Read [API configuration](#api-configuration) to configure the `events-burst-limit` and `events-rate-limit` options.
 
 #### Example POST request to events endpoint {#events-post-example}
 
@@ -301,14 +301,14 @@ For more information, read the [StatsD documentation][21].
 
 ### Configure the StatsD listener
 
-To configure the StatsD listener, specify the [`statsd-event-handlers`][22] configuration flag in the [agent configuration][24], and start the agent.
+To configure the StatsD listener, specify the [`statsd-event-handlers`][22] configuration option in the [agent configuration][24], and start the agent.
 For example, to start an agent that sends StatsD metrics to InfluxDB, run:
 
 {{< code shell >}}
 sensu-agent --statsd-event-handlers influx-db
 {{< /code >}}
 
-Use the [StatsD configuration flags][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
+Use the [StatsD configuration options][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
 For example, to start an agent with a customized address and flush interval, run:
 
 {{< code shell >}}
@@ -323,7 +323,7 @@ sensu-agent --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd
 
 Sensu agents listen for external monitoring data using TCP and UDP sockets.
 The agent sockets accept JSON event data and pass events to the Sensu backend event pipeline for processing.
-The TCP and UDP sockets listen on the address and port specified by the [socket configuration flags][17].
+The TCP and UDP sockets listen on the address and port specified by the [socket configuration options][17].
 
 ### Use the TCP socket
 
@@ -489,19 +489,19 @@ example      | {{< code json >}}{
 ## Keepalive monitoring
 
 Sensu keepalives are the heartbeat mechanism used to ensure that all registered agents are operational and able to reach the [Sensu backend][2].
-Sensu agents publish keepalive events containing [entity][3] configuration data to the Sensu backend according to the interval specified by the [`keepalive-interval`][4] configuration flag.
+Sensu agents publish keepalive events containing [entity][3] configuration data to the Sensu backend according to the interval specified by the [`keepalive-interval`][4] configuration option.
 
-If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-critical-timeout`][4] configuration flag, the Sensu backend creates a keepalive **critical** alert in the Sensu web UI.
+If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-critical-timeout`][4] configuration option, the Sensu backend creates a keepalive **critical** alert in the Sensu web UI.
 The `keepalive-critical-timeout` is set to `0` (disabled) by default to help ensure that it will not interfere with your `keepalive-warning-timeout` setting.
 
-If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-warning-timeout`][58] configuration flag, the Sensu backend creates a keepalive **warning** alert in the Sensu web UI.
+If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-warning-timeout`][58] configuration option, the Sensu backend creates a keepalive **warning** alert in the Sensu web UI.
 The value you specify for `keepalive-warning-timeout` must be lower than the value you specify for `keepalive-critical-timeout`.
 
 {{% notice note %}}
-**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
+**NOTE**: If you set the [`deregister` configuration option](#ephemeral-agent-configuration) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
 Deregistration prevents and clears alerts for failing keepalives for agent entities &mdash; the backend does not distinguish between intentional shutdown and failure.
-As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
-If you want to receive alerts for failing keepalives, set the [deregister](#ephemeral-agent-configuration-flags) configuration flag to `false`.
+As a result, if you set `deregister` to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
+If you want to receive alerts for failing keepalives, set the [deregister configuration option](#ephemeral-agent-configuration) to `false`.
 {{% /notice %}}
 
 You can use keepalives to identify unhealthy systems and network partitions, send notifications, and trigger auto-remediation, among other useful actions.
@@ -553,8 +553,8 @@ spec:
 
 {{< /language-toggle >}}
 
-You can also use the [`keepalive-handlers`][53] flag to send keepalive events to any handler you have configured.
-If you do not specify a keepalive handler with the `keepalive-handlers` flag, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+You can also use the [`keepalive-handlers`][53] configuration option to send keepalive events to any handler you have configured.
+If you do not specify a keepalive handler with the `keepalive-handlers` option, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 
 ## Connection failure
 
@@ -801,8 +801,8 @@ However, all registration events are logged in the [Sensu backend log](../backen
 
 As with registration events, the Sensu backend can create and process a deregistration event when the Sensu agent process stops.
 You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
-To enable deregistration events, use the [`deregister` flag][13], and specify the event handler using the [`deregistration-handler` flag][13].
-You can specify a deregistration handler per agent using the [`deregistration-handler` agent flag][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration flag][37].
+To enable deregistration events, use the [`deregister` option][13], and specify the event handler using the [`deregistration-handler` option][13].
+You can specify a deregistration handler per agent using the [`deregistration-handler` agent option][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration option][37].
 
 {{% notice note %}}
 **NOTE**: Deregistration is supported for [agent entities](../../observe-entities/#agent-entities) that have sent at least one keepalive.
@@ -812,40 +812,31 @@ Deregistration is **not** supported for [proxy entities](../../observe-entities/
 ### Cluster
 
 Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url` configuration flag][16].
-For more information about clustering, read [Backend datastore configuration flags][35] and [Run a Sensu cluster][36].
+For more information about clustering, read [Backend datastore configuration][35] and [Run a Sensu cluster][36].
 
 ### Synchronize time
 
 System clocks between agents and the backend should be synchronized to a central NTP server.
 If system time is out of sync, it may cause issues with keepalive, metric, and check alerts.
 
-## Configuration via flags
+## Agent configuration options
 
-The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
+Agent configuration is customizable.
+This section describes each configuration option in more detail, including examples for each [configuration method][70].
 
-{{< platformBlock "Linux" >}}
-
-### Linux
-
-Specify the agent configuration with either a `.yml` file or `sensu-agent start` command line flags.
-Configuration via command line flags overrides attributes specified in a configuration file.
-Review the [example Sensu agent configuration file][5] for flags and defaults.
-
-### Configuration summary
+You can customize agent configuration with the [agent configuration file][69] (Linux and Windows), [command line flag arguments][24] (Linux), or [environment variables][50] (Linux and Windows).
 
 {{% notice note %}}
-**NOTE**: Process discovery is disabled in this version of Sensu.
-The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**NOTE**: The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 {{% /notice %}}
 
-To view configuration information for the sensu-agent start command, run:
+To view available configuration options for the `sensu-agent start` command, run:
 
 {{< code shell >}}
 sensu-agent start --help
 {{< /code >}}
 
-The response will list command information and configuration flags for sensu-agent start:
+The response will list configuration options as command line flags for `sensu-agent start`:
 
 {{< code text >}}
 start the sensu agent
@@ -904,22 +895,13 @@ Flags:
       --user string                         agent user (default "agent")
 {{< /code >}}
 
-{{< platformBlockClose >}}
-
-{{< platformBlock "Windows" >}}
-
-### Windows
-
-Specify the agent configuration using a `.yml` file.
-Review the [example agent configuration file][5] (also provided with Sensu packages at `%ALLUSERSPROFILE%\sensu\config\agent.yml.example`; default `C:\ProgramData\sensu\config\agent.yml.example`).
-
-{{< platformBlockClose >}}
-
-### General configuration flags
-
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+**NOTE**: Process discovery is disabled in this version of Sensu.
+The `--discover-processes` configuration option is not available, and new events will not include data in the `processes` attributes.
+Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
+
+### General configuration
 
 <a id="agent-managed-entity"></a>
 
@@ -932,20 +914,20 @@ default      | false
 environment variable | `SENSU_AGENT_MANAGED_ENTITY`
 command line example   | {{< code shell >}}
 sensu-agent start --agent-managed-entity{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 agent-managed-entity: true{{< /code >}}
 
 <a id="allow-list"></a>
 
 | allow-list |      |
 ------------------|------
-description       | Path to yaml or json file that contains the allow list of check or hook commands the agent can execute. Read [allow list configuration commands][49] and the [example allow list configuration][48] for information about building a configuration file.
+description       | Path to yaml or json file that contains the allow list of check or hook commands the agent can execute. Read [Allow list configuration][49] and the [example allow list configuration][48] for information about building a configuration file.
 type              | String
 default           | `""`
 environment variable | `SENSU_ALLOW_LIST`
 command line example   | {{< code shell >}}
 sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
 
 | annotations|      |
@@ -961,10 +943,12 @@ command line example   | {{< code shell >}}
 sensu-agent start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-agent start --annotations example-key="example value" --annotations example-key2="example value"
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
+
+<a id="assets-burst-limit"></a>
 
 | assets-burst-limit   |      |
 --------------|------
@@ -974,7 +958,7 @@ default       | `100`
 environment variable | `SENSU_ASSETS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --assets-burst-limit 100{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
 
 | assets-rate-limit   |      |
@@ -985,7 +969,7 @@ default       | `1.39`
 environment variable | `SENSU_ASSETS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --assets-rate-limit 1.39{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 <a id="backend-handshake-timeout"></a>
@@ -998,7 +982,7 @@ default       | `15`
 environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-handshake-timeout 20{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
 <a id="backend-heartbeat-interval"></a>
@@ -1011,7 +995,7 @@ default       | `30`
 environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
 <a id="backend-heartbeat-timeout"></a>
@@ -1024,7 +1008,7 @@ default       | `45`
 environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-heartbeat-timeout 60{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-heartbeat-timeout: 60{{< /code >}}
 
 | backend-url |      |
@@ -1033,7 +1017,9 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
-default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
+default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_URL`
 command line example | {{< language-toggle >}}
 {{< code shell "ws" >}}
@@ -1045,7 +1031,7 @@ sensu-agent start --backend-url wss://127.0.0.1:8081
 sensu-agent start --backend-url wss://127.0.0.1:8081 --backend-url wss://127.0.0.1:8082
 {{< /code >}}
 {{< /language-toggle >}}
-/etc/sensu/agent.yml example | {{< language-toggle >}}
+agent.yml config file example | {{< language-toggle >}}
 {{< code shell "ws" >}}
 backend-url:
   - "ws://127.0.0.1:8081"
@@ -1068,7 +1054,7 @@ default       | <ul><li>Linux: `/var/cache/sensu/sensu-agent`</li><li>Windows: `
 environment variable | `SENSU_CACHE_DIR`
 command line example   | {{< code shell >}}
 sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
 <a id="config-file"></a>
@@ -1094,7 +1080,7 @@ default       | false
 environment variable | `SENSU_DISABLE_ASSETS`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-assets{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
 <a id="discover-processes"></a>
@@ -1111,7 +1097,7 @@ default       | false
 environment variable | `SENSU_DISCOVER_PROCESSES`
 command line example   | {{< code shell >}}
 sensu-agent start --discover-processes{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 discover-processes: true{{< /code >}}
 
 | labels     |      |
@@ -1127,7 +1113,7 @@ command line example   | {{< code shell >}}
 sensu-agent start --labels proxy_type=website
 sensu-agent start --labels example_key1="example value" example_key2="example value"
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 labels:
   proxy_type: website
 {{< /code >}}
@@ -1137,12 +1123,12 @@ labels:
 | log-level   |      |
 --------------|------
 description   | Logging level: `panic`, `fatal`, `error`, `warn`, `info`, or `debug`.
-type          | String
-default       | `info` in Sensu Go 6.4.0<br>`warn` in Sensu Go 6.4.1
+type          | String  
+default       | `info` in Sensu Go 6.4.0<br>`warn` in Sensu Go 6.4.1  
 environment variable | `SENSU_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-agent start --log-level debug{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 log-level: debug{{< /code >}}
 
 <a id="name-attribute"></a>
@@ -1155,7 +1141,7 @@ default       | Defaults to hostname (for example, `sensu-centos`).
 environment variable | `SENSU_NAME`
 command line example   | {{< code shell >}}
 sensu-agent start --name agent-01{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 name: "agent-01"{{< /code >}}
 
 <a id="subscriptions-flag"></a>
@@ -1169,13 +1155,13 @@ command line example   | {{< code shell >}}
 sensu-agent start --subscriptions disk-checks,process-checks
 sensu-agent start --subscriptions disk-checks --subscriptions process-checks
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 subscriptions:
   - disk-checks
   - process-checks
 {{< /code >}}
 
-### API configuration flags
+### API configuration
 
 | api-host    |      |
 --------------|------
@@ -1185,7 +1171,7 @@ default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --api-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 api-host: "127.0.0.1"{{< /code >}}
 
 | api-port    |      |
@@ -1196,7 +1182,7 @@ default       | `3031`
 environment variable | `SENSU_API_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --api-port 3031{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 api-port: 3031{{< /code >}}
 
 | disable-api |      |
@@ -1207,7 +1193,7 @@ default       | `false`
 environment variable | `SENSU_DISABLE_API`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-api{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-api: true{{< /code >}}
 
 | events-burst-limit | |
@@ -1218,7 +1204,7 @@ default       | `10`
 environment variable | `SENSU_EVENTS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --events-burst-limit 20{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 events-burst-limit: 20{{< /code >}}
 
 | events-rate-limit | |
@@ -1229,10 +1215,10 @@ default       | `10.0`
 environment variable | `SENSU_EVENTS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --events-rate-limit 20.0{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 events-rate-limit: 20.0{{< /code >}}
 
-### Ephemeral agent configuration flags
+### Ephemeral agent configuration
 
 | deregister  |      |
 --------------|------
@@ -1244,7 +1230,7 @@ default       | `false`
 environment variable | `SENSU_DEREGISTER`
 command line example   | {{< code shell >}}
 sensu-agent start --deregister{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 deregister: true{{< /code >}}
 
 <a id="agent-deregistration-handler-attribute"></a>
@@ -1256,7 +1242,7 @@ type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
 sensu-agent start --deregistration-handler deregister{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 deregistration-handler: deregister{{< /code >}}
 
 <a id="detect-cloud-provider-flag"></a>
@@ -1269,10 +1255,10 @@ default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
 command line example   | {{< code shell >}}
 sensu-agent start --detect-cloud-provider false{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 detect-cloud-provider: false{{< /code >}}
 
-### Keepalive configuration flags
+### Keepalive configuration
 
 | keepalive-critical-timeout |      |
 --------------------|------
@@ -1283,7 +1269,7 @@ default             | `0`
 environment variable   | `SENSU_KEEPALIVE_CRITICAL_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
 <a id="keepalive-handlers-flag"></a>
@@ -1296,7 +1282,7 @@ default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-handlers slack,email{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-handlers:
 - slack
 - email
@@ -1310,7 +1296,7 @@ default              | `20`
 environment variable   | `SENSU_KEEPALIVE_INTERNAL`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-interval 30{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-interval: 30{{< /code >}}
 
 <a id="keepalive-warning-timeout-flag"></a>
@@ -1324,10 +1310,10 @@ default             | `120`
 environment variable   | `SENSU_KEEPALIVE_WARNING_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-warning-timeout 300{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-warning-timeout: 300{{< /code >}}
 
-### Security configuration flags
+### Security configuration
 
 | cert-file  |      |
 -------------|------
@@ -1337,7 +1323,7 @@ default      | `""`
 environment variable | `SENSU_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --cert-file /path/to/tls/agent.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 cert-file: "/path/to/tls/agent.pem"{{< /code >}}
 
 | insecure-skip-tls-verify |      |
@@ -1350,7 +1336,7 @@ default                    | `false`
 environment variable       | `SENSU_INSECURE_SKIP_TLS_VERIFY`
 command line example   | {{< code shell >}}
 sensu-agent start --insecure-skip-tls-verify{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 | key-file   |      |
@@ -1361,7 +1347,7 @@ default      | `""`
 environment variable | `SENSU_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --key-file /path/to/tls/agent-key.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 key-file: "/path/to/tls/agent-key.pem"{{< /code >}}
 
 | namespace |      |
@@ -1375,8 +1361,10 @@ default        | `default`
 environment variable   | `SENSU_NAMESPACE`
 command line example   | {{< code shell >}}
 sensu-agent start --namespace ops{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 namespace: ops{{< /code >}}
+
+<a id="agent-password-option"></a>
 
 | password    |      |
 --------------|------
@@ -1386,7 +1374,7 @@ default       | `P@ssw0rd!`
 environment variable   | `SENSU_PASSWORD`
 command line example   | {{< code shell >}}
 sensu-agent start --password secure-password{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 password: secure-password{{< /code >}}
 
 | redact      |      |
@@ -1400,7 +1388,7 @@ default       | By default, Sensu redacts the following fields: `password`, `pas
 environment variable   | `SENSU_REDACT`
 command line example   | {{< code shell >}}
 sensu-agent start --redact secret,ec2_access_key{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 redact:
   - secret
   - ec2_access_key
@@ -1419,7 +1407,7 @@ default           | false
 environment variable | `SENSU_REQUIRE_FIPS`
 command line example   | {{< code shell >}}
 sensu-agent start --require-fips{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -1433,7 +1421,7 @@ default           | false
 environment variable | `SENSU_REQUIRE_OPENSSL`
 command line example   | {{< code shell >}}
 sensu-agent start --require-openssl{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -1444,8 +1432,10 @@ default           | `""`
 environment variable   | `SENSU_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 trusted-ca-file: "/path/to/tls/ca.pem"{{< /code >}}
+
+<a id="agent-user-option"></a>
 
 | user |      |
 --------------|------
@@ -1455,10 +1445,10 @@ default       | `agent`
 environment variable   | `SENSU_USER`
 command line example   | {{< code shell >}}
 sensu-agent start --user agent-01{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 user: "agent-01"{{< /code >}}
 
-### Socket configuration flags
+### Socket configuration
 
 | disable-sockets |      |
 ------------------|------
@@ -1468,7 +1458,7 @@ default           | `false`
 environment variable   | `SENSU_DISABLE_SOCKETS`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-sockets{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-sockets: true{{< /code >}}
 
 | socket-host |      |
@@ -1479,7 +1469,7 @@ default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --socket-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 socket-host: "127.0.0.1"{{< /code >}}
 
 | socket-port |      |
@@ -1490,10 +1480,10 @@ default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --socket-port 3030{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 socket-port: 3030{{< /code >}}
 
-### StatsD configuration flags
+### StatsD configuration
 
 | statsd-disable |      |
 -----------------|------
@@ -1503,7 +1493,7 @@ default          | `false`
 environment variable   | `SENSU_STATSD_DISABLE`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-disable{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-disable: true{{< /code >}}
 
 | statsd-event-handlers |      |
@@ -1515,7 +1505,7 @@ command line example   | {{< code shell >}}
 sensu-agent start --statsd-event-handlers influxdb,opentsdb
 sensu-agent start --statsd-event-handlers influxdb --statsd-event-handlers opentsdb
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-event-handlers:
   - influxdb
   - opentsdb
@@ -1529,7 +1519,7 @@ default                  | `10`
 environment variable     | `SENSU_STATSD_FLUSH_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-flush-interval 30{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-flush-interval: 30{{< /code >}}
 
 | statsd-metrics-host |      |
@@ -1540,7 +1530,7 @@ default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-metrics-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-metrics-host: "127.0.0.1"{{< /code >}}
 
 | statsd-metrics-port |      |
@@ -1551,13 +1541,13 @@ default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-metrics-port 8125{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-metrics-port: 8125{{< /code >}}
 
-### Allow list configuration commands
+### Allow list configuration
 
 The allow list includes check and hook commands the agent can execute.
-Use the [allow-list flag][56] to specify the path to the yaml or json file that contains your allow list.
+Use the [`allow-list` configuration option][56] to specify the path to the yaml or json file that contains your allow list.
 
 Use these commands to build your allow list configuration file.
 
@@ -1677,9 +1667,38 @@ sha512: 4f926bf4328...
 
 {{< /language-toggle >}}
 
-## Configuration via environment variables
+## Agent configuration methods
 
-Instead of using configuration flags, you can use environment variables to configure your Sensu agent.
+### Agent configuration file
+
+For Linux and Windows agents, you can customize the agent configuration in a `.yml` configuration file.
+
+The default agent configuration file path for Linux is `/etc/sensu/agent.yml`.
+The default agent configuration file path for Windows is `C:\ProgramData\sensu\config\agent.yml.example`.
+
+To use the `agent.yml` file to configure the agent, list the desired configuration attributes and values.
+Review the [example Sensu agent configuration file][5] for a complete example.
+
+Configuration via command line flags or environment variables overrides any configuration specified in the agent configuration file.
+Read [Create overrides][68] to learn more.
+
+### Command line flags
+
+For Linux agents, you can customize the agent configuration with `sensu-agent start` command line flags.
+
+To use command line flags, specify the desired configuration flags and values along with the `sensu-agent start` command.
+For example:
+
+{{< code shell >}}
+sensu-agent start --name webserver_05 --keepalive-warning-timeout 60 --keepalive-critical-timeout 120
+{{< /code >}}
+
+Configuration via command line flags overrides attributes specified in a configuration file or with environment variables.
+Read [Create overrides][68] to learn more.
+
+### Environment variables
+
+Instead of using the agent configuration file or command line flags, you can use environment variables to configure your Sensu agent.
 Each agent configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
@@ -1757,8 +1776,8 @@ sc.exe start SensuAgent
      {{< /language-toggle >}}
 
 {{% notice note %}}
-**NOTE**: Sensu includes an environment variable for each agent configuration flag.
-They are listed in the [configuration flag description tables](#general-configuration-flags).
+**NOTE**: Sensu includes an environment variable for each agent configuration option.
+They are listed in the [configuration description tables](#general-configuration).
 {{% /notice %}}
 
 ### Format for label and annotation environment variables
@@ -1864,12 +1883,12 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 **NOTE**: If you define the `HTTP_PROXY` and `HTTPS_PROXY` environment variables, the agent WebSocket connection will also use the proxy URL you specify.
 {{% /notice %}}
 
-## Create overrides
+## Create configuration overrides
 
 Sensu has default settings and limits for certain configuration attributes, like the default log level.
 Depending on your environment and preferences, you may want to create overrides for these Sensu-specific defaults and limits.
 
-You can create overrides in several ways:
+You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-agent start`.
 - Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
@@ -1923,7 +1942,7 @@ log-level: debug
 [1]: ../../../operations/deploy-sensu/install-sensu#install-sensu-agents
 [2]: ../backend/
 [3]: ../../observe-entities/entities/
-[4]: #keepalive-configuration-flags
+[4]: #keepalive-configuration
 [5]: ../../../files/windows/agent.yml
 [6]: ../../../sensuctl/
 [7]: ../../observe-events/events/
@@ -1932,18 +1951,18 @@ log-level: debug
 [10]: ../../observe-transform/mutators/
 [11]: https://en.wikipedia.org/wiki/Configuration_management_database
 [12]: https://www.servicenow.com/products/it-operations-management.html
-[13]: #ephemeral-agent-configuration-flags
+[13]: #ephemeral-agent-configuration
 [14]: ../checks/
 [15]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
-[16]: #general-configuration-flags
-[17]: #socket-configuration-flags
-[18]: #api-configuration-flags
+[16]: #general-configuration
+[17]: #socket-configuration
+[18]: #api-configuration
 [19]: https://sourceforge.net/projects/netcat/
 [20]: https://en.wikipedia.org/wiki/Dead_man%27s_switch
 [21]: https://github.com/etsy/statsd
-[22]: #statsd-configuration-flags
+[22]: #statsd-configuration
 [23]: https://github.com/statsd/statsd#key-concepts
-[24]: #configuration-via-flags
+[24]: #command-line-flags
 [25]: ../../../api/#response-filtering
 [26]: ../../../sensuctl/filter-responses/
 [27]: ../tokens/
@@ -1954,9 +1973,9 @@ log-level: debug
 [32]: ../checks/#proxy-entity-name-attribute
 [33]: ../../observe-entities/monitor-external-resources/
 [34]: #backend-heartbeat-interval
-[35]: ../backend#datastore-and-cluster-configuration-flags
+[35]: ../backend/#datastore-and-cluster-configuration
 [36]: ../../../operations/deploy-sensu/cluster-sensu/
-[37]: ../backend#general-configuration-flags
+[37]: ../backend/#general-configuration
 [38]: #name
 [39]: ../../../operations/control-access/rbac/#agent-user
 [40]: ../../observe-process/send-slack-alerts/
@@ -1968,8 +1987,8 @@ log-level: debug
 [46]: ../../../operations/deploy-sensu/secure-sensu/
 [47]: https://en.m.wikipedia.org/wiki/Protocol_Buffers
 [48]: #example-allow-list-configuration
-[49]: #allow-list-configuration-commands
-[50]: #configuration-via-environment-variables
+[49]: #allow-list-configuration
+[50]: #environment-variables
 [51]: #events-post-specification
 [52]: ../../observe-process/handlers/#keepalive-event-handlers
 [53]: #keepalive-handlers-flag
@@ -1980,3 +1999,4 @@ log-level: debug
 [58]: #keepalive-warning-timeout-flag
 [59]: ../../../operations/control-access/#use-built-in-basic-authentication
 [60]: #log-level
+[69]: #agent-configuration-file

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -811,7 +811,7 @@ Deregistration is **not** supported for [proxy entities](../../observe-entities/
 
 ### Cluster
 
-Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url` configuration flag][16].
+Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url`][16] configuration option.
 For more information about clustering, read [Backend datastore configuration][35] and [Run a Sensu cluster][36].
 
 ### Synchronize time
@@ -1088,7 +1088,7 @@ disable-assets: true{{< /code >}}
 | discover-processes |      |
 --------------|------
 description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the discover-processes flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `discover-processes` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}{{% notice note %}}
 **NOTE**: Process discovery is disabled in this version of Sensu. The discover-processes flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
@@ -1237,7 +1237,7 @@ deregister: true{{< /code >}}
 
 | deregistration-handler |      |
 -------------------------|------
-description              | Name of the event handler to use when processing the agent's deregistration events. This flag overrides any handlers applied by the [`deregistration-handler` backend configuration flag][37].
+description              | Name of the event handler to use when processing the agent's deregistration events. This configuration option overrides any handlers applied by the [`deregistration-handler`][37] backend configuration option.
 type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
@@ -1249,7 +1249,7 @@ deregistration-handler: deregister{{< /code >}}
 
 | detect-cloud-provider  |      |
 -------------------------|------
-description              | `true` to enable cloud provider detection mechanisms. Otherwise, `false`. When this flag is enabled, the agent will attempt to read files, resolve hostnames, and make HTTP requests to determine what cloud environment it is running in.
+description              | `true` to enable cloud provider detection mechanisms. Otherwise, `false`. When this option is enabled, the agent will attempt to read files, resolve hostnames, and make HTTP requests to determine what cloud environment it is running in.
 type                     | Boolean
 default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
@@ -1276,7 +1276,7 @@ keepalive-critical-timeout: 300{{< /code >}}
 
 | keepalive-handlers |      |
 --------------------|------
-description         | [Keepalive event handlers][52] to use for the entity, specified in a comma-delimited list. You can specify any configured handler and invoke the `keepalive-handlers` flag multiple times. If keepalive handlers are not specified, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+description         | [Keepalive event handlers][52] to use for the entity, specified in a comma-delimited list. You can specify any configured handler and invoke the `keepalive-handlers` configuration option multiple times. If keepalive handlers are not specified, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 type                | List
 default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
@@ -1329,7 +1329,7 @@ cert-file: "/path/to/tls/agent.pem"{{< /code >}}
 | insecure-skip-tls-verify |      |
 ---------------------------|------
 description                | Skip SSL verification. {{% notice warning %}}
-**WARNING**: This configuration flag is intended for use in development systems only. Do not use this flag in production.
+**WARNING**: This configuration option is intended for use in development systems only. Do not use this configuration option in production.
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
@@ -1399,7 +1399,7 @@ redact:
 | require-fips |      |
 ------------------|------
 description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu agent startup if `true` but OpenSSL is not running in FIPS mode. {{% notice note %}}
-**NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `require-fips` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
@@ -1413,7 +1413,7 @@ require-fips: true{{< /code >}}
 | require-openssl |      |
 ------------------|------
 description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu agent startup if `true` but Go's standard cryptography library is loaded. {{% notice note %}}
-**NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `--require-openssl` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -661,9 +661,9 @@ agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 | agent-burst-limit   |      |
 --------------|------
 description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice note %}}
-**NOTE**: The agent-burst-limit flag is deprecated.
+**NOTE**: The `agent-burst-limit` configuration flag is deprecated.
 {{% /notice %}} {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-burst-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-burst-limit` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer
 default       | `null`
@@ -700,7 +700,7 @@ agent-port: 8081{{< /code >}}
 | agent-rate-limit   |      |
 --------------|------
 description   | Maximum number of agent transport WebSocket connections per second, per backend.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-rate-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-rate-limit` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer
 default       | `null`
@@ -714,7 +714,7 @@ agent-rate-limit: 10{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the `dashboard-cert-file` configuration option is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -726,7 +726,7 @@ cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 | insecure-skip-tls-verify |      |
 ---------------------------|------
 description                | If `true`, skip SSL verification. Otherwise, `false`. {{% notice warning %}}
-**WARNING**: This configuration flag is intended for use in development systems only. Do not use this flag in production.
+**WARNING**: This configuration option is intended for use in development systems only. Do not use this configuration option in production.
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
@@ -767,7 +767,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the `dashboard-key-file` configuration option is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
@@ -781,7 +781,7 @@ key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 | require-fips |      |
 ------------------|------
 description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu backend startup if `true` but OpenSSL is not running in FIPS mode. {{% notice note %}}
-**NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `require-fips` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
@@ -795,7 +795,7 @@ require-fips: true{{< /code >}}
 | require-openssl |      |
 ------------------|------
 description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu backend startup if `true` but Go's standard cryptography library is loaded. {{% notice note %}}
-**NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `--require-openssl` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -303,15 +303,7 @@ To configure a cluster, see:
 System clocks between agents and the backend should be synchronized to a central NTP server.
 If system time is out of sync, it may cause issues with keepalive, metric, and check alerts.
 
-## Configuration via flags
-
-You can specify the backend configuration with either a `/etc/sensu/backend.yml` file or `sensu-backend start` [configuration flags][15].
-The backend requires that the `state-dir` flag is set before starting.
-All other required flags have default values.
-Review the [example backend configuration file][17] for flags and defaults.
-The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
-
-### Certificate bundles or chains
+## Certificate bundles or chains
 
 The Sensu backend supports all types of certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 This is because the Go standard library assumes that the first certificate listed in the PEM file is the server certificate &mdash; the certificate that the program will use to show its own identity.
@@ -323,15 +315,24 @@ You must present the whole chain to the remote so it can determine whether it tr
 
 The Sensu backend checks certificate revocation list (CRL) and Online Certificate Status Protocol (OCSP) endpoints for mutual transport layer security (mTLS), etcd client, and etcd peer connections whose remote sides present X.509 certificates that provide CRL and OCSP revocation information.
 
-### Configuration summary
+## Backend configuration options
 
-To view configuration information for the sensu-backend start command, run:
+Backend configuration is customizable.
+This section describes each configuration option in more detail, including examples for each [configuration method][79].
+
+You can customize backend configuration with the [backend configuration file][76], [command line flag arguments][77], or [environment variables][78].
+
+{{% notice note %}}
+**NOTE**: The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
+{{% /notice %}}
+
+To view configuration information for the `sensu-backend start` command, run:
 
 {{< code shell >}}
 sensu-backend start --help
 {{< /code >}}
 
-The response will list command information and configuration flags for sensu-backend start:
+The response will list configuration options as command line flags for `sensu-backend start`:
 
 {{< code text >}}
 start the sensu backend
@@ -416,13 +417,12 @@ Store Flags:
       --no-embed-etcd                              don't embed etcd, use external etcd instead
 {{< /code >}}
 
-For more information about log configuration flags, read [Event logging][65].
+The backend requires that the [`state-dir`][75] configuration option is set before starting.
+All other required flags have default values.
 
-### General configuration flags
+For more information about log configuration options, read [Event logging][65].
 
-{{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
-{{% /notice %}}
+### General configuration
 
 | annotations|      |
 -------------|------
@@ -437,7 +437,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-backend start --annotations example-key="example value" --annotations example-key2="example value"
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
@@ -450,7 +450,7 @@ default      | `[::]:8080`
 environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
 command line example   | {{< code shell >}}
 sensu-backend start --api-listen-address [::]:8080{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
 
 <a id="api-request-limit"></a>
@@ -463,18 +463,20 @@ default      | `512000`
 environment variable | `SENSU_BACKEND_API_REQUEST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --api-request-limit 1024000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-request-limit: 1024000{{< /code >}}
 
 | api-url  |      |
 -------------|------
 description  | URL used to connect to the API.
 type         | String
-default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker)
+default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_API_URL`
 command line example   | {{< code shell >}}
 sensu-backend start --api-url http://localhost:8080{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-url: "http://localhost:8080"{{< /code >}}
 
 | assets-burst-limit   |      |
@@ -485,7 +487,7 @@ default       | `100`
 environment variable | `SENSU_BACKEND_ASSETS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --assets-burst-limit 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
 
 | assets-rate-limit   |      |
@@ -496,7 +498,7 @@ default       | `1.39`
 environment variable | `SENSU_BACKEND_ASSETS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --assets-rate-limit 1.39{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 | cache-dir   |      |
@@ -507,7 +509,7 @@ default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
 command line example   | {{< code shell >}}
 sensu-backend start --cache-dir /var/cache/sensu-backend{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 cache-dir: "/var/cache/sensu-backend"{{< /code >}}
 
 | config-file |      |
@@ -531,7 +533,7 @@ default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
 command line example   | {{< code shell >}}
 sensu-backend start --debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 debug: true{{< /code >}}
 
 <a id="deregistration-handler-attribute"></a>
@@ -544,7 +546,7 @@ default                  | `""`
 environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
 sensu-backend start --deregistration-handler deregister{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 deregistration-handler: "deregister"{{< /code >}}
 
 | labels     |      |
@@ -560,7 +562,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --labels security_zone=us-west-2a
 sensu-backend start --labels example_key1="example value" example_key2="example value"
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
   example_key1: "example value"
@@ -577,7 +579,7 @@ default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-backend start --log-level debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
 
 <a id="metrics-refresh-interval"></a>
@@ -590,8 +592,10 @@ default      | `1m`
 environment variable | `SENSU_BACKEND_METRICS_REFRESH_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --metrics-refresh-interval 10s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 metrics-refresh-interval: "10s"{{< /code >}}
+
+<a id="state-dir-option"></a>
 
 | state-dir  |      |
 -------------|------
@@ -603,10 +607,10 @@ command line example   | {{< code shell >}}
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
 
-### Agent communication configuration flags
+### Agent communication configuration
 
 | agent-auth-cert-file |      |
 -------------|------
@@ -616,7 +620,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-cert-file: /path/to/tls/backend-1.pem{{< /code >}}
 
 | agent-auth-crl-urls |      |
@@ -627,7 +631,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-crl-urls: http://localhost/CARoot.crl{{< /code >}}
 
 | agent-auth-key-file |      |
@@ -638,7 +642,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-key-file: /path/to/tls/backend-1-key.pem{{< /code >}}
 
 | agent-auth-trusted-ca-file |      |
@@ -649,7 +653,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 
 <a id="agent-burst-limit"></a>
@@ -666,7 +670,7 @@ default       | `null`
 environment variable | `SENSU_BACKEND_AGENT_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-burst-limit 10{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-burst-limit: 10{{< /code >}}
 
 | agent-host   |      |
@@ -677,7 +681,7 @@ default        | `[::]`
 environment variable | `SENSU_BACKEND_AGENT_HOST`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-host 127.0.0.1{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-host: "127.0.0.1"{{< /code >}}
 
 | agent-port |      |
@@ -688,7 +692,7 @@ default      | `8081`
 environment variable | `SENSU_BACKEND_AGENT_PORT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-port 8081{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-port: 8081{{< /code >}}
 
 <a id="agent-rate-limit"></a>
@@ -703,10 +707,10 @@ default       | `null`
 environment variable | `SENSU_BACKEND_AGENT_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-rate-limit 10{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-rate-limit: 10{{< /code >}}
 
-### Security configuration flags
+### Security configuration
 
 | cert-file  |      |
 -------------|------
@@ -716,7 +720,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 | insecure-skip-tls-verify |      |
@@ -729,7 +733,7 @@ default                    | `false`
 environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
 command line example   | {{< code shell >}}
 sensu-backend start --insecure-skip-tls-verify{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 <a id="jwt-attributes"></a>
@@ -744,7 +748,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --jwt-private-key-file /path/to/key/private.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 jwt-private-key-file: /path/to/key/private.pem{{< /code >}}
 
 | jwt-public-key-file |      |
@@ -758,7 +762,7 @@ environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
 command line example   | {{< code shell >}}
 sensu-backend start --jwt-public-key-file /path/to/key/public.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
@@ -769,7 +773,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 <a id="fips-openssl"></a>
@@ -785,7 +789,7 @@ default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_FIPS`
 command line example   | {{< code shell >}}
 sensu-backend start --require-fips{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -799,7 +803,7 @@ default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_OPENSSL`
 command line example   | {{< code shell >}}
 sensu-backend start --require-openssl{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -810,20 +814,20 @@ default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 trusted-ca-file: "/path/to/tls/ca.pem"{{< /code >}}
 
-### Web UI configuration flags
+### Web UI configuration
 
 | dashboard-cert-file | |
 -------------|------
-description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` configuration option](#security-configuration) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-cert-file /path/to/tls/separate-webui-cert.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-cert-file: "/path/to/tls/separate-webui-cert.pem"{{< /code >}}
 
 | dashboard-host |      |
@@ -834,18 +838,18 @@ default          | `[::]`
 environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-host 127.0.0.1{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-host: "127.0.0.1"{{< /code >}}
 
 | dashboard-key-file | |
 -------------|------
-description  | Web UI TLS certificate key in PEM format. This key secures communication with the Sensu web UI. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` flag](#security-configuration-flags) for the web UI.
+description  | Web UI TLS certificate key in PEM format. This key secures communication with the Sensu web UI. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` configuration option](#security-configuration) for the web UI.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-key-file /path/to/tls/separate-webui-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-key-file: "/path/to/tls/separate-webui-key.pem"{{< /code >}}
 
 | dashboard-port |      |
@@ -856,14 +860,10 @@ default          | `3000`
 environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-port 3000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-port: 3000{{< /code >}}
 
-### Datastore and cluster configuration flags
-
-{{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
-{{% /notice %}}
+### Datastore and cluster configuration
 
 | etcd-advertise-client-urls |      |
 --------------|------
@@ -872,13 +872,15 @@ description   | List of this member's client URLs to advertise to the rest of th
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
-default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
+default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-advertise-client-urls:
   - http://localhost:2378
   - http://localhost:2379
@@ -895,7 +897,7 @@ default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 <a id="etcd-cipher-suites"></a>
@@ -921,7 +923,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -938,7 +940,7 @@ default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-cert-auth{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-client-cert-auth: true{{< /code >}}
 
 | etcd-client-urls      |      |
@@ -954,11 +956,13 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-urls 'https://10.0.0.1:2379 https://10.1.0.1:2379'
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
+
+<a id="etcd-discovery"></a>
 
 | etcd-discovery        |      |
 ------------------------|------
@@ -971,10 +975,12 @@ default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-discovery:
   - https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 {{< /code >}}
+
+<a id="etcd-discovery-srv"></a>
 
 | etcd-discovery-srv    |      |
 ------------------------|------
@@ -987,7 +993,7 @@ default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-discovery-srv example.org{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-discovery-srv:
   - example.org
 {{< /code >}}
@@ -999,13 +1005,15 @@ description                        | List of this member's peer URLs to advertis
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
-default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
+default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-advertise-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
@@ -1018,11 +1026,13 @@ description            | Initial cluster configuration for bootstrapping.{{% not
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
-default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
+default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380"{{< /code >}}
 
 | etcd-initial-cluster-state |      |
@@ -1036,7 +1046,7 @@ default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster-state existing{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
@@ -1050,7 +1060,7 @@ default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 | etcd-key-file  |      |
@@ -1063,7 +1073,7 @@ type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 <a id="etcd-listen-client-urls"></a>
@@ -1081,7 +1091,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-listen-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
@@ -1100,7 +1110,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-listen-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
@@ -1116,7 +1126,7 @@ default      | [Backend log level][60] value (or `debug`, if the backend log lev
 environment variable | `SENSU_BACKEND_ETCD_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-log-level debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-log-level: "debug"{{< /code >}}
 
 | etcd-name      |      |
@@ -1130,7 +1140,7 @@ default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-name backend-0{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
@@ -1143,7 +1153,7 @@ type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 | etcd-peer-client-cert-auth |      |
@@ -1157,7 +1167,7 @@ default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-client-cert-auth{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-client-cert-auth: true{{< /code >}}
 
 | etcd-peer-key-file |      |
@@ -1170,7 +1180,7 @@ type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 | etcd-peer-trusted-ca-file |      |
@@ -1183,7 +1193,7 @@ type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | etcd-trusted-ca-file |      |
@@ -1197,7 +1207,7 @@ default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-trusted-ca-file ./ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | no-embed-etcd  |      |
@@ -1211,7 +1221,7 @@ default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
 command line example   | {{< code shell >}}
 sensu-backend start --no-embed-etcd{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 no-embed-etcd: true{{< /code >}}
 
 ### Advanced configuration options
@@ -1231,7 +1241,7 @@ default                | `1000`
 environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-election-timeout 1000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
 
 <a id="etcd-heartbeat-interval"></a>
@@ -1248,7 +1258,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-heartbeat-interval 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-heartbeat-interval: 100{{< /code >}}
 
 | etcd-max-request-bytes |      |
@@ -1263,7 +1273,7 @@ default                | `1572864`
 environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-max-request-bytes 1572864{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-max-request-bytes: 1572864{{< /code >}}
 
 | etcd-quota-backend-bytes |      |
@@ -1278,7 +1288,7 @@ default                | `4294967296`
 environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-quota-backend-bytes 4294967296{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-quota-backend-bytes: 4294967296{{< /code >}}
 
 | eventd-buffer-size   |      |
@@ -1291,7 +1301,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --eventd-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 eventd-buffer-size: 100{{< /code >}}
 
 | eventd-workers       |      |
@@ -1304,7 +1314,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --eventd-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 eventd-workers: 100{{< /code >}}
 
 | keepalived-buffer-size |      |
@@ -1317,7 +1327,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --keepalived-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 keepalived-buffer-size: 100{{< /code >}}
 
 | keepalived-workers |      |
@@ -1329,7 +1339,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --keepalived-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 keepalived-workers: 100{{< /code >}}
 
 | pipelined-buffer-size |      |
@@ -1342,7 +1352,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --pipelined-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 pipelined-buffer-size: 100{{< /code >}}
 
 | pipelined-workers |      |
@@ -1355,12 +1365,38 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --pipelined-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 pipelined-workers: 100{{< /code >}}
 
-## Configuration via environment variables
+## Backend configuration methods
 
-Instead of using configuration flags, you can use environment variables to configure your Sensu backend.
+### Backend configuration file
+
+You can customize the backend configuration in a `.yml` configuration file.
+
+To use the `backend.yml` file to configure the backend, list the desired configuration attributes and values.
+Review the [example Sensu backend configuration file][17] for a complete example.
+
+Configuration via command line flags or environment variables overrides any configuration specified in the backend configuration file.
+Read [Create overrides][74] to learn more.
+
+### Command line flags
+
+You can customize the backend configuration with `sensu-agent start` command line flags.
+
+To use command line flags, specify the desired configuration flags and values along with the `sensu-backend start` command.
+For example:
+
+{{< code shell >}}
+sensu-backend start --deregistration-handler slack_deregister --log-level debug
+{{< /code >}}
+
+Configuration via command line flags overrides attributes specified in a configuration file or with environment variables.
+Read [Create overrides][74] to learn more.
+
+### Environment variables
+
+Instead of using a configuration file or command line flags, you can use environment variables to configure your Sensu backend.
 Each backend configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
@@ -1420,7 +1456,7 @@ sudo systemctl restart sensu-backend
 
 {{% notice note %}}
 **NOTE**: Sensu includes an environment variable for each backend configuration flag.
-They are listed in the [configuration flag description tables](#general-configuration-flags).
+They are listed in the [configuration description tables](#general-configuration).
 {{% /notice %}}
 
 ### Format for label and annotation environment variables
@@ -1498,12 +1534,12 @@ spec:
 Read the [secrets reference](https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/) and [Use Env for secrets management](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management) for details.
 {{% /notice %}}
 
-## Create overrides
+## Create configuration overrides
 
 Sensu has default settings and limits for certain configuration attributes, like the default log level.
 Depending on your environment and preferences, you may want to create overrides for these Sensu-specific defaults and limits.
 
-You can create overrides in several ways:
+You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-backend start`.
 - Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
@@ -1568,7 +1604,7 @@ The event logging functionality provides better performance and reliability than
 To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
 {{% /notice %}}
 
-Use these backend configuration flags to customize event logging:
+Use these backend configuration options to customize event logging:
 
 | event-log-buffer-size |      |
 -----------------------|------
@@ -1578,7 +1614,7 @@ default                | 100000
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-buffer-size 100000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-buffer-size: 100000{{< /code >}}
 
 | event-log-buffer-wait |      |
@@ -1589,7 +1625,7 @@ default                | 10ms
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_WAIT`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-buffer-wait 10ms{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-buffer-wait: 10ms{{< /code >}}
 
 <a id="event-log-file"></a>
@@ -1603,7 +1639,7 @@ type                   | String
 environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-file /var/log/sensu/events.log{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-file: "/var/log/sensu/events.log"{{< /code >}}
 
 <a id="event-log-parallel-encoders"></a>
@@ -1618,7 +1654,7 @@ default                | false
 environment variable   | `SENSU_BACKEND_EVENT_LOG_PARALLEL_ENCODERS`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-parallel-encoders true{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-parallel-encoders: true{{< /code >}}
 
 ### Log rotation
@@ -1678,10 +1714,10 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [9]: ../../observe-filter/filters/
 [10]: ../../observe-transform/mutators/
 [11]: ../../observe-process/handlers/
-[12]: #datastore-and-cluster-configuration-flags
+[12]: #datastore-and-cluster-configuration
 [13]: ../../../operations/deploy-sensu/cluster-sensu/
 [14]: ../../../api/
-[15]: #general-configuration-flags
+[15]: #general-configuration
 [16]: https://etcd.io/docs/current/tuning/#time-parameters
 [17]: ../../../files/backend.yml
 [18]: https://golang.org/pkg/crypto/tls/#pkg-constants
@@ -1708,3 +1744,9 @@ This will cause sensu-backend (and sensu-agent, if translated for the Sensu agen
 [60]: #backend-log-level
 [61]: #event-log-file
 [65]: #event-logging
+[74]: #create-configuration-overrides
+[75]: #state-dir-option
+[76]: #backend-configuration-file
+[77]: #backend-configuration-options
+[78]: #environment-variables
+[79]: #backend-configuration-methods

--- a/content/sensu-go/6.4/operations/control-access/rbac.md
+++ b/content/sensu-go/6.4/operations/control-access/rbac.md
@@ -166,7 +166,7 @@ By default, the `agent` user belongs to the `system:agent` group.
 The `system:agent` cluster role binding grants the `system:agent` cluster role to the members of this group.
 To grant agent users the permissions they need to report events into any namespace, add agent users to the `system:agent` group.
 
-Configure the `agent` user's credentials with the [`user` and `password` agent configuration flags][41].
+Configure the `agent` user's credentials with the [`user`][41] and [`password`][68] agent configuration options.
 
 ### View users
 
@@ -3217,7 +3217,7 @@ type: Group
 [38]: ../../../observability-pipeline/observe-schedule/rule-templates/
 [39]: ../ad-auth/#ad-groups-prefix
 [40]: ../../deploy-sensu/etcdreplicators/
-[41]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
+[41]: ../../../observability-pipeline/observe-schedule/agent/#agent-password-option
 [42]: ../../deploy-sensu/install-sensu/#install-the-sensu-backend
 [45]: ../../../sensuctl/#change-the-admin-users-password
 [46]: ../../manage-secrets/secrets-providers/
@@ -3241,3 +3241,4 @@ type: Group
 [65]: #spec-attributes-for-role-binding-and-cluster-role-binding-resources
 [66]: #role_ref-attributes
 [67]: #subjects-attributes
+[68]: ../../../observability-pipeline/observe-schedule/agent/#agent-user-option

--- a/content/sensu-go/6.4/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/deployment-architecture.md
@@ -158,7 +158,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 
 [1]: ../hardware-requirements/#backend-recommended-configuration
 [2]: ../../../api/
-[3]: ../../../observability-pipeline/observe-schedule/agent/#general-configuration-flags
 [4]: https://etcd.io/docs/
 [5]: https://etcd.io/docs/current/op-guide/security/
 [6]: ../secure-sensu/

--- a/content/sensu-go/6.4/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/install-sensu.md
@@ -560,7 +560,7 @@ sensuctl license info
 [4]: ../../../sensuctl/
 [5]: ../../../platforms/
 [6]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
-[7]: ../../../observability-pipeline/observe-schedule/agent#configuration-via-flags
+[7]: ../../../observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [8]: ../secure-sensu/
 [9]: ../../../observability-pipeline/observe-schedule/monitor-server-resources/
 [10]: ../../../observability-pipeline/observe-process/send-slack-alerts/

--- a/content/sensu-go/6.4/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.4/operations/deploy-sensu/secure-sensu.md
@@ -76,7 +76,7 @@ etcd-peer-client-cert-auth: "true"
    Because etcd does not require authentication by default, you must set the `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` parameters to `true` to secure Sensu's embedded etcd datastore against unauthorized access.
 
 {{% notice note %}}
-**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags) includes more information about each etcd store parameter.
+**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration) includes more information about each etcd store parameter.
 {{% /notice %}}
 
 ## Secure the Sensu agent API, HTTP API, and web UI
@@ -118,7 +118,7 @@ After you restart the `sensu-backend` service, the parameters will load and you 
 Configuring these attributes will also ensure that agents can communicate securely.
 
 {{% notice note %}}
-**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#security-configuration-flags) includes more information about each API and web UI security configuration parameter.
+**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#security-configuration) includes more information about each API and web UI security configuration parameter.
 {{% /notice %}}
 
 ### Specify a separate web UI certificate and key
@@ -135,7 +135,7 @@ dashboard-key-file: "/etc/sensu/tls/separate-webui-key.pem"
 
 {{% notice note %}}
 **NOTE**: If you do not specify a separate certificate and key for the web UI with `dashboard-cert-file` and `dashboard-key-file`, Sensu uses the certificate and key specified for the `cert-file` and `key-file` parameters for the web UI.
-The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#web-ui-configuration-flags) includes more information about the `dashboard-cert-file` and `dashboard-key-file` web UI configuration parameters.
+The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#web-ui-configuration) includes more information about the `dashboard-cert-file` and `dashboard-key-file` web UI configuration parameters.
 {{% /notice %}}
 
 ## Secure Sensu agent-to-server communication
@@ -262,7 +262,6 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [3]: ../../control-access/rbac/
 [4]: ../generate-certificates/#create-a-certificate-authority-ca
 [6]: https://etcd.io/docs/latest/op-guide/security/
-[7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/
 [12]: ../generate-certificates/

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -231,7 +231,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 Read the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml`).
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml` or `C:\ProgramData\sensu\config\agent.yml.example`).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
@@ -580,7 +580,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [53]: ../../deploy-sensu/install-sensu#install-sensuctl
 [54]: ../../control-access/rbac/#resources
 [55]: ../../deploy-sensu/install-sensu#install-sensu-agents
-[56]: ../../../observability-pipeline/observe-schedule/agent#configuration-via-flags
+[56]: ../../../observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [57]: ../../../observability-pipeline/observe-schedule/collect-metrics-with-checks/
 [58]: ../../../observability-pipeline/observe-schedule/checks#metadata-attributes
 [59]: https://bonsai.sensu.io/assets?q=eventfilter

--- a/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/migrate.md
@@ -239,7 +239,7 @@ api-port: 3031
 socket-port: 3030
 {{< /code >}}
 
-You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
+You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` configuration options.
 
 Sensu should now be installed and functional.
 The next step is to translate your Sensu Core configuration to Sensu Go.

--- a/content/sensu-go/6.4/operations/maintain-sensu/tune.md
+++ b/content/sensu-go/6.4/operations/maintain-sensu/tune.md
@@ -21,14 +21,14 @@ These pages describe common problems and solutions, planning and optimization co
 
 If you use embedded etcd for storage, you might notice high network or storage latency.
 
-To make etcd more latency-tolerant, increase the values for the [etcd election timeout][1] and [etcd heartbeat interval][2] backend configuration flags.
+To make etcd more latency-tolerant, increase the values for the [`etcd election timeout`][1] and [`etcd heartbeat interval`][2] backend configuration options.
 For example, you might increase `etcd-election-timeout` from 1000 to 5000 and `etcd-heartbeat-interval` from 100 to 500.
 
 Read the [etcd tuning documentation][3] for etcd-specific tuning best practices.
 
 ## Advanced backend configuration options for etcd
 
-The [backend reference][11] describes other advanced configuration flags in addition to etcd election timeout and heartbeat interval.
+The [backend reference][11] describes other advanced configuration options in addition to etcd election timeout and heartbeat interval.
 
 Adjust these values with caution.
 Improper adjustment can increase memory and CPU usage or result in a non-functioning Sensu instance.
@@ -50,16 +50,16 @@ Read the [PostgreSQL parameters documentation][5] for information about setting 
 ## Agent reconnection rate
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-rate-limit backend configuration flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-rate-limit` backend configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 It may take several minutes for all agents to reconnect after a sensu-backend restart, especially if you have a large number of agents.
 The agent reconnection rate depends on deployment variables like the number of CPUs, disk space, network speeds, whether you're using a load balancer, and even physical distance between agents and backends.
 
 Although many variables affect the agent reconnection rate, a reasonable estimate is approximately 100 agents per backend per second.
-If you observe slower agent reconnection rates in your Sensu deployment, consider using the [agent-rate-limit][14] backend configuration flag.
+If you observe slower agent reconnection rates in your Sensu deployment, consider using If you observe slower agent reconnection rates in your Sensu deployment, consider using the [`agent-rate-limit`][14] backend configuration option.
 
-The [agent-rate-limit][14] backend configuration flag allows you to set the maximum number of agent transport WebSocket connections per second, per backend.
+The [`agent-rate-limit`][14] backend configuration option allows you to set the maximum number of agent transport WebSocket connections per second, per backend.
 Set the agent-rate-limit to 100 to improve agent reconnection rate and reduce the time required for all of your agents to reconnect after a backend restart.
 
 ## Splay and proxy check scheduling

--- a/content/sensu-go/6.4/platforms.md
+++ b/content/sensu-go/6.4/platforms.md
@@ -175,7 +175,7 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.4.3/sensu-go_6.4
 
 Builds that support the Federal Information Processing Standard (FIPS) for Federal Risk and Authorization Management Program (FedRAMP) compliance are available for Linux `amd64`.
 
-Sensu FIPS builds with [FIPS-mode configuration flags][51] are linked with the FIPS 140-2 validated cryptographic library.
+Sensu FIPS builds with [FIPS-mode configuration options][51] are linked with the FIPS 140-2 validated cryptographic library.
 You can run Red Hat Enterprise Linux (RHEL) with the FIPS-mode kernel option to enforce FIPS systemwide &mdash; Sensu FIPS builds comply with this mode.
 
 [Contact Sensu][50] to request builds with FIPS support.

--- a/content/sensu-go/6.4/plugins/assets.md
+++ b/content/sensu-go/6.4/plugins/assets.md
@@ -293,14 +293,14 @@ When Sensu finds a matching build, it downloads the build artifact from the spec
 If the asset definition includes headers, they are passed along as part of the HTTP request.
 If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
 
-Set the backend or agent's local cache path with the `--cache-dir` flag.
-Disable dynamic runtime assets for an agent with the agent `--disable-assets` [configuration flag][30].
+Set the backend or agent's local cache path with the `cache-dir` configuration option.
+Disable dynamic runtime assets for an agent with the agent [`disable-assets`][30] configuration option.
 
 {{% notice note %}}
-**NOTE**: Dynamic runtime asset builds are unpacked into the cache directory that is configured with the `--cache-dir` flag.
+**NOTE**: Dynamic runtime asset builds are unpacked into the cache directory that is configured with the `cache-dir` configuration option.
 {{% /notice %}}
 
-Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][40] and [backend][41] to configure a global rate limit for fetching dynamic runtime assets.
+Use the `assets-rate-limit` and `assets-burst-limit` configuration options for the [agent][40] and [backend][41] to configure a global rate limit for fetching dynamic runtime assets.
 
 ### Dynamic runtime asset build execution
 

--- a/content/sensu-go/6.4/plugins/assets.md
+++ b/content/sensu-go/6.4/plugins/assets.md
@@ -1306,7 +1306,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 [37]: https://bonsai.sensu.io/sign-in
 [38]: https://bonsai.sensu.io/new
 [39]: ../../web-ui/search#search-for-labels
-[40]: ../../observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[40]: ../../observability-pipeline/observe-schedule/agent/#assets-burst-limit
 [41]: ../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
 [42]: #filters-attribute
 [43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -310,7 +310,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.1.
 - ([Commercial feature][193]) In the web UI, fixed a bug that allowed users to edit Sensu [agent-managed entities][204].
 - Fixed a bug that generated a small amount of extra etcd or PostgreSQL traffic upon keepalive failure.
 - In silenced entries, the `expire` field now represents the configured number of seconds until the entry should be deleted rather than the entry's remaining duration.
-- Labels and annotations can now be configured with [flags][205] for sensu-agent.
+- Labels and annotations are now [configuration options][205] for sensu-agent.
 
 ## 6.2.0 release notes
 
@@ -663,7 +663,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration flags][142] to populate the `processes` field in entity.system if enabled.
+- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
 - ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
@@ -728,7 +728,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
-- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][136] and [backend][137].
+- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-burst-limit` and `--assets-rate-limit` flags for the [agent][136] and [backend][137].
 - Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
@@ -962,7 +962,7 @@ Users will need to [run 'sensu-backend init'][102] on every new installation and
 - Added a new flag,`--etcd-client-urls`, which should be used with sensu-backend when it is not operating as an etcd member.
 The flag is also used by the new `sensu-backend init` subcommand.
 - Added the ['sensu-backend init' subcommand][102].
-- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][100] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
+- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][292] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
 - Added [`--keepalive-critical-timeout`][101] to define the time after which a critical keepalive event should be created for an agent and [`--keepalive-warning-timeout`][101], which is an alias of `--keepalive-timeout` for backward compatibility.
 
 **IMPROVEMENTS:**
@@ -1767,7 +1767,7 @@ To get started with Sensu Go:
 [26]: /sensu-go/5.4/observability-pipeline/observe-schedule/agent/#events-post
 [27]: /sensu-go/5.5/operations/monitor-sensu/tessen/
 [28]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service/
-[29]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[29]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#general-configuration
 [30]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets
 [31]: /sensu-go/5.4/api/other/metrics/
 [32]: /sensu-go/5.6/web-ui/
@@ -1778,7 +1778,7 @@ To get started with Sensu Go:
 [37]: /sensu-go/5.6/operations/control-access/
 [38]: /sensu-go/5.6/operations/control-access/ldap-auth/#ldap-binding-attributes
 [39]: /sensu-go/5.6/operations/control-access/ad-auth/#ad-binding-attributes
-[40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration
 [41]: /sensu-go/5.7/operations/deploy-sensu/install-sensu/#install-sensu-agents
 [42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/
 [43]: /sensu-go/5.7/api/#response-filtering
@@ -1838,8 +1838,8 @@ To get started with Sensu Go:
 [97]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler/
 [98]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler/
 [99]: /sensu-go/5.2/commercial/
-[100]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags
-[101]: /sensu-go/5.16/observability-pipeline/observe-schedule/agent/#keepalive-configuration-flags
+[100]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery
+[101]: /sensu-go/5.16/observability-pipeline/observe-schedule/agent/#keepalive-configuration
 [102]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#initialization
 [103]: /sensu-go/5.16/web-ui/
 [104]: /sensu-go/5.16/
@@ -1872,13 +1872,13 @@ To get started with Sensu Go:
 [133]: /sensu-go/5.19/platforms/
 [134]: /sensu-go/5.19/operations/deploy-sensu/install-sensu/
 [135]: /sensu-go/5.19/web-ui/
-[136]: /sensu-go/5.19/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[136]: /sensu-go/5.19/observability-pipeline/observe-schedule/agent/#assets-burst-limit
 [137]: /sensu-go/5.19/observability-pipeline/observe-schedule/backend/#configuration-via-flags
 [138]: /sensu-go/5.20/api#field-selector
 [139]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#log-rotation
 [140]: /sensu-go/5.20/operations/maintain-sensu/troubleshoot/#increment-log-level-verbosity
 [141]: /sensu-go/5.20/commercial/
-[142]: /sensu-go/5.20/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[142]: /sensu-go/5.20/observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [143]: /sensu-go/5.20/observability-pipeline/observe-entities/entities/#processes-attributes
 [144]: /sensu-go/5.20/sensuctl/create-manage-resources/#supported-resource-types
 [145]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#configuration-summary
@@ -1939,7 +1939,7 @@ To get started with Sensu Go:
 [202]: /sensu-go/6.2/sensuctl/#first-time-setup-and-authentication
 [203]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#agent-managed-entity
 [204]: /sensu-go/6.2/observability-pipeline/observe-entities/entities/#manage-agent-entities-via-the-agent
-[205]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[205]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [206]: /sensu-go/5.21/observability-pipeline/observe-schedule/backend/#log-rotation
 [207]: /sensu-go/6.3/commercial/
 [208]: /sensu-go/6.3/observability-pipeline/observe-schedule/backend/#agent-burst-limit
@@ -1963,3 +1963,4 @@ To get started with Sensu Go:
 [226]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-log-parallel-encoders
 [227]: /sensu-go/6.4/api/other/metrics/
 [228]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-logging
+[292]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery-srv

--- a/content/sensu-go/6.4/release-notes.md
+++ b/content/sensu-go/6.4/release-notes.md
@@ -190,7 +190,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.3.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][207]) Added [business service monitoring (BSM)][210] to provide high-level visibility into the current health of any number of business services, with a [built-in aggregate check rule template][211].
-- ([Commercial feature][207]) Added support for agent transport rate limiting via [`agent-burst-limit`][208] and [`agent-rate-limit`][209] backend configuration flags.
+- ([Commercial feature][207]) Added support for agent transport rate limiting via [`agent-burst-limit`][208] and [`agent-rate-limit`][209] backend configuration options.
 - ([Commercial feature][207]) Added the `event-log-buffer-wait` backend configuration flag, which allows you to specify how long the event logger will wait for the writer to consume events from the buffer when the buffer is full.
 - Added the entity class [service][213], which represents a business service for the business service monitoring (BSM) feature.
 
@@ -433,7 +433,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.1.0.
 - ([Commercial feature][172]) Added the [Sensu SaltStack Enterprise Handler][183] for launching
 SaltStack Enterprise Jobs for automated remediation.
 - ([Commercial feature][172]) The Alpine-based Docker image now has multi-architecture support with support for the linux/386, linux/amd64, linux/arm64, linux/arm/v6, linux/arm/v7, linux/ppc64le, and linux/s390x platforms.
-- The backend flag [`--api-request-limit`][173] is now available to configure the maximum API request body size (in bytes).
+- The backend configuration option [`api-request-limit`][173] is now available to configure the maximum API request body size (in bytes).
 - In the [REST API][174], most configuration resources now support the PATCH method for making updates.
 - Added new handler and check plugins: [Sensu Go Elasticsearch Handler][184], [Sensu Rundeck Handler][185], and [Sensu Kubernetes Events Check][186].
 
@@ -602,7 +602,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.21.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][158]) Added [entity count and limit][156] for each entity class in the tabular title in the response for `sensuctl license info` (in addition to the total entity count and limit).
-- ([Commercial feature][158]) Added Linux amd64 OpenSSL-linked binaries for the Sensu agent and backend, with accompanying `--require-fips` and `--require-openssl` flags for the [agent][161] and [backend][160].
+- ([Commercial feature][158]) Added Linux amd64 OpenSSL-linked binaries for the Sensu agent and backend, with accompanying `require-fips` and `require-openssl` configuration options for the [agent][161] and [backend][160].
 - Added `sensuctl user hash-password` command to generate password hashes.
 - Added the ability to reset passwords via the backend API and `sensuctl user reset-password`.
 
@@ -663,9 +663,9 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
+- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` option to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
-- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
+- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration option for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
 - ([Commercial feature][141]) Added a PostgreSQL metrics suite so metricsd can collect metrics about events stored in PostgreSQL.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
@@ -728,7 +728,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
-- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-burst-limit` and `--assets-rate-limit` flags for the [agent][136] and [backend][137].
+- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `assets-burst-limit` and `assets-rate-limit` configuration options for the [agent][136] and [backend][137].
 - Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
@@ -898,7 +898,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][106]) Added [HTTP API for secrets management][108], with Sensu's `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
-- Added the `keepalive-handlers` agent configuration flag to specify the keepalive handlers to use for an entity's events.
+- Added the `keepalive-handlers` agent configuration option to specify the keepalive handlers to use for an entity's events.
 
 **IMPROVEMENTS:**
 
@@ -942,7 +942,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.16.1.
 **December 16, 2019** &mdash; The latest release of Sensu Go, version 5.16.0, is now available for download.
 This is another important release, with many new features, improvements, and fixes.
 We introduced an initialization subcommand for **new** installations that allows you to specify an admin username and password instead of using a pre-defined default.
-We also added new backend flags to help you take advantage of etcd auto-discovery features and agent flags you can use to define a timeout period for critical and warning keepalive events.
+We also added new backend configuration options to help you take advantage of etcd auto-discovery features and agent configuration options you can use to define a timeout period for critical and warning keepalive events.
 
 New web UI features include a switcher that makes it easier to switch between namespaces in the dashboard, breadcrumbs on every page, OIDC authentication in the dashboard, a drawer that replaces the app bar to make more room for content, and more.
 
@@ -959,11 +959,11 @@ Users will need to [run 'sensu-backend init'][102] on every new installation and
 
 - ([Commercial feature][105]) Users can now authenticate with OIDC in the dashboard.
 - ([Commercial feature][105]) Label selectors now match the event's check and entity labels.
-- Added a new flag,`--etcd-client-urls`, which should be used with sensu-backend when it is not operating as an etcd member.
-The flag is also used by the new `sensu-backend init` subcommand.
+- Added a new configuration option, `etcd-client-urls`, to use with sensu-backend when it is not operating as an etcd member.
+The configuration option is also used by the new `sensu-backend init` subcommand.
 - Added the ['sensu-backend init' subcommand][102].
-- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][292] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
-- Added [`--keepalive-critical-timeout`][101] to define the time after which a critical keepalive event should be created for an agent and [`--keepalive-warning-timeout`][101], which is an alias of `--keepalive-timeout` for backward compatibility.
+- Added the [`etcd-discovery`][100] and [`etcd-discovery-srv`][292] configuration options to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
+- Added the [`keepalive-critical-timeout`][101] configuration option to define the time after which a critical keepalive event should be created for an agent and the [`keepalive-warning-timeout`][101] configuration option, which is an alias of `keepalive-timeout` for backward compatibility.
 
 **IMPROVEMENTS:**
 
@@ -1247,7 +1247,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.11.0.
 Read the [sensuctl reference][72] for more information.
 - Assets now include a `headers` attribute to include HTTP headers in requests to retrieve assets, allowing you to access secured assets.
 Read the [asset reference][70] for examples.
-- Sensu agents now support the `disable-assets` configuration flag, allowing you to disable asset retrieval for individual agents.
+- Sensu agents now support the `disable-assets` configuration option, allowing you to disable asset retrieval for individual agents.
 Read the [agent reference][71] for examples.
 - Sensu [binary-only distributions][69] are now available as zip files.
 
@@ -1354,7 +1354,7 @@ If you're upgrading a Sensu cluster from 5.7.0 or earlier, read the [instruction
 Read the [web UI docs][54] to get started using the Sensu web UI.
 - ([Commercial feature][53]) Manage your Sensu event handlers from your browser: Sensu's web UI now supports creating, editing, and deleting handlers.
 Read the [web UI docs][54] to get started using the Sensu web UI.
-- ([Commercial feature][53]) Sensu now supports event logging to a file using the `event-log-file` and `event-log-buffer-size` configuration flags.
+- ([Commercial feature][53]) Sensu now supports event logging to a file using the `event-log-file` and `event-log-buffer-size` configuration options.
 You can use this event log file as an input source for your favorite data lake solution.
 Read the [backend reference][55] for more information.
 
@@ -1525,7 +1525,7 @@ Read the [/metrics API documentation][31] for more information.
 **IMPROVEMENTS:**
 
 - Sensu now lets you specify a separate TLS certificate and key to secure the dashboard.
-Read the [backend reference][24] to configure the `dashboard-cert-file` and `dashboard-key-file` flags, and check out the [guide to securing Sensu][25] for the complete guide to making your Sensu instance production-ready.
+Read the [backend reference][24] to configure the `dashboard-cert-file` and `dashboard-key-file` options, and check out the [guide to securing Sensu][25] for the complete guide to making your Sensu instance production-ready.
 - The Sensu agent events API now queues events before sending them to the backend, making the agent events API more robust and preventing data loss in the event of a loss of connection with the backend or agent shutdown.
 Read the [agent reference][26] for more information.
 
@@ -1572,7 +1572,7 @@ You can now use the dashboard to review check details like command, subscription
 
 - Sensu Go 5.3.0 fixes all known TLS vulnerabilities affecting the backend, including increasing the minimum supported TLS version to 1.2 and removing all ciphers except those with perfect forward secrecy.
 - Sensu now enforces uniform TLS configuration for all three backend components: `apid`, `agentd`, and `dashboardd`.
-- The backend no longer requires the `trusted-ca-file` flag when using TLS.
+- The backend no longer requires the `trusted-ca-file` configuration option when using TLS.
 - The backend no longer loads server TLS configuration for the HTTP client.
 
 **FIXES:**
@@ -1696,7 +1696,7 @@ Read the [upgrade guide][3] for more information.
 
 **NEW FEATURES:**
 
-- Sensu [agents][4] now include `trusted-ca-file` and `insecure-skip-tls-verify` configuration flags, giving you more flexibility with certificates when connecting agents to the backend over TLS.
+- Sensu [agents][4] now include `trusted-ca-file` and `insecure-skip-tls-verify` configuration options, giving you more flexibility with certificates when connecting agents to the backend over TLS.
 
 **IMPROVEMENTS:**
 

--- a/content/sensu-go/6.4/sensuctl/_index.md
+++ b/content/sensu-go/6.4/sensuctl/_index.md
@@ -478,7 +478,7 @@ create  delete  import  list
 
 [1]: ../operations/control-access/rbac/
 [2]: ../operations/deploy-sensu/install-sensu/#install-sensuctl
-[3]: ../observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[3]: ../observability-pipeline/observe-schedule/backend/
 [4]: ../operations/deploy-sensu/cluster-sensu/
 [5]: create-manage-resources/#create-resources
 [6]: #sensu-backend-url

--- a/content/sensu-go/6.5/api/_index.md
+++ b/content/sensu-go/6.5/api/_index.md
@@ -85,7 +85,7 @@ Beta APIs are more stable than alpha versions, but they offer similarly short-li
 ## Request size limit
 
 The default limit for API request body size is 0.512 MB.
-Use the [`--api-request-limit` backend configuration flag][21] to customize the API request body size limit if needed.
+Use the [`api-request-limit` backend configuration option][21] to customize the API request body size limit if needed.
 
 ## Access control
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -1787,7 +1787,7 @@ status: Ss
 [31]: ../#agent-entities
 [32]: ../#proxy-entities
 [33]: ../../../web-ui/view-manage-resources/#manage-entities
-[34]: ../../observe-schedule/agent/#ephemeral-agent-configuration-flags
+[34]: ../../observe-schedule/agent/#ephemeral-agent-configuration
 [35]: ../../observe-schedule/agent/#config-file
 [36]: ../../../api/core/entities/
 [37]: ../../../sensuctl/create-manage-resources/#update-resources

--- a/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-entities/entities.md
@@ -222,9 +222,9 @@ If you change an agent entity's class to `proxy`, the backend will revert the ch
 ### Manage agent entities via the agent
 
 If you prefer, you can manage agent entities via the agent rather than the backend.
-To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
+To do this, add the [`agent-managed-entity`][16] configuration option when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
 
-When you start an agent with the `--agent-managed-entity` flag or set `agent-managed-entity: true` in `agent.yml`, the agent becomes responsible for managing its entity configuration.
+When you start an agent with the `agent-managed-entity` configuration option set to `true`, the agent becomes responsible for managing its entity configuration.
 An entity managed by this agent will include the label `sensu.io/managed_by: sensu-agent`.
 You cannot update these agent-managed entities via the Sensu backend REST API.
 To change an agent's configuration, restart the agent.
@@ -1233,7 +1233,7 @@ arm_version: 7
 
 cloud_provider | 
 ---------------|------ 
-description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
+description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`detect-cloud-provider`][25] configuration option is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
 **NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
 {{% /notice %}}
 required       | false 
@@ -1594,7 +1594,7 @@ name: eth0
 ### Processes attributes
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag](../../observe-schedule/agent/#discover-processes) in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes`](../../observe-schedule/agent/#discover-processes) configuration option in the packaged Sensu Go distribution.
 For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -37,7 +37,7 @@ Instead, you must configure event handlers to send the data to a storage solutio
 
 ## Configure the StatsD listener
 
-Use flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
+Use configuration flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
 
 The following flags allow you to configure event handlers, flush interval, address, and port:
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/handlers.md
@@ -284,8 +284,8 @@ spec:
 
 {{< /language-toggle >}}
 
-You can also use the [`keepalive-handlers`][19] flag to send keepalive events to any handler you have configured.
-If you do not specify a keepalive handler with the `keepalive-handlers` flag, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+You can also use the [`keepalive-handlers`][19] configuration option to send keepalive events to any handler you have configured.
+If you do not specify a keepalive handler with the `keepalive-handlers` configuration option, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 
 ## Handler specification
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -123,7 +123,7 @@ If system time is out of sync, it may cause issues with keepalive, metric, and c
 
 ## Agent connection to a cluster
 
-Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url` configuration flag][16].
+Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url`][16] configuration option.
 
 For more information about clustering, read [Backend datastore configuration][35] and [Run a Sensu cluster][36].
 
@@ -916,7 +916,7 @@ disable-assets: true{{< /code >}}
 | discover-processes |      |
 --------------|------
 description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the discover-processes flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `discover-processes` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}{{% notice note %}}
 **NOTE**: Process discovery is disabled in this version of Sensu. The discover-processes flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
@@ -1106,7 +1106,7 @@ deregister: true{{< /code >}}
 
 | deregistration-handler |      |
 -------------------------|------
-description              | Name of the event handler to use when processing the agent's deregistration events. This flag overrides any handlers applied by the [`deregistration-handler` backend configuration flag][37].
+description              | Name of the event handler to use when processing the agent's deregistration events. This configuration option overrides any handlers applied by the [`deregistration-handler`][37] backend configuration option.
 type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
@@ -1118,7 +1118,7 @@ deregistration-handler: deregister{{< /code >}}
 
 | detect-cloud-provider  |      |
 -------------------------|------
-description              | `true` to enable cloud provider detection mechanisms. Otherwise, `false`. When this flag is enabled, the agent will attempt to read files, resolve hostnames, and make HTTP requests to determine what cloud environment it is running in.
+description              | `true` to enable cloud provider detection mechanisms. Otherwise, `false`. When this option is enabled, the agent will attempt to read files, resolve hostnames, and make HTTP requests to determine what cloud environment it is running in.
 type                     | Boolean
 default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
@@ -1145,7 +1145,7 @@ keepalive-critical-timeout: 300{{< /code >}}
 
 | keepalive-handlers |      |
 --------------------|------
-description         | [Keepalive event handlers][52] to use for the entity, specified in a comma-delimited list. You can specify any configured handler and invoke the `keepalive-handlers` flag multiple times. If keepalive handlers are not specified, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+description         | [Keepalive event handlers][52] to use for the entity, specified in a comma-delimited list. You can specify any configured handler and invoke the `keepalive-handlers` configuration option multiple times. If keepalive handlers are not specified, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 type                | List
 default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
@@ -1198,7 +1198,7 @@ cert-file: "/path/to/tls/agent.pem"{{< /code >}}
 | insecure-skip-tls-verify |      |
 ---------------------------|------
 description                | Skip SSL verification. {{% notice warning %}}
-**WARNING**: This configuration flag is intended for use in development systems only. Do not use this flag in production.
+**WARNING**: This configuration option is intended for use in development systems only. Do not use this configuration option in production.
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
@@ -1268,7 +1268,7 @@ redact:
 | require-fips |      |
 ------------------|------
 description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu agent startup if `true` but OpenSSL is not running in FIPS mode. {{% notice note %}}
-**NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `require-fips` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
@@ -1282,7 +1282,7 @@ require-fips: true{{< /code >}}
 | require-openssl |      |
 ------------------|------
 description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu agent startup if `true` but Go's standard cryptography library is loaded. {{% notice note %}}
-**NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `--require-openssl` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -125,24 +125,24 @@ If system time is out of sync, it may cause issues with keepalive, metric, and c
 
 Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url` configuration flag][16].
 
-For more information about clustering, read [Backend datastore configuration flags][35] and [Run a Sensu cluster][36].
+For more information about clustering, read [Backend datastore configuration][35] and [Run a Sensu cluster][36].
 
 ## Keepalive monitoring
 
 Sensu keepalives are the heartbeat mechanism used to ensure that all registered agents are operational and able to reach the [Sensu backend][2].
-Sensu agents publish keepalive events containing [entity][3] configuration data to the Sensu backend according to the interval specified by the [`keepalive-interval`][4] configuration flag.
+Sensu agents publish keepalive events containing [entity][3] configuration data to the Sensu backend according to the interval specified by the [`keepalive-interval`][4] configuration option.
 
-If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-critical-timeout`][4] configuration flag, the Sensu backend creates a keepalive **critical** alert in the Sensu web UI.
+If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-critical-timeout`][4] configuration option, the Sensu backend creates a keepalive **critical** alert in the Sensu web UI.
 The `keepalive-critical-timeout` is set to `0` (disabled) by default to help ensure that it will not interfere with your `keepalive-warning-timeout` setting.
 
-If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-warning-timeout`][58] configuration flag, the Sensu backend creates a keepalive **warning** alert in the Sensu web UI.
+If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-warning-timeout`][58] configuration option, the Sensu backend creates a keepalive **warning** alert in the Sensu web UI.
 The value you specify for `keepalive-warning-timeout` must be lower than the value you specify for `keepalive-critical-timeout`.
 
 {{% notice note %}}
-**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
+**NOTE**: If you set the [`deregister` configuration option](#ephemeral-agent-configuration) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
 Deregistration prevents and clears alerts for failing keepalives for agent entities &mdash; the backend does not distinguish between intentional shutdown and failure.
-As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
-If you want to receive alerts for failing keepalives, set the [deregister](#ephemeral-agent-configuration-flags) configuration flag to `false`.
+As a result, if you set `deregister` to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
+If you want to receive alerts for failing keepalives, set the [deregister configuration option](#ephemeral-agent-configuration) to `false`.
 {{% /notice %}}
 
 You can use keepalives to identify unhealthy systems and network partitions, send notifications, and trigger auto-remediation, among other useful actions.
@@ -194,8 +194,8 @@ spec:
 
 {{< /language-toggle >}}
 
-You can also use the [`keepalive-handlers`][53] flag to send keepalive events to any handler you have configured.
-If you do not specify a keepalive handler with the `keepalive-handlers` flag, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+You can also use the [`keepalive-handlers`][53] configuration option to send keepalive events to any handler you have configured.
+If you do not specify a keepalive handler with the `keepalive-handlers` option, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 
 ## Create observability events using service checks
 
@@ -235,7 +235,7 @@ Read the [entities reference][3] and [Monitor external resources][33] for more i
 ## Create observability events using the agent API
 
 The Sensu agent API allows external sources to send monitoring data to Sensu without requiring the external sources to know anything about Sensu's internal implementation.
-The agent API listens on the address and port specified with the [API configuration attributes][18].
+The agent API listens on the address and port specified with the agent [API configuration options][18].
 
 The agent API supports only unsecured HTTP requests (no HTTPS).
 Requests for unknown endpoints will result in an `HTTP 404 Not Found` response.
@@ -249,7 +249,7 @@ In case of a loss of connection with the backend or agent shutdown, the agent pr
 When the connection is reestablished, the agent sends the queued events to the backend.
 
 The agent API `/events` endpoint uses a configurable burst limit and rate limit for relaying events to the backend.
-Read [API configuration flags](#api-configuration-flags) to configure the `events-burst-limit` and `events-rate-limit` flags.
+Read [API configuration](#api-configuration) to configure the `events-burst-limit` and `events-rate-limit` options.
 
 #### Example POST request to events endpoint
 
@@ -419,14 +419,14 @@ For more information about StatsD, read the [StatsD documentation][21].
 
 ### Configure the StatsD listener
 
-To configure the StatsD listener, specify the [`statsd-event-handlers`][22] configuration flag in the [agent configuration][24] and start the agent.
+To configure the StatsD listener, specify the [`statsd-event-handlers`][22] configuration option in the [agent configuration][24] and start the agent.
 For example, to start an agent that sends StatsD metrics to InfluxDB, run:
 
 {{< code shell >}}
 sensu-agent --statsd-event-handlers influx-db
 {{< /code >}}
 
-Use the [StatsD configuration flags][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
+Use the [StatsD configuration options][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
 For example, to start an agent with a customized address and flush interval, run:
 
 {{< code shell >}}
@@ -441,7 +441,7 @@ sensu-agent --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd
 
 Sensu agents listen for external monitoring data using TCP and UDP sockets.
 The agent sockets accept JSON event data and pass events to the Sensu backend event pipeline for processing.
-The TCP and UDP sockets listen on the address and port specified by the [socket configuration flags][17].
+The TCP and UDP sockets listen on the address and port specified by the [socket configuration options][17].
 
 ### Use the TCP socket
 
@@ -636,42 +636,32 @@ However, all registration events are logged in the [Sensu backend log](../backen
 
 As with registration events, the Sensu backend can create and process a deregistration event when the Sensu agent process stops.
 You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
-To enable deregistration events, use the [`deregister` flag][13], and specify the event handler using the [`deregistration-handler` flag][13].
-You can specify a deregistration handler per agent using the [`deregistration-handler` agent flag][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration flag][37].
+To enable deregistration events, use the [`deregister` option][13], and specify the event handler using the [`deregistration-handler` option][13].
+You can specify a deregistration handler per agent using the [`deregistration-handler` agent option][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration option][37].
 
 {{% notice note %}}
 **NOTE**: Deregistration is supported for [agent entities](../../observe-entities/#agent-entities) that have sent at least one keepalive.
 Deregistration is **not** supported for [proxy entities](../../observe-entities/#proxy-entities), which do not send keepalives, and the backend does not automatically create and process deregistration events for proxy entities.
 {{% /notice %}}
 
-## Configuration via flags
+## Agent configuration options
 
-For Linux agents, customize the agent configuration with `sensu-agent start` command line flags or in a `.yml` file.
-The default agent configuration file path for Linux is `/etc/sensu/agent.yml`.
-Configuration via command line flags overrides attributes specified in a configuration file.
-Read [Create overrides][68] to learn more.
+Agent configuration is customizable.
+This section describes each configuration option in more detail, including examples for each [configuration method][70].
 
-For Windows agents, customize the agent configuration in a `.yml` file.
-The default agent configuration file path for Windows is `C:\ProgramData\sensu\config\agent.yml.example`.
-
-Review the [example Sensu agent configuration file][5] for a complete list of flags and default values.
-The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
-
-### Agent configuration flag summary
+You can customize agent configuration with the [agent configuration file][69] (Linux and Windows), [command line flag arguments][24] (Linux), or [environment variables][50] (Linux and Windows).
 
 {{% notice note %}}
-**NOTE**: Process discovery is disabled in this version of Sensu.
-The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**NOTE**: The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 {{% /notice %}}
 
-To view configuration information for the sensu-agent start command, run:
+To view available configuration options for the `sensu-agent start` command, run:
 
 {{< code shell >}}
 sensu-agent start --help
 {{< /code >}}
 
-The response will list command information and configuration flags for sensu-agent start:
+The response will list configuration options as command line flags for `sensu-agent start`:
 
 {{< code text >}}
 start the sensu agent
@@ -733,11 +723,13 @@ Flags:
       --user string                         agent user (default "agent")
 {{< /code >}}
 
-### General configuration flags
-
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+**NOTE**: Process discovery is disabled in this version of Sensu.
+The `--discover-processes` configuration option is not available, and new events will not include data in the `processes` attributes.
+Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
+
+### General configuration
 
 <a id="agent-managed-entity"></a>
 
@@ -750,20 +742,20 @@ default      | false
 environment variable | `SENSU_AGENT_MANAGED_ENTITY`
 command line example   | {{< code shell >}}
 sensu-agent start --agent-managed-entity{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 agent-managed-entity: true{{< /code >}}
 
 <a id="allow-list"></a>
 
 | allow-list |      |
 ------------------|------
-description       | Path to yaml or json file that contains the allow list of check or hook commands the agent can execute. Read [allow list configuration commands][49] and the [example allow list configuration][48] for information about building a configuration file.
+description       | Path to yaml or json file that contains the allow list of check or hook commands the agent can execute. Read [Allow list configuration][49] and the [example allow list configuration][48] for information about building a configuration file.
 type              | String
 default           | `""`
 environment variable | `SENSU_ALLOW_LIST`
 command line example   | {{< code shell >}}
 sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
 
 | annotations|      |
@@ -779,10 +771,12 @@ command line example   | {{< code shell >}}
 sensu-agent start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-agent start --annotations example-key="example value" --annotations example-key2="example value"
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
+
+<a id="assets-burst-limit"></a>
 
 | assets-burst-limit   |      |
 --------------|------
@@ -792,7 +786,7 @@ default       | `100`
 environment variable | `SENSU_ASSETS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --assets-burst-limit 100{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
 
 | assets-rate-limit   |      |
@@ -803,7 +797,7 @@ default       | `1.39`
 environment variable | `SENSU_ASSETS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --assets-rate-limit 1.39{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 <a id="backend-handshake-timeout"></a>
@@ -816,7 +810,7 @@ default       | `15`
 environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-handshake-timeout 20{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
 <a id="backend-heartbeat-interval"></a>
@@ -829,7 +823,7 @@ default       | `30`
 environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
 <a id="backend-heartbeat-timeout"></a>
@@ -842,7 +836,7 @@ default       | `45`
 environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-heartbeat-timeout 60{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-heartbeat-timeout: 60{{< /code >}}
 
 | backend-url |      |
@@ -851,7 +845,9 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
-default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
+default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_URL`
 command line example | {{< language-toggle >}}
 {{< code shell "ws" >}}
@@ -863,7 +859,7 @@ sensu-agent start --backend-url wss://127.0.0.1:8081
 sensu-agent start --backend-url wss://127.0.0.1:8081 --backend-url wss://127.0.0.1:8082
 {{< /code >}}
 {{< /language-toggle >}}
-/etc/sensu/agent.yml example | {{< language-toggle >}}
+agent.yml config file example | {{< language-toggle >}}
 {{< code shell "ws" >}}
 backend-url:
   - "ws://127.0.0.1:8081"
@@ -886,7 +882,7 @@ default       | <ul><li>Linux: `/var/cache/sensu/sensu-agent`</li><li>Windows: `
 environment variable | `SENSU_CACHE_DIR`
 command line example   | {{< code shell >}}
 sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
 <a id="config-file"></a>
@@ -912,7 +908,7 @@ default       | false
 environment variable | `SENSU_DISABLE_ASSETS`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-assets{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
 <a id="discover-processes"></a>
@@ -929,7 +925,7 @@ default       | false
 environment variable | `SENSU_DISCOVER_PROCESSES`
 command line example   | {{< code shell >}}
 sensu-agent start --discover-processes{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 discover-processes: true{{< /code >}}
 
 | labels     |      |
@@ -945,7 +941,7 @@ command line example   | {{< code shell >}}
 sensu-agent start --labels proxy_type=website
 sensu-agent start --labels example_key1="example value" example_key2="example value"
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 labels:
   proxy_type: website
 {{< /code >}}
@@ -960,7 +956,7 @@ default       | `warn`
 environment variable | `SENSU_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-agent start --log-level debug{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 log-level: debug{{< /code >}}
 
 <a id="name-attribute"></a>
@@ -973,7 +969,7 @@ default       | Defaults to hostname (for example, `sensu-centos`).
 environment variable | `SENSU_NAME`
 command line example   | {{< code shell >}}
 sensu-agent start --name agent-01{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 name: "agent-01"{{< /code >}}
 
 <a id="retry-max"></a>
@@ -986,7 +982,7 @@ default       | `120s`
 environment variable | `SENSU_RETRY_MAX`
 command line example   | {{< code shell >}}
 sensu-agent start --retry-max 120s{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 retry-max: 120s{{< /code >}}
 
 <a id="retry-min"></a>
@@ -999,7 +995,7 @@ default       | `1s`
 environment variable | `SENSU_RETRY_MIN`
 command line example   | {{< code shell >}}
 sensu-agent start --retry-min 1s{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 retry-min: 1s{{< /code >}}
 
 <a id="retry-multiplier"></a>
@@ -1014,7 +1010,7 @@ default       | `2.0`
 environment variable | `SENSU_RETRY_MULTIPLIER`
 command line example   | {{< code shell >}}
 sensu-agent start --retry-multiplier 2.0{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 retry-multiplier: 2.0{{< /code >}}
 
 <a id="subscriptions-flag"></a>
@@ -1028,13 +1024,13 @@ command line example   | {{< code shell >}}
 sensu-agent start --subscriptions disk-checks,process-checks
 sensu-agent start --subscriptions disk-checks --subscriptions process-checks
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 subscriptions:
   - disk-checks
   - process-checks
 {{< /code >}}
 
-### API configuration flags
+### API configuration
 
 | api-host    |      |
 --------------|------
@@ -1044,7 +1040,7 @@ default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --api-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 api-host: "127.0.0.1"{{< /code >}}
 
 | api-port    |      |
@@ -1055,7 +1051,7 @@ default       | `3031`
 environment variable | `SENSU_API_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --api-port 3031{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 api-port: 3031{{< /code >}}
 
 | disable-api |      |
@@ -1066,7 +1062,7 @@ default       | `false`
 environment variable | `SENSU_DISABLE_API`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-api{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-api: true{{< /code >}}
 
 | events-burst-limit | |
@@ -1077,7 +1073,7 @@ default       | `10`
 environment variable | `SENSU_EVENTS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --events-burst-limit 20{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 events-burst-limit: 20{{< /code >}}
 
 | events-rate-limit | |
@@ -1088,10 +1084,10 @@ default       | `10.0`
 environment variable | `SENSU_EVENTS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --events-rate-limit 20.0{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 events-rate-limit: 20.0{{< /code >}}
 
-### Ephemeral agent configuration flags
+### Ephemeral agent configuration
 
 | deregister  |      |
 --------------|------
@@ -1103,7 +1099,7 @@ default       | `false`
 environment variable | `SENSU_DEREGISTER`
 command line example   | {{< code shell >}}
 sensu-agent start --deregister{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 deregister: true{{< /code >}}
 
 <a id="agent-deregistration-handler-attribute"></a>
@@ -1115,7 +1111,7 @@ type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
 sensu-agent start --deregistration-handler deregister{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 deregistration-handler: deregister{{< /code >}}
 
 <a id="detect-cloud-provider-flag"></a>
@@ -1128,10 +1124,10 @@ default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
 command line example   | {{< code shell >}}
 sensu-agent start --detect-cloud-provider false{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 detect-cloud-provider: false{{< /code >}}
 
-### Keepalive configuration flags
+### Keepalive configuration
 
 | keepalive-critical-timeout |      |
 --------------------|------
@@ -1142,7 +1138,7 @@ default             | `0`
 environment variable   | `SENSU_KEEPALIVE_CRITICAL_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
 <a id="keepalive-handlers-flag"></a>
@@ -1155,7 +1151,7 @@ default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-handlers slack,email{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-handlers:
 - slack
 - email
@@ -1169,7 +1165,7 @@ default              | `20`
 environment variable   | `SENSU_KEEPALIVE_INTERNAL`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-interval 30{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-interval: 30{{< /code >}}
 
 <a id="keepalive-warning-timeout-flag"></a>
@@ -1183,10 +1179,10 @@ default             | `120`
 environment variable   | `SENSU_KEEPALIVE_WARNING_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-warning-timeout 300{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-warning-timeout: 300{{< /code >}}
 
-### Security configuration flags
+### Security configuration
 
 | cert-file  |      |
 -------------|------
@@ -1196,7 +1192,7 @@ default      | `""`
 environment variable | `SENSU_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --cert-file /path/to/tls/agent.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 cert-file: "/path/to/tls/agent.pem"{{< /code >}}
 
 | insecure-skip-tls-verify |      |
@@ -1209,7 +1205,7 @@ default                    | `false`
 environment variable       | `SENSU_INSECURE_SKIP_TLS_VERIFY`
 command line example   | {{< code shell >}}
 sensu-agent start --insecure-skip-tls-verify{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 | key-file   |      |
@@ -1220,7 +1216,7 @@ default      | `""`
 environment variable | `SENSU_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --key-file /path/to/tls/agent-key.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 key-file: "/path/to/tls/agent-key.pem"{{< /code >}}
 
 | namespace |      |
@@ -1234,8 +1230,10 @@ default        | `default`
 environment variable   | `SENSU_NAMESPACE`
 command line example   | {{< code shell >}}
 sensu-agent start --namespace ops{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 namespace: ops{{< /code >}}
+
+<a id="agent-password-option"></a>
 
 | password    |      |
 --------------|------
@@ -1245,7 +1243,7 @@ default       | `P@ssw0rd!`
 environment variable   | `SENSU_PASSWORD`
 command line example   | {{< code shell >}}
 sensu-agent start --password secure-password{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 password: secure-password{{< /code >}}
 
 | redact      |      |
@@ -1259,7 +1257,7 @@ default       | By default, Sensu redacts the following fields: `password`, `pas
 environment variable   | `SENSU_REDACT`
 command line example   | {{< code shell >}}
 sensu-agent start --redact secret,ec2_access_key{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 redact:
   - secret
   - ec2_access_key
@@ -1278,7 +1276,7 @@ default           | false
 environment variable | `SENSU_REQUIRE_FIPS`
 command line example   | {{< code shell >}}
 sensu-agent start --require-fips{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -1292,7 +1290,7 @@ default           | false
 environment variable | `SENSU_REQUIRE_OPENSSL`
 command line example   | {{< code shell >}}
 sensu-agent start --require-openssl{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -1303,8 +1301,10 @@ default           | `""`
 environment variable   | `SENSU_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 trusted-ca-file: "/path/to/tls/ca.pem"{{< /code >}}
+
+<a id="agent-user-option"></a>
 
 | user |      |
 --------------|------
@@ -1314,10 +1314,10 @@ default       | `agent`
 environment variable   | `SENSU_USER`
 command line example   | {{< code shell >}}
 sensu-agent start --user agent-01{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 user: "agent-01"{{< /code >}}
 
-### Socket configuration flags
+### Socket configuration
 
 | disable-sockets |      |
 ------------------|------
@@ -1327,7 +1327,7 @@ default           | `false`
 environment variable   | `SENSU_DISABLE_SOCKETS`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-sockets{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-sockets: true{{< /code >}}
 
 | socket-host |      |
@@ -1338,7 +1338,7 @@ default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --socket-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 socket-host: "127.0.0.1"{{< /code >}}
 
 | socket-port |      |
@@ -1349,10 +1349,10 @@ default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --socket-port 3030{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 socket-port: 3030{{< /code >}}
 
-### StatsD configuration flags
+### StatsD configuration
 
 | statsd-disable |      |
 -----------------|------
@@ -1362,7 +1362,7 @@ default          | `false`
 environment variable   | `SENSU_STATSD_DISABLE`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-disable{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-disable: true{{< /code >}}
 
 | statsd-event-handlers |      |
@@ -1374,7 +1374,7 @@ command line example   | {{< code shell >}}
 sensu-agent start --statsd-event-handlers influxdb,opentsdb
 sensu-agent start --statsd-event-handlers influxdb --statsd-event-handlers opentsdb
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-event-handlers:
   - influxdb
   - opentsdb
@@ -1388,7 +1388,7 @@ default                  | `10`
 environment variable     | `SENSU_STATSD_FLUSH_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-flush-interval 30{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-flush-interval: 30{{< /code >}}
 
 | statsd-metrics-host |      |
@@ -1399,7 +1399,7 @@ default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-metrics-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-metrics-host: "127.0.0.1"{{< /code >}}
 
 | statsd-metrics-port |      |
@@ -1410,13 +1410,13 @@ default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-metrics-port 8125{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-metrics-port: 8125{{< /code >}}
 
-### Allow list configuration commands
+### Allow list configuration
 
 The allow list includes check and hook commands the agent can execute.
-Use the [allow-list flag][56] to specify the path to the yaml or json file that contains your allow list.
+Use the [`allow-list` configuration option][56] to specify the path to the yaml or json file that contains your allow list.
 
 Use these commands to build your allow list configuration file.
 
@@ -1536,9 +1536,38 @@ sha512: 4f926bf4328...
 
 {{< /language-toggle >}}
 
-## Configuration via environment variables
+## Agent configuration methods
 
-Instead of using configuration flags, you can use environment variables to configure your Sensu agent.
+### Agent configuration file
+
+For Linux and Windows agents, you can customize the agent configuration in a `.yml` configuration file.
+
+The default agent configuration file path for Linux is `/etc/sensu/agent.yml`.
+The default agent configuration file path for Windows is `C:\ProgramData\sensu\config\agent.yml.example`.
+
+To use the `agent.yml` file to configure the agent, list the desired configuration attributes and values.
+Review the [example Sensu agent configuration file][5] for a complete example.
+
+Configuration via command line flags or environment variables overrides any configuration specified in the agent configuration file.
+Read [Create overrides][68] to learn more.
+
+### Command line flags
+
+For Linux agents, you can customize the agent configuration with `sensu-agent start` command line flags.
+
+To use command line flags, specify the desired configuration flags and values along with the `sensu-agent start` command.
+For example:
+
+{{< code shell >}}
+sensu-agent start --name webserver_05 --keepalive-warning-timeout 60 --keepalive-critical-timeout 120
+{{< /code >}}
+
+Configuration via command line flags overrides attributes specified in a configuration file or with environment variables.
+Read [Create overrides][68] to learn more.
+
+### Environment variables
+
+Instead of using the agent configuration file or command line flags, you can use environment variables to configure your Sensu agent.
 Each agent configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
@@ -1616,8 +1645,8 @@ sc.exe start SensuAgent
      {{< /language-toggle >}}
 
 {{% notice note %}}
-**NOTE**: Sensu includes an environment variable for each agent configuration flag.
-They are listed in the [configuration flag description tables](#general-configuration-flags).
+**NOTE**: Sensu includes an environment variable for each agent configuration option.
+They are listed in the [configuration description tables](#general-configuration).
 {{% /notice %}}
 
 ### Format for label and annotation environment variables
@@ -1723,12 +1752,12 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 **NOTE**: If you define the `HTTP_PROXY` and `HTTPS_PROXY` environment variables, the agent WebSocket connection will also use the proxy URL you specify.
 {{% /notice %}}
 
-## Create overrides
+## Create configuration overrides
 
 Sensu has default settings and limits for certain configuration attributes, like the default log level.
 Depending on your environment and preferences, you may want to create overrides for these Sensu-specific defaults and limits.
 
-You can create overrides in several ways:
+You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-agent start`.
 - Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
@@ -1974,7 +2003,7 @@ sensu-agent start --help
 [1]: ../../../operations/deploy-sensu/install-sensu#install-sensu-agents
 [2]: ../backend/
 [3]: ../../observe-entities/entities/
-[4]: #keepalive-configuration-flags
+[4]: #keepalive-configuration
 [5]: ../../../files/windows/agent.yml
 [6]: ../../../sensuctl/
 [7]: ../../observe-events/events/
@@ -1983,18 +2012,18 @@ sensu-agent start --help
 [10]: ../../observe-transform/mutators/
 [11]: https://en.wikipedia.org/wiki/Configuration_management_database
 [12]: https://www.servicenow.com/products/it-operations-management.html
-[13]: #ephemeral-agent-configuration-flags
+[13]: #ephemeral-agent-configuration
 [14]: ../checks/
 [15]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
-[16]: #general-configuration-flags
-[17]: #socket-configuration-flags
-[18]: #api-configuration-flags
+[16]: #general-configuration
+[17]: #socket-configuration
+[18]: #api-configuration
 [19]: https://sourceforge.net/projects/netcat/
 [20]: https://en.wikipedia.org/wiki/Dead_man%27s_switch
 [21]: https://github.com/etsy/statsd
-[22]: #statsd-configuration-flags
+[22]: #statsd-configuration
 [23]: https://github.com/statsd/statsd#key-concepts
-[24]: #configuration-via-flags
+[24]: #command-line-flags
 [25]: ../../../api/#response-filtering
 [26]: ../../../sensuctl/filter-responses/
 [27]: ../tokens/
@@ -2005,9 +2034,9 @@ sensu-agent start --help
 [32]: ../checks/#proxy-entity-name-attribute
 [33]: ../../observe-entities/monitor-external-resources/
 [34]: #backend-heartbeat-interval
-[35]: ../backend#datastore-and-cluster-configuration-flags
+[35]: ../backend/#datastore-and-cluster-configuration
 [36]: ../../../operations/deploy-sensu/cluster-sensu/
-[37]: ../backend#general-configuration-flags
+[37]: ../backend/#general-configuration
 [38]: #name
 [39]: ../../../operations/control-access/rbac/#agent-user
 [40]: ../../observe-process/send-slack-alerts/
@@ -2019,8 +2048,8 @@ sensu-agent start --help
 [46]: ../../../operations/deploy-sensu/secure-sensu/
 [47]: https://en.m.wikipedia.org/wiki/Protocol_Buffers
 [48]: #example-allow-list-configuration
-[49]: #allow-list-configuration-commands
-[50]: #configuration-via-environment-variables
+[49]: #allow-list-configuration
+[50]: #environment-variables
 [51]: #events-post-specification
 [52]: ../../observe-process/handlers/#keepalive-event-handlers
 [53]: #keepalive-handlers-flag
@@ -2032,4 +2061,6 @@ sensu-agent start --help
 [60]: #log-level
 [61]: #retry-min
 [62]: #retry-multiplier
-[68]: #create-overrides
+[68]: #create-configuration-overrides
+[69]: #agent-configuration-file
+[70]: #agent-configuration-methods

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -295,23 +295,24 @@ Check scheduling is subscription-based: the backend sends check requests to [sub
 
 For information about creating and managing checks, read the [checks reference][5] and the guides [Monitor server resources with checks][3] and [Collect metrics with checks][4].
 
-## Configuration via flags
+## Backend configuration options
 
-You can specify the backend configuration with either a `/etc/sensu/backend.yml` file or `sensu-backend start` [configuration flags][15].
-The backend requires that the `state-dir` flag is set before starting.
-All other required flags have default values.
-Review the [example backend configuration file][17] for flags and defaults.
-The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
+Backend configuration is customizable.
+This section describes each configuration option in more detail, including examples for each [configuration method][79].
 
-### Configuration summary
+You can customize backend configuration with the [backend configuration file][76], [command line flag arguments][77], or [environment variables][78].
 
-To view configuration information for the sensu-backend start command, run:
+{{% notice note %}}
+**NOTE**: The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
+{{% /notice %}}
+
+To view configuration information for the `sensu-backend start` command, run:
 
 {{< code shell >}}
 sensu-backend start --help
 {{< /code >}}
 
-The response will list command information and configuration flags for sensu-backend start:
+The response will list configuration options as command line flags for `sensu-backend start`:
 
 {{< code text >}}
 start the sensu backend
@@ -399,13 +400,12 @@ Store Flags:
       --no-embed-etcd                             don't embed etcd, use external etcd instead
 {{< /code >}}
 
-For more information about log configuration flags, read [Event logging][65] and [Platform metrics logging][66].
+The backend requires that the [`state-dir`][75] configuration option is set before starting.
+All other required flags have default values.
 
-### General configuration flags
+For more information about log configuration options, read [Event logging][65] and [Platform metrics logging][66].
 
-{{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
-{{% /notice %}}
+### General configuration
 
 | annotations|      |
 -------------|------
@@ -420,7 +420,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-backend start --annotations example-key="example value" --annotations example-key2="example value"
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
@@ -433,7 +433,7 @@ default      | `[::]:8080`
 environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
 command line example   | {{< code shell >}}
 sensu-backend start --api-listen-address [::]:8080{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
 
 <a id="api-request-limit"></a>
@@ -446,33 +446,36 @@ default      | `512000`
 environment variable | `SENSU_BACKEND_API_REQUEST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --api-request-limit 1024000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-request-limit: 1024000{{< /code >}}
 
 | api-url  |      |
 -------------|------
 description  | URL used to connect to the API.
 type         | String
-default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker)
+default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_API_URL`
 command line example   | {{< code shell >}}
 sensu-backend start --api-url http://localhost:8080{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-url: "http://localhost:8080"{{< /code >}}
 
 <a id="api-write-timeout"></a>
 
 | api-write-timeout  |      |
 -------------|------
-description  | Maximum amount of time to wait before timing out on API HTTP server response writes. In milliseconds (`ms`), seconds (`s`), minutes (`m`), or hours (`h`).{{% notice note %}}
-**NOTE**: [Upgrade](../../../operations/maintain-sensu/upgrade/) to Sensu Go 6.5.5 to use the `api-write-timeout` configuration flag.
+description  | Maximum amount of time to wait before timing out on API HTTP server response writes. In milliseconds (`ms`), seconds (`s`), minutes (`m`), or hours (`h`).{{% notice note %}}  
+**NOTE**: [Upgrade](../../../operations/maintain-sensu/upgrade/) to Sensu Go 6.5.5 to use the `api-write-timeout` configuration flag. 
 {{% /notice %}}
+type         | String
 type         | String
 default      | `15s`
 environment variable | `SENSU_BACKEND_API_WRITE_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-backend start --api-write-timeout 15s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-write-timeout: 15s{{< /code >}}
 
 | assets-burst-limit   |      |
@@ -483,7 +486,7 @@ default       | `100`
 environment variable | `SENSU_BACKEND_ASSETS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --assets-burst-limit 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
 
 | assets-rate-limit   |      |
@@ -494,7 +497,7 @@ default       | `1.39`
 environment variable | `SENSU_BACKEND_ASSETS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --assets-rate-limit 1.39{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 | cache-dir   |      |
@@ -505,7 +508,7 @@ default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
 command line example   | {{< code shell >}}
 sensu-backend start --cache-dir /var/cache/sensu-backend{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 cache-dir: "/var/cache/sensu-backend"{{< /code >}}
 
 | config-file |      |
@@ -529,7 +532,7 @@ default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
 command line example   | {{< code shell >}}
 sensu-backend start --debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 debug: true{{< /code >}}
 
 <a id="deregistration-handler-attribute"></a>
@@ -542,7 +545,7 @@ default                  | `""`
 environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
 sensu-backend start --deregistration-handler deregister{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 deregistration-handler: "deregister"{{< /code >}}
 
 | labels     |      |
@@ -558,7 +561,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --labels security_zone=us-west-2a
 sensu-backend start --labels example_key1="example value" example_key2="example value"
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
   example_key1: "example value"
@@ -575,21 +578,25 @@ default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-backend start --log-level debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
 
 <a id="metrics-refresh-interval"></a>
 
 | metrics-refresh-interval |      |
 -------------|------
-description  | Interval at which Sensu should refresh metrics. In hours, minutes, seconds, or a combination &mdash; for example, `5m`, `1m30s`, and `1h10m30s` are all valid values.
+description  | Interval at which Sensu should refresh metrics. In hours, minutes, seconds, or a combination &mdash; for example, `5m`, `1m30s`, and `1h10m30s` are all valid values.{{% notice commercial %}}
+**COMMERCIAL FEATURE**: Access the `metrics-refresh-interval` flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+{{% /notice %}}
 type         | String
 default      | `1m`
 environment variable | `SENSU_BACKEND_METRICS_REFRESH_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --metrics-refresh-interval 10s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 metrics-refresh-interval: 10s{{< /code >}}
+
+<a id="state-dir-option"></a>
 
 | state-dir  |      |
 -------------|------
@@ -601,10 +608,10 @@ command line example   | {{< code shell >}}
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
 
-### Agent communication configuration flags
+### Agent communication configuration
 
 | agent-auth-cert-file |      |
 -------------|------
@@ -614,7 +621,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-cert-file: /path/to/tls/backend-1.pem{{< /code >}}
 
 | agent-auth-crl-urls |      |
@@ -625,7 +632,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-crl-urls: http://localhost/CARoot.crl{{< /code >}}
 
 | agent-auth-key-file |      |
@@ -636,7 +643,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-key-file: /path/to/tls/backend-1-key.pem{{< /code >}}
 
 | agent-auth-trusted-ca-file |      |
@@ -647,7 +654,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 
 <a id="agent-burst-limit"></a>
@@ -664,7 +671,7 @@ default       | `null`
 environment variable | `SENSU_BACKEND_AGENT_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-burst-limit 10{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-burst-limit: 10{{< /code >}}
 
 | agent-host   |      |
@@ -675,7 +682,7 @@ default        | `[::]`
 environment variable | `SENSU_BACKEND_AGENT_HOST`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-host 127.0.0.1{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-host: "127.0.0.1"{{< /code >}}
 
 | agent-port |      |
@@ -686,7 +693,7 @@ default      | `8081`
 environment variable | `SENSU_BACKEND_AGENT_PORT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-port 8081{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-port: 8081{{< /code >}}
 
 <a id="agent-rate-limit"></a>
@@ -701,10 +708,10 @@ default       | `null`
 environment variable | `SENSU_BACKEND_AGENT_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-rate-limit 10{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-rate-limit: 10{{< /code >}}
 
-### Security configuration flags
+### Security configuration
 
 | cert-file  |      |
 -------------|------
@@ -714,7 +721,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 | insecure-skip-tls-verify |      |
@@ -727,7 +734,7 @@ default                    | `false`
 environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
 command line example   | {{< code shell >}}
 sensu-backend start --insecure-skip-tls-verify{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 <a id="jwt-attributes"></a>
@@ -742,7 +749,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --jwt-private-key-file /path/to/key/private.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 jwt-private-key-file: /path/to/key/private.pem{{< /code >}}
 
 | jwt-public-key-file |      |
@@ -756,7 +763,7 @@ environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
 command line example   | {{< code shell >}}
 sensu-backend start --jwt-public-key-file /path/to/key/public.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
@@ -767,7 +774,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 <a id="fips-openssl"></a>
@@ -783,7 +790,7 @@ default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_FIPS`
 command line example   | {{< code shell >}}
 sensu-backend start --require-fips{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -797,7 +804,7 @@ default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_OPENSSL`
 command line example   | {{< code shell >}}
 sensu-backend start --require-openssl{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -808,20 +815,20 @@ default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 trusted-ca-file: "/path/to/tls/ca.pem"{{< /code >}}
 
-### Web UI configuration flags
+### Web UI configuration
 
 | dashboard-cert-file | |
 -------------|------
-description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` configuration option](#security-configuration) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-cert-file /path/to/tls/separate-webui-cert.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-cert-file: "/path/to/tls/separate-webui-cert.pem"{{< /code >}}
 
 | dashboard-host |      |
@@ -832,18 +839,18 @@ default          | `[::]`
 environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-host 127.0.0.1{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-host: "127.0.0.1"{{< /code >}}
 
 | dashboard-key-file | |
 -------------|------
-description  | Web UI TLS certificate key in PEM format. This key secures communication with the Sensu web UI. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` flag](#security-configuration-flags) for the web UI.
+description  | Web UI TLS certificate key in PEM format. This key secures communication with the Sensu web UI. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` configuration option](#security-configuration) for the web UI.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-key-file /path/to/tls/separate-webui-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-key-file: "/path/to/tls/separate-webui-key.pem"{{< /code >}}
 
 | dashboard-port |      |
@@ -854,29 +861,25 @@ default          | `3000`
 environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-port 3000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-port: 3000{{< /code >}}
 
 <a id="dashboard-write-timeout"></a>
 
 | dashboard-write-timeout  |      |
 -------------|------
-description  | Maximum amount of time to wait before timing out on web UI HTTP server response writes. In milliseconds (`ms`), seconds (`s`), minutes (`m`), or hours (`h`).{{% notice note %}}
-**NOTE**: [Upgrade](../../../operations/maintain-sensu/upgrade/) to Sensu Go 6.5.5 to use the `dashboard-write-timeout` configuration flag.
+description  | Maximum amount of time to wait before timing out on web UI HTTP server response writes. In milliseconds (`ms`), seconds (`s`), minutes (`m`), or hours (`h`).{{% notice note %}}  
+**NOTE**: [Upgrade](../../../operations/maintain-sensu/upgrade/) to Sensu Go 6.5.5 to use the `dashboard-write-timeout` configuration flag. 
 {{% /notice %}}
 type         | String
 default      | `15s`
 environment variable | `SENSU_BACKEND_DASHBOARD_WRITE_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-write-timeout 15s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-write-timeout: 15s{{< /code >}}
 
-### Datastore and cluster configuration flags
-
-{{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
-{{% /notice %}}
+### Datastore and cluster configuration
 
 | etcd-advertise-client-urls |      |
 --------------|------
@@ -885,13 +888,15 @@ description   | List of this member's client URLs to advertise to the rest of th
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
-default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
+default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-advertise-client-urls:
   - http://localhost:2378
   - http://localhost:2379
@@ -908,7 +913,7 @@ default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 <a id="etcd-cipher-suites"></a>
@@ -934,7 +939,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -951,7 +956,7 @@ default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-cert-auth{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-client-cert-auth: true{{< /code >}}
 
 | etcd-client-urls      |      |
@@ -967,11 +972,13 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-urls 'https://10.0.0.1:2379 https://10.1.0.1:2379'
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
+
+<a id="etcd-discovery"></a>
 
 | etcd-discovery        |      |
 ------------------------|------
@@ -984,10 +991,12 @@ default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-discovery:
   - https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 {{< /code >}}
+
+<a id="etcd-discovery-srv"></a>
 
 | etcd-discovery-srv    |      |
 ------------------------|------
@@ -1000,7 +1009,7 @@ default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-discovery-srv example.org{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-discovery-srv:
   - example.org
 {{< /code >}}
@@ -1012,13 +1021,15 @@ description                        | List of this member's peer URLs to advertis
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
-default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
+default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-advertise-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
@@ -1031,11 +1042,13 @@ description            | Initial cluster configuration for bootstrapping.{{% not
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
-default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
+default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380"{{< /code >}}
 
 | etcd-initial-cluster-state |      |
@@ -1049,7 +1062,7 @@ default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster-state existing{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
@@ -1063,7 +1076,7 @@ default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 | etcd-key-file  |      |
@@ -1076,7 +1089,7 @@ type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 <a id="etcd-listen-client-urls"></a>
@@ -1094,7 +1107,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-listen-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
@@ -1113,7 +1126,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-listen-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
@@ -1129,7 +1142,7 @@ default      | [Backend log level][60] value (or `debug`, if the backend log lev
 environment variable | `SENSU_BACKEND_ETCD_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-log-level debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-log-level: "debug"{{< /code >}}
 
 | etcd-name      |      |
@@ -1143,7 +1156,7 @@ default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-name backend-0{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
@@ -1156,7 +1169,7 @@ type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 | etcd-peer-client-cert-auth |      |
@@ -1170,7 +1183,7 @@ default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-client-cert-auth{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-client-cert-auth: true{{< /code >}}
 
 | etcd-peer-key-file |      |
@@ -1183,7 +1196,7 @@ type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 | etcd-peer-trusted-ca-file |      |
@@ -1196,7 +1209,7 @@ type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | etcd-trusted-ca-file |      |
@@ -1210,7 +1223,7 @@ default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-trusted-ca-file ./ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | no-embed-etcd  |      |
@@ -1224,7 +1237,7 @@ default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
 command line example   | {{< code shell >}}
 sensu-backend start --no-embed-etcd{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 no-embed-etcd: true{{< /code >}}
 
 ### Advanced configuration options
@@ -1244,7 +1257,7 @@ default                | `1000`
 environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-election-timeout 1000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
 
 <a id="etcd-heartbeat-interval"></a>
@@ -1261,7 +1274,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-heartbeat-interval 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-heartbeat-interval: 100{{< /code >}}
 
 | etcd-max-request-bytes |      |
@@ -1276,7 +1289,7 @@ default                | `1572864`
 environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-max-request-bytes 1572864{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-max-request-bytes: 1572864{{< /code >}}
 
 | etcd-quota-backend-bytes |      |
@@ -1291,7 +1304,7 @@ default                | `4294967296`
 environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-quota-backend-bytes 4294967296{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-quota-backend-bytes: 4294967296{{< /code >}}
 
 | eventd-buffer-size   |      |
@@ -1304,7 +1317,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --eventd-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 eventd-buffer-size: 100{{< /code >}}
 
 | eventd-workers       |      |
@@ -1317,7 +1330,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --eventd-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 eventd-workers: 100{{< /code >}}
 
 | keepalived-buffer-size |      |
@@ -1330,7 +1343,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --keepalived-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 keepalived-buffer-size: 100{{< /code >}}
 
 | keepalived-workers |      |
@@ -1342,7 +1355,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --keepalived-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 keepalived-workers: 100{{< /code >}}
 
 | pipelined-buffer-size |      |
@@ -1355,7 +1368,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --pipelined-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 pipelined-buffer-size: 100{{< /code >}}
 
 | pipelined-workers |      |
@@ -1368,12 +1381,38 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --pipelined-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 pipelined-workers: 100{{< /code >}}
 
-## Configuration via environment variables
+## Backend configuration methods
 
-Instead of using configuration flags, you can use environment variables to configure your Sensu backend.
+### Backend configuration file
+
+You can customize the backend configuration in a `.yml` configuration file.
+
+To use the `backend.yml` file to configure the backend, list the desired configuration attributes and values.
+Review the [example Sensu backend configuration file][17] for a complete example.
+
+Configuration via command line flags or environment variables overrides any configuration specified in the backend configuration file.
+Read [Create overrides][74] to learn more.
+
+### Command line flags
+
+You can customize the backend configuration with `sensu-agent start` command line flags.
+
+To use command line flags, specify the desired configuration flags and values along with the `sensu-backend start` command.
+For example:
+
+{{< code shell >}}
+sensu-backend start --deregistration-handler slack_deregister --log-level debug
+{{< /code >}}
+
+Configuration via command line flags overrides attributes specified in a configuration file or with environment variables.
+Read [Create overrides][74] to learn more.
+
+### Environment variables
+
+Instead of using a configuration file or command line flags, you can use environment variables to configure your Sensu backend.
 Each backend configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
@@ -1433,7 +1472,7 @@ sudo systemctl restart sensu-backend
 
 {{% notice note %}}
 **NOTE**: Sensu includes an environment variable for each backend configuration flag.
-They are listed in the [configuration flag description tables](#general-configuration-flags).
+They are listed in the [configuration description tables](#general-configuration).
 {{% /notice %}}
 
 ### Format for label and annotation environment variables
@@ -1511,12 +1550,12 @@ spec:
 Read the [secrets reference](https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/) and [Use Env for secrets management](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management) for details.
 {{% /notice %}}
 
-## Create overrides
+## Create configuration overrides
 
 Sensu has default settings and limits for certain configuration attributes, like the default log level.
 Depending on your environment and preferences, you may want to create overrides for these Sensu-specific defaults and limits.
 
-You can create overrides in several ways:
+You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-backend start`.
 - Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
@@ -1576,7 +1615,7 @@ The event logging functionality provides better performance and reliability than
 To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
 {{% /notice %}}
 
-Use these backend configuration flags to customize event logging:
+Use these backend configuration options to customize event logging:
 
 | event-log-buffer-size |      |
 -----------------------|------
@@ -1586,7 +1625,7 @@ default                | 100000
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-buffer-size 100000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-buffer-size: 100000{{< /code >}}
 
 | event-log-buffer-wait |      |
@@ -1597,7 +1636,7 @@ default                | 10ms
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_WAIT`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-buffer-wait 10ms{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-buffer-wait: 10ms{{< /code >}}
 
 <a id="event-log-file"></a>
@@ -1611,7 +1650,7 @@ type                   | String
 environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-file /var/log/sensu/events.log{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-file: "/var/log/sensu/events.log"{{< /code >}}
 
 <a id="event-log-parallel-encoders"></a>
@@ -1624,7 +1663,7 @@ default                | false
 environment variable   | `SENSU_BACKEND_EVENT_LOG_PARALLEL_ENCODERS`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-parallel-encoders true{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-parallel-encoders: true{{< /code >}}
 
 ### Log rotation
@@ -1682,7 +1721,7 @@ Sensu appends updated metrics at the interval you specify with the platform-metr
 
 To rotate the platform metrics log, use the same methods as for [event log rotation][63].
 
-Use these backend configuration flags to customize platform metrics logging:
+Use these backend configuration options to customize platform metrics logging:
 
 | disable-platform-metrics |      |
 -----------------------|------
@@ -1692,7 +1731,7 @@ default                | false
 environment variable   | `SENSU_BACKEND_DISABLE_PLATFORM_METRICS`
 command line example   | {{< code shell >}}
 sensu-backend start --disable-platform-metrics false{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 disable-platform-metrics: false{{< /code >}}
 
 | platform-metrics-log-file |      |
@@ -1705,7 +1744,7 @@ default                | /var/log/sensu/sensu-backend/stats.log
 environment variable   | `SENSU_BACKEND_PLATFORM_METRICS_LOG_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --platform-metrics-log-file /var/log/sensu/sensu-backend/stats.log{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 platform-metrics-log-file: "/var/log/sensu/sensu-backend/stats.log"{{< /code >}}
 
 | platform-metrics-logging-interval |      |
@@ -1716,7 +1755,7 @@ default                | 60s
 environment variable   | `SENSU_BACKEND_PLATFORM_METRICS_LOGGING_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --platform-metrics-logging-interval 60s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 platform-metrics-logging-interval: 60s{{< /code >}}
 
 ## Service management
@@ -1829,10 +1868,10 @@ sensu-backend start --help
 [9]: ../../observe-filter/filters/
 [10]: ../../observe-transform/mutators/
 [11]: ../../observe-process/handlers/
-[12]: #datastore-and-cluster-configuration-flags
+[12]: #datastore-and-cluster-configuration
 [13]: ../../../operations/deploy-sensu/cluster-sensu/
 [14]: ../../../api/
-[15]: #general-configuration-flags
+[15]: #general-configuration
 [16]: https://etcd.io/docs/current/tuning/#time-parameters
 [17]: ../../../files/backend.yml
 [18]: https://golang.org/pkg/crypto/tls/#pkg-constants
@@ -1866,5 +1905,11 @@ sensu-backend start --help
 [66]: #platform-metrics-logging
 [70]: ../../observe-process/pipelines/
 [71]: ../../../guides/
-[72]: #datastore-and-cluster-configuration-flags
+[72]: #datastore-and-cluster-configuration
 [73]: #advanced-configuration-options
+[74]: #create-configuration-overrides
+[75]: #state-dir-option
+[76]: #backend-configuration-file
+[77]: #backend-configuration-options
+[78]: #environment-variables
+[79]: #backend-configuration-methods

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -215,7 +215,7 @@ Store Flags:
       --etcd-trusted-ca-file string          path to the client server TLS trusted CA cert file
 {{< /code >}}
 
-For more information about the initialization store flags, read [Datastore and cluster configuration flags][72] and [Advanced configuration options][73].
+For more information about the initialization store flags, read [Datastore and cluster configuration][72] and [Advanced configuration options][73].
 
 <a id="ignore-already-initialized"></a>
 
@@ -586,7 +586,7 @@ log-level: "debug"{{< /code >}}
 | metrics-refresh-interval |      |
 -------------|------
 description  | Interval at which Sensu should refresh metrics. In hours, minutes, seconds, or a combination &mdash; for example, `5m`, `1m30s`, and `1h10m30s` are all valid values.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the `metrics-refresh-interval` flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `metrics-refresh-interval` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type         | String
 default      | `1m`
@@ -662,9 +662,9 @@ agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 | agent-burst-limit   |      |
 --------------|------
 description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice note %}}
-**NOTE**: The agent-burst-limit flag is deprecated.
+**NOTE**: The `agent-burst-limit` configuration flag is deprecated.
 {{% /notice %}} {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-burst-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-burst-limit` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer
 default       | `null`
@@ -701,7 +701,7 @@ agent-port: 8081{{< /code >}}
 | agent-rate-limit   |      |
 --------------|------
 description   | Maximum number of agent transport WebSocket connections per second, per backend.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-rate-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-rate-limit` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer
 default       | `null`
@@ -715,7 +715,7 @@ agent-rate-limit: 10{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the `dashboard-cert-file` configuration option is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -727,7 +727,7 @@ cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 | insecure-skip-tls-verify |      |
 ---------------------------|------
 description                | If `true`, skip SSL verification. Otherwise, `false`. {{% notice warning %}}
-**WARNING**: This configuration flag is intended for use in development systems only. Do not use this flag in production.
+**WARNING**: This configuration option is intended for use in development systems only. Do not use this configuration option in production.
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
@@ -768,7 +768,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the `dashboard-key-file` configuration option is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
@@ -782,7 +782,7 @@ key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 | require-fips |      |
 ------------------|------
 description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu backend startup if `true` but OpenSSL is not running in FIPS mode. {{% notice note %}}
-**NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `require-fips` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
@@ -796,7 +796,7 @@ require-fips: true{{< /code >}}
 | require-openssl |      |
 ------------------|------
 description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu backend startup if `true` but Go's standard cryptography library is loaded. {{% notice note %}}
-**NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `--require-openssl` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean

--- a/content/sensu-go/6.5/operations/control-access/rbac.md
+++ b/content/sensu-go/6.5/operations/control-access/rbac.md
@@ -169,7 +169,7 @@ By default, the `agent` user belongs to the `system:agent` group.
 The `system:agent` cluster role binding grants the `system:agent` cluster role to the members of this group.
 To grant agent users the permissions they need to report events into any namespace, add agent users to the `system:agent` group.
 
-Configure the `agent` user's credentials with the [`user` and `password` agent configuration flags][41].
+Configure the `agent` user's credentials with the [`user`][41] and [`password`][68] agent configuration options.
 
 ### View users
 
@@ -3280,7 +3280,7 @@ type: Group
 [38]: ../../../observability-pipeline/observe-schedule/rule-templates/
 [39]: ../ad-auth/#ad-groups-prefix
 [40]: ../../deploy-sensu/etcdreplicators/
-[41]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
+[41]: ../../../observability-pipeline/observe-schedule/agent/#agent-password-option
 [42]: ../../deploy-sensu/install-sensu/#install-the-sensu-backend
 [43]: ../../../observability-pipeline/observe-process/sumo-logic-metrics-handlers/
 [44]: ../../../observability-pipeline/observe-process/tcp-stream-handlers/
@@ -3307,3 +3307,4 @@ type: Group
 [65]: #spec-attributes-for-role-binding-and-cluster-role-binding-resources
 [66]: #role_ref-attributes
 [67]: #subjects-attributes
+[68]: ../../../observability-pipeline/observe-schedule/agent/#agent-user-option

--- a/content/sensu-go/6.5/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/deployment-architecture.md
@@ -158,7 +158,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 
 [1]: ../hardware-requirements/#backend-recommended-configuration
 [2]: ../../../api/
-[3]: ../../../observability-pipeline/observe-schedule/agent/#general-configuration-flags
 [4]: https://etcd.io/docs/
 [5]: https://etcd.io/docs/current/op-guide/security/
 [6]: ../secure-sensu/

--- a/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
@@ -560,7 +560,7 @@ sensuctl license info
 [4]: ../../../sensuctl/
 [5]: ../../../platforms/
 [6]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
-[7]: ../../../observability-pipeline/observe-schedule/agent#configuration-via-flags
+[7]: ../../../observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [8]: ../secure-sensu/
 [9]: ../../../observability-pipeline/observe-schedule/monitor-server-resources/
 [10]: ../../../observability-pipeline/observe-process/send-slack-alerts/

--- a/content/sensu-go/6.5/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/secure-sensu.md
@@ -76,7 +76,7 @@ etcd-peer-client-cert-auth: "true"
    Because etcd does not require authentication by default, you must set the `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` parameters to `true` to secure Sensu's embedded etcd datastore against unauthorized access.
 
 {{% notice note %}}
-**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags) includes more information about each etcd store parameter.
+**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration) includes more information about each etcd store parameter.
 {{% /notice %}}
 
 ## Secure the Sensu agent API, HTTP API, and web UI
@@ -118,7 +118,7 @@ After you restart the `sensu-backend` service, the parameters will load and you 
 Configuring these attributes will also ensure that agents can communicate securely.
 
 {{% notice note %}}
-**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#security-configuration-flags) includes more information about each API and web UI security configuration parameter.
+**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#security-configuration) includes more information about each API and web UI security configuration parameter.
 {{% /notice %}}
 
 ### Specify a separate web UI certificate and key
@@ -135,7 +135,7 @@ dashboard-key-file: "/etc/sensu/tls/separate-webui-key.pem"
 
 {{% notice note %}}
 **NOTE**: If you do not specify a separate certificate and key for the web UI with `dashboard-cert-file` and `dashboard-key-file`, Sensu uses the certificate and key specified for the `cert-file` and `key-file` parameters for the web UI.
-The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#web-ui-configuration-flags) includes more information about the `dashboard-cert-file` and `dashboard-key-file` web UI configuration parameters.
+The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#web-ui-configuration) includes more information about the `dashboard-cert-file` and `dashboard-key-file` web UI configuration parameters.
 {{% /notice %}}
 
 ## Secure Sensu agent-to-server communication
@@ -262,7 +262,6 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [3]: ../../control-access/rbac/
 [4]: ../generate-certificates/#create-a-certificate-authority-ca
 [6]: https://etcd.io/docs/latest/op-guide/security/
-[7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/
 [12]: ../generate-certificates/

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -233,7 +233,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 Read the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml`).
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml` or `C:\ProgramData\sensu\config\agent.yml.example`).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
@@ -582,7 +582,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [53]: ../../deploy-sensu/install-sensu#install-sensuctl
 [54]: ../../control-access/rbac/#resources
 [55]: ../../deploy-sensu/install-sensu#install-sensu-agents
-[56]: ../../../observability-pipeline/observe-schedule/agent#configuration-via-flags
+[56]: ../../../observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [57]: ../../../observability-pipeline/observe-schedule/collect-metrics-with-checks/
 [58]: ../../../observability-pipeline/observe-schedule/checks#metadata-attributes
 [59]: https://bonsai.sensu.io/assets?q=eventfilter

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -241,7 +241,7 @@ api-port: 3031
 socket-port: 3030
 {{< /code >}}
 
-You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
+You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` configuration options.
 
 Sensu should now be installed and functional.
 The next step is to translate your Sensu Core configuration to Sensu Go.

--- a/content/sensu-go/6.5/operations/maintain-sensu/tune.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/tune.md
@@ -21,14 +21,14 @@ These pages describe common problems and solutions, planning and optimization co
 
 If you use embedded etcd for storage, you might notice high network or storage latency.
 
-To make etcd more latency-tolerant, increase the values for the [etcd election timeout][1] and [etcd heartbeat interval][2] backend configuration flags.
+To make etcd more latency-tolerant, increase the values for the [`etcd election timeout`][1] and [`etcd heartbeat interval`][2] backend configuration options.
 For example, you might increase `etcd-election-timeout` from 1000 to 5000 and `etcd-heartbeat-interval` from 100 to 500.
 
 Read the [etcd tuning documentation][3] for etcd-specific tuning best practices.
 
 ## Advanced backend configuration options for etcd
 
-The [backend reference][11] describes other advanced configuration flags in addition to etcd election timeout and heartbeat interval.
+The [backend reference][11] describes other advanced configuration options in addition to etcd election timeout and heartbeat interval.
 
 Adjust these values with caution.
 Improper adjustment can increase memory and CPU usage or result in a non-functioning Sensu instance.
@@ -50,16 +50,16 @@ Read the [PostgreSQL parameters documentation][5] for information about setting 
 ## Agent reconnection rate
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-rate-limit backend configuration flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-rate-limit` backend configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 It may take several minutes for all agents to reconnect after a sensu-backend restart, especially if you have a large number of agents.
 The agent reconnection rate depends on deployment variables like the number of CPUs, disk space, network speeds, whether you're using a load balancer, and even physical distance between agents and backends.
 
 Although many variables affect the agent reconnection rate, a reasonable estimate is approximately 100 agents per backend per second.
-If you observe slower agent reconnection rates in your Sensu deployment, consider using the [agent-rate-limit][14] backend configuration flag.
+If you observe slower agent reconnection rates in your Sensu deployment, consider using If you observe slower agent reconnection rates in your Sensu deployment, consider using the [`agent-rate-limit`][14] backend configuration option.
 
-The [agent-rate-limit][14] backend configuration flag allows you to set the maximum number of agent transport WebSocket connections per second, per backend.
+The [`agent-rate-limit`][14] backend configuration option allows you to set the maximum number of agent transport WebSocket connections per second, per backend.
 Set the agent-rate-limit to 100 to improve agent reconnection rate and reduce the time required for all of your agents to reconnect after a backend restart.
 
 ## Splay and proxy check scheduling

--- a/content/sensu-go/6.5/platforms.md
+++ b/content/sensu-go/6.5/platforms.md
@@ -175,7 +175,7 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.5.5/sensu-go_6.5
 
 Builds that support the Federal Information Processing Standard (FIPS) for Federal Risk and Authorization Management Program (FedRAMP) compliance are available for Linux `amd64`.
 
-Sensu FIPS builds with [FIPS-mode configuration flags][51] are linked with the FIPS 140-2 validated cryptographic library.
+Sensu FIPS builds with [FIPS-mode configuration options][51] are linked with the FIPS 140-2 validated cryptographic library.
 You can run Red Hat Enterprise Linux (RHEL) with the FIPS-mode kernel option to enforce FIPS systemwide &mdash; Sensu FIPS builds comply with this mode.
 
 [Contact Sensu][50] to request builds with FIPS support.

--- a/content/sensu-go/6.5/plugins/assets.md
+++ b/content/sensu-go/6.5/plugins/assets.md
@@ -293,14 +293,14 @@ When Sensu finds a matching build, it downloads the build artifact from the spec
 If the asset definition includes headers, they are passed along as part of the HTTP request.
 If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
 
-Set the backend or agent's local cache path with the `--cache-dir` flag.
-Disable dynamic runtime assets for an agent with the agent `--disable-assets` [configuration flag][30].
+Set the backend or agent's local cache path with the `cache-dir` configuration option.
+Disable dynamic runtime assets for an agent with the agent [`disable-assets`][30] configuration option.
 
 {{% notice note %}}
-**NOTE**: Dynamic runtime asset builds are unpacked into the cache directory that is configured with the `--cache-dir` flag.
+**NOTE**: Dynamic runtime asset builds are unpacked into the cache directory that is configured with the `cache-dir` configuration option.
 {{% /notice %}}
 
-Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][40] and [backend][41] to configure a global rate limit for fetching dynamic runtime assets.
+Use the `assets-rate-limit` and `assets-burst-limit` configuration options for the [agent][40] and [backend][41] to configure a global rate limit for fetching dynamic runtime assets.
 
 ### Dynamic runtime asset build execution
 

--- a/content/sensu-go/6.5/plugins/assets.md
+++ b/content/sensu-go/6.5/plugins/assets.md
@@ -1306,7 +1306,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 [37]: https://bonsai.sensu.io/sign-in
 [38]: https://bonsai.sensu.io/new
 [39]: ../../web-ui/search#search-for-labels
-[40]: ../../observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[40]: ../../observability-pipeline/observe-schedule/agent/#assets-burst-limit
 [41]: ../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
 [42]: #filters-attribute
 [43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -467,7 +467,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.1.
 - ([Commercial feature][193]) In the web UI, fixed a bug that allowed users to edit Sensu [agent-managed entities][204].
 - Fixed a bug that generated a small amount of extra etcd or PostgreSQL traffic upon keepalive failure.
 - In silenced entries, the `expire` field now represents the configured number of seconds until the entry should be deleted rather than the entry's remaining duration.
-- Labels and annotations can now be configured with [flags][205] for sensu-agent.
+- Labels and annotations are now [configuration options][205] for sensu-agent.
 
 ## 6.2.0 release notes
 
@@ -820,7 +820,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration flags][142] to populate the `processes` field in entity.system if enabled.
+- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
 - ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
@@ -885,7 +885,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
-- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][136] and [backend][137].
+- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-burst-limit` and `--assets-rate-limit` flags for the [agent][136] and [backend][137].
 - Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
@@ -1119,7 +1119,7 @@ Users will need to [run 'sensu-backend init'][102] on every new installation and
 - Added a new flag,`--etcd-client-urls`, which should be used with sensu-backend when it is not operating as an etcd member.
 The flag is also used by the new `sensu-backend init` subcommand.
 - Added the ['sensu-backend init' subcommand][102].
-- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][100] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
+- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][292] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
 - Added [`--keepalive-critical-timeout`][101] to define the time after which a critical keepalive event should be created for an agent and [`--keepalive-warning-timeout`][101], which is an alias of `--keepalive-timeout` for backward compatibility.
 
 **IMPROVEMENTS:**
@@ -1924,7 +1924,7 @@ To get started with Sensu Go:
 [26]: /sensu-go/5.4/observability-pipeline/observe-schedule/agent/#events-post
 [27]: /sensu-go/5.5/operations/monitor-sensu/tessen/
 [28]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service/
-[29]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[29]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#general-configuration
 [30]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets
 [31]: /sensu-go/5.4/api/other/metrics/
 [32]: /sensu-go/5.6/web-ui/
@@ -1935,7 +1935,7 @@ To get started with Sensu Go:
 [37]: /sensu-go/5.6/operations/control-access/
 [38]: /sensu-go/5.6/operations/control-access/ldap-auth/#ldap-binding-attributes
 [39]: /sensu-go/5.6/operations/control-access/ad-auth/#ad-binding-attributes
-[40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration
 [41]: /sensu-go/5.7/operations/deploy-sensu/install-sensu/#install-sensu-agents
 [42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/
 [43]: /sensu-go/5.7/api/#response-filtering
@@ -1995,8 +1995,8 @@ To get started with Sensu Go:
 [97]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler/
 [98]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler/
 [99]: /sensu-go/5.2/commercial/
-[100]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags
-[101]: /sensu-go/5.16/observability-pipeline/observe-schedule/agent/#keepalive-configuration-flags
+[100]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery
+[101]: /sensu-go/5.16/observability-pipeline/observe-schedule/agent/#keepalive-configuration
 [102]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#initialization
 [103]: /sensu-go/5.16/web-ui/
 [104]: /sensu-go/5.16/
@@ -2029,13 +2029,13 @@ To get started with Sensu Go:
 [133]: /sensu-go/5.19/platforms/
 [134]: /sensu-go/5.19/operations/deploy-sensu/install-sensu/
 [135]: /sensu-go/5.19/web-ui/
-[136]: /sensu-go/5.19/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[136]: /sensu-go/5.19/observability-pipeline/observe-schedule/agent/#assets-burst-limit
 [137]: /sensu-go/5.19/observability-pipeline/observe-schedule/backend/#configuration-via-flags
 [138]: /sensu-go/5.20/api#field-selector
 [139]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#log-rotation
 [140]: /sensu-go/5.20/operations/maintain-sensu/troubleshoot/#increment-log-level-verbosity
 [141]: /sensu-go/5.20/commercial/
-[142]: /sensu-go/5.20/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[142]: /sensu-go/5.20/observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [143]: /sensu-go/5.20/observability-pipeline/observe-entities/entities/#processes-attributes
 [144]: /sensu-go/5.20/sensuctl/create-manage-resources/#supported-resource-types
 [145]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#configuration-summary
@@ -2096,7 +2096,7 @@ To get started with Sensu Go:
 [202]: /sensu-go/6.2/sensuctl/#first-time-setup-and-authentication
 [203]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#agent-managed-entity
 [204]: /sensu-go/6.2/observability-pipeline/observe-entities/entities/#manage-agent-entities-via-the-agent
-[205]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[205]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [206]: /sensu-go/5.21/observability-pipeline/observe-schedule/backend/#log-rotation
 [207]: /sensu-go/6.3/commercial/
 [208]: /sensu-go/6.3/observability-pipeline/observe-schedule/backend/#agent-burst-limit
@@ -2120,6 +2120,7 @@ To get started with Sensu Go:
 [226]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-log-parallel-encoders
 [227]: /sensu-go/6.4/api/other/metrics/
 [228]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-logging
+[229]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery-srv
 [229]: /sensu-go/6.5/commercial/
 [230]: /sensu-go/6.5/observability-pipeline/observe-process/sumo-logic-metrics-handlers/
 [231]: /sensu-go/6.5/observability-pipeline/observe-process/tcp-stream-handlers/
@@ -2148,3 +2149,4 @@ To get started with Sensu Go:
 [255]: #652-release-notes
 [256]: /sensu-go/6.5/observability-pipeline/observe-schedule/backend/#api-write-timeout
 [257]: /sensu-go/6.5/observability-pipeline/observe-schedule/backend/#dashboard-write-timeout
+[292]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery-srv

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -99,13 +99,13 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
 
 **November 22, 2021** &mdash; The latest release of Sensu Go, version 6.5.5, is now available for download.
 
-The Sensu Go 6.5.5 patch release adds two backend configuration flags for configuring the API and web UI HTTP servers' write timeouts and three new GraphQL duration metrics for the metrics log. This release also delivers several bug fixes, including fixes for sensu-backend and sensu-agent panics and failed keepalive lease grant operations.
+The Sensu Go 6.5.5 patch release adds two backend configuration options for configuring the API and web UI HTTP servers' write timeouts and three new GraphQL duration metrics for the metrics log. This release also delivers several bug fixes, including fixes for sensu-backend and sensu-agent panics and failed keepalive lease grant operations.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.5.5.
 
 **IMPROVEMENTS**
-- Added the [api-write-timeout][256] and [dashboard-write-timeout][257] backend configuration flags.
-These flags allow you to configure the timeout for the respective HTTP servers' response writes, which is helpful when requests might take more than a few seconds to complete.
+- Added the [api-write-timeout][256] and [dashboard-write-timeout][257] backend configuration options.
+These options allow you to configure the timeout for the respective HTTP servers' response writes, which is helpful when requests might take more than a few seconds to complete.
 - Added graphql_duration_seconds, graphql_duration_seconds_sum, and graphql_duration_seconds_count to the [metrics log][238]. Also added objectives (0.5, 0.9, 0.99) to the graphql_duration_seconds metric.
 - Added Prometheus metrics for tracking lease operations, with labels for operation type and status, and added sensu_go_lease_ops to the [metrics log][238].
 
@@ -224,16 +224,16 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.5.0.
 - New [pipelines][233] resource allows you to specify event filters, mutators, and handlers in a single workflow instead of listing filters and mutators in handler definitions. You can reference pipelines in your check definitions. The [`/pipelines` API endpoint][234] provides HTTP access for retrieving pipeline data and configuring pipelines, and you can use [sensuctl][235] to manage pipelines. [Upgrade your Sensu agents][1] to Sensu Go 6.5.0 to use pipelines resources.
 - [JavaScript mutators][246] are now available. JavaScript mutators are evaluated by the Otto JavaScript VM as JavaScript programs, which enables greater throughput at scale than pipe mutators.
 - Check definitions now include the [pipelines attribute][236] for specifying pipeline resources to use for the check's observability events.
-- Added [platform metrics logging][238] to log core Sensu metrics in InfluxDB Line Protocol format, along with the `disable-platform-metrics`, `platform-metrics-log-file`, and `platform-metrics-logging-interval` backend configuration flags for managing the platform metrics logging feature.
+- Added [platform metrics logging][238] to log core Sensu metrics in InfluxDB Line Protocol format, along with the `disable-platform-metrics`, `platform-metrics-log-file`, and `platform-metrics-logging-interval` backend configuration options for managing the platform metrics logging feature.
 - [Event logging][237] is no longer a commercial-only feature.
 - You can now set sensuctl environment variables for a [single sensuctl command][243] or with [sensuctl configure][244].
 
 **IMPROVEMENTS:**
 
-- Added environment variables `SENSU_BACKEND_ETCD_CLIENT_USERNAME` and `SENSU_BACKEND_ETCD_CLIENT_PASSWORD` for [connecting to external etcd via username and password authentication][245] instead of certificate authentication. There are no corresponding configuration flags &mdash; these configuration options must be set via environment variables.
+- Added environment variables `SENSU_BACKEND_ETCD_CLIENT_USERNAME` and `SENSU_BACKEND_ETCD_CLIENT_PASSWORD` for [connecting to external etcd via username and password authentication][245] instead of certificate authentication. There are no corresponding command line flags &mdash; these configuration options must be set via environment variables.
 - You can now add an [API key][248] when you initialize the backend to make automated cluster setup and deployment more straightforward.
 - Events now include the name of the agent that processed the event in the [`processed_by` attribute][251] to help you determine which agent processed an event executed by a proxy check request or a POST request to the events API.
-- Added the [`ignore-already-initialized` backend flag][253], which you can use to suppress the "already initialized" response and return an exit code 0 if a cluster has already been initialized.
+- Added the [`ignore-already-initialized`][253] backend configuration option, which you can use to suppress the "already initialized" response and return an exit code 0 if a cluster has already been initialized.
 - Upgraded Go version from 1.16.5 to 1.17.1.
 
 **SECURITY:**
@@ -347,7 +347,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.3.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][207]) Added [business service monitoring (BSM)][210] to provide high-level visibility into the current health of any number of business services, with a [built-in aggregate check rule template][211].
-- ([Commercial feature][207]) Added support for agent transport rate limiting via [`agent-burst-limit`][208] and [`agent-rate-limit`][209] backend configuration flags.
+- ([Commercial feature][207]) Added support for agent transport rate limiting via [`agent-burst-limit`][208] and [`agent-rate-limit`][209] backend configuration options.
 - ([Commercial feature][207]) Added the `event-log-buffer-wait` backend configuration flag, which allows you to specify how long the event logger will wait for the writer to consume events from the buffer when the buffer is full.
 - Added the entity class [service][213], which represents a business service for the business service monitoring (BSM) feature.
 
@@ -590,7 +590,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.1.0.
 - ([Commercial feature][172]) Added the [Sensu SaltStack Enterprise Handler][183] for launching
 SaltStack Enterprise Jobs for automated remediation.
 - ([Commercial feature][172]) The Alpine-based Docker image now has multi-architecture support with support for the linux/386, linux/amd64, linux/arm64, linux/arm/v6, linux/arm/v7, linux/ppc64le, and linux/s390x platforms.
-- The backend flag [`--api-request-limit`][173] is now available to configure the maximum API request body size (in bytes).
+- The backend configuration option [`api-request-limit`][173] is now available to configure the maximum API request body size (in bytes).
 - In the [REST API][174], most configuration resources now support the PATCH method for making updates.
 - Added new handler and check plugins: [Sensu Go Elasticsearch Handler][184], [Sensu Rundeck Handler][185], and [Sensu Kubernetes Events Check][186].
 
@@ -759,7 +759,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.21.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][158]) Added [entity count and limit][156] for each entity class in the tabular title in the response for `sensuctl license info` (in addition to the total entity count and limit).
-- ([Commercial feature][158]) Added Linux amd64 OpenSSL-linked binaries for the Sensu agent and backend, with accompanying `--require-fips` and `--require-openssl` flags for the [agent][161] and [backend][160].
+- ([Commercial feature][158]) Added Linux amd64 OpenSSL-linked binaries for the Sensu agent and backend, with accompanying `require-fips` and `require-openssl` configuration options for the [agent][161] and [backend][160].
 - Added `sensuctl user hash-password` command to generate password hashes.
 - Added the ability to reset passwords via the backend API and `sensuctl user reset-password`.
 
@@ -820,9 +820,9 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
+- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` option to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
-- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
+- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration option for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
 - ([Commercial feature][141]) Added a PostgreSQL metrics suite so metricsd can collect metrics about events stored in PostgreSQL.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
@@ -885,7 +885,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
-- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-burst-limit` and `--assets-rate-limit` flags for the [agent][136] and [backend][137].
+- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `assets-burst-limit` and `assets-rate-limit` configuration options for the [agent][136] and [backend][137].
 - Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
@@ -1055,7 +1055,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][106]) Added [HTTP API for secrets management][108], with Sensu's `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
-- Added the `keepalive-handlers` agent configuration flag to specify the keepalive handlers to use for an entity's events.
+- Added the `keepalive-handlers` agent configuration option to specify the keepalive handlers to use for an entity's events.
 
 **IMPROVEMENTS:**
 
@@ -1099,7 +1099,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.16.1.
 **December 16, 2019** &mdash; The latest release of Sensu Go, version 5.16.0, is now available for download.
 This is another important release, with many new features, improvements, and fixes.
 We introduced an initialization subcommand for **new** installations that allows you to specify an admin username and password instead of using a pre-defined default.
-We also added new backend flags to help you take advantage of etcd auto-discovery features and agent flags you can use to define a timeout period for critical and warning keepalive events.
+We also added new backend configuration options to help you take advantage of etcd auto-discovery features and agent configuration options you can use to define a timeout period for critical and warning keepalive events.
 
 New web UI features include a switcher that makes it easier to switch between namespaces in the dashboard, breadcrumbs on every page, OIDC authentication in the dashboard, a drawer that replaces the app bar to make more room for content, and more.
 
@@ -1116,11 +1116,11 @@ Users will need to [run 'sensu-backend init'][102] on every new installation and
 
 - ([Commercial feature][105]) Users can now authenticate with OIDC in the dashboard.
 - ([Commercial feature][105]) Label selectors now match the event's check and entity labels.
-- Added a new flag,`--etcd-client-urls`, which should be used with sensu-backend when it is not operating as an etcd member.
-The flag is also used by the new `sensu-backend init` subcommand.
+- Added a new configuration option, `etcd-client-urls`, to use with sensu-backend when it is not operating as an etcd member.
+The configuration option is also used by the new `sensu-backend init` subcommand.
 - Added the ['sensu-backend init' subcommand][102].
-- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][292] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
-- Added [`--keepalive-critical-timeout`][101] to define the time after which a critical keepalive event should be created for an agent and [`--keepalive-warning-timeout`][101], which is an alias of `--keepalive-timeout` for backward compatibility.
+- Added the [`etcd-discovery`][100] and [`etcd-discovery-srv`][292] configuration options to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
+- Added the [`keepalive-critical-timeout`][101] configuration option to define the time after which a critical keepalive event should be created for an agent and the [`keepalive-warning-timeout`][101] configuration option, which is an alias of `keepalive-timeout` for backward compatibility.
 
 **IMPROVEMENTS:**
 
@@ -1404,7 +1404,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.11.0.
 Read the [sensuctl reference][72] for more information.
 - Assets now include a `headers` attribute to include HTTP headers in requests to retrieve assets, allowing you to access secured assets.
 Read the [asset reference][70] for examples.
-- Sensu agents now support the `disable-assets` configuration flag, allowing you to disable asset retrieval for individual agents.
+- Sensu agents now support the `disable-assets` configuration option, allowing you to disable asset retrieval for individual agents.
 Read the [agent reference][71] for examples.
 - Sensu [binary-only distributions][69] are now available as zip files.
 
@@ -1511,7 +1511,7 @@ If you're upgrading a Sensu cluster from 5.7.0 or earlier, read the [instruction
 Read the [web UI docs][54] to get started using the Sensu web UI.
 - ([Commercial feature][53]) Manage your Sensu event handlers from your browser: Sensu's web UI now supports creating, editing, and deleting handlers.
 Read the [web UI docs][54] to get started using the Sensu web UI.
-- ([Commercial feature][53]) Sensu now supports event logging to a file using the `event-log-file` and `event-log-buffer-size` configuration flags.
+- ([Commercial feature][53]) Sensu now supports event logging to a file using the `event-log-file` and `event-log-buffer-size` configuration options.
 You can use this event log file as an input source for your favorite data lake solution.
 Read the [backend reference][55] for more information.
 
@@ -1682,7 +1682,7 @@ Read the [/metrics API documentation][31] for more information.
 **IMPROVEMENTS:**
 
 - Sensu now lets you specify a separate TLS certificate and key to secure the dashboard.
-Read the [backend reference][24] to configure the `dashboard-cert-file` and `dashboard-key-file` flags, and check out the [guide to securing Sensu][25] for the complete guide to making your Sensu instance production-ready.
+Read the [backend reference][24] to configure the `dashboard-cert-file` and `dashboard-key-file` options, and check out the [guide to securing Sensu][25] for the complete guide to making your Sensu instance production-ready.
 - The Sensu agent events API now queues events before sending them to the backend, making the agent events API more robust and preventing data loss in the event of a loss of connection with the backend or agent shutdown.
 Read the [agent reference][26] for more information.
 
@@ -1729,7 +1729,7 @@ You can now use the dashboard to review check details like command, subscription
 
 - Sensu Go 5.3.0 fixes all known TLS vulnerabilities affecting the backend, including increasing the minimum supported TLS version to 1.2 and removing all ciphers except those with perfect forward secrecy.
 - Sensu now enforces uniform TLS configuration for all three backend components: `apid`, `agentd`, and `dashboardd`.
-- The backend no longer requires the `trusted-ca-file` flag when using TLS.
+- The backend no longer requires the `trusted-ca-file` configuration option when using TLS.
 - The backend no longer loads server TLS configuration for the HTTP client.
 
 **FIXES:**
@@ -1853,7 +1853,7 @@ Read the [upgrade guide][3] for more information.
 
 **NEW FEATURES:**
 
-- Sensu [agents][4] now include `trusted-ca-file` and `insecure-skip-tls-verify` configuration flags, giving you more flexibility with certificates when connecting agents to the backend over TLS.
+- Sensu [agents][4] now include `trusted-ca-file` and `insecure-skip-tls-verify` configuration options, giving you more flexibility with certificates when connecting agents to the backend over TLS.
 
 **IMPROVEMENTS:**
 

--- a/content/sensu-go/6.5/sensuctl/_index.md
+++ b/content/sensu-go/6.5/sensuctl/_index.md
@@ -495,7 +495,7 @@ source ~/.zshrc
 
 [1]: ../operations/control-access/rbac/
 [2]: ../operations/deploy-sensu/install-sensu/#install-sensuctl
-[3]: ../observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[3]: ../observability-pipeline/observe-schedule/backend/
 [4]: ../operations/deploy-sensu/cluster-sensu/
 [5]: create-manage-resources/#create-resources
 [6]: #sensu-backend-url

--- a/content/sensu-go/6.6/api/_index.md
+++ b/content/sensu-go/6.6/api/_index.md
@@ -85,7 +85,7 @@ Beta APIs are more stable than alpha versions, but they offer similarly short-li
 ## Request size limit
 
 The default limit for API request body size is 0.512 MB.
-Use the [`--api-request-limit` backend configuration flag][21] to customize the API request body size limit if needed.
+Use the [`api-request-limit` backend configuration option][21] to customize the API request body size limit if needed.
 
 ## Access control
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
@@ -1787,7 +1787,7 @@ status: Ss
 [31]: ../#agent-entities
 [32]: ../#proxy-entities
 [33]: ../../../web-ui/view-manage-resources/#manage-entities
-[34]: ../../observe-schedule/agent/#ephemeral-agent-configuration-flags
+[34]: ../../observe-schedule/agent/#ephemeral-agent-configuration
 [35]: ../../observe-schedule/agent/#config-file
 [36]: ../../../api/core/entities/
 [37]: ../../../sensuctl/create-manage-resources/#update-resources

--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/entities.md
@@ -222,9 +222,9 @@ If you change an agent entity's class to `proxy`, the backend will revert the ch
 ### Manage agent entities via the agent
 
 If you prefer, you can manage agent entities via the agent rather than the backend.
-To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
+To do this, add the [`agent-managed-entity`][16] configuration option when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
 
-When you start an agent with the `--agent-managed-entity` flag or set `agent-managed-entity: true` in `agent.yml`, the agent becomes responsible for managing its entity configuration.
+When you start an agent with the `agent-managed-entity` configuration option set to `true`, the agent becomes responsible for managing its entity configuration.
 An entity managed by this agent will include the label `sensu.io/managed_by: sensu-agent`.
 You cannot update these agent-managed entities via the Sensu backend REST API.
 To change an agent's configuration, restart the agent.
@@ -1233,7 +1233,7 @@ arm_version: 7
 
 cloud_provider | 
 ---------------|------ 
-description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
+description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`detect-cloud-provider`][25] configuration option is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
 **NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
 {{% /notice %}}
 required       | false 
@@ -1594,7 +1594,7 @@ name: eth0
 ### Processes attributes
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag](../../observe-schedule/agent/#discover-processes) in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes`](../../observe-schedule/agent/#discover-processes) configuration option in the packaged Sensu Go distribution.
 For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -37,7 +37,7 @@ Instead, you must configure event handlers to send the data to a storage solutio
 
 ## Configure the StatsD listener
 
-Use flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
+Use configuration flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
 
 The following flags allow you to configure event handlers, flush interval, address, and port:
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/handlers.md
@@ -284,8 +284,8 @@ spec:
 
 {{< /language-toggle >}}
 
-You can also use the [`keepalive-handlers`][19] flag to send keepalive events to any handler you have configured.
-If you do not specify a keepalive handler with the `keepalive-handlers` flag, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+You can also use the [`keepalive-handlers`][19] configuration option to send keepalive events to any handler you have configured.
+If you do not specify a keepalive handler with the `keepalive-handlers` configuration option, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 
 ## Handler specification
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -123,7 +123,7 @@ If system time is out of sync, it may cause issues with keepalive, metric, and c
 
 ## Agent connection to a cluster
 
-Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url` configuration flag][16].
+Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url`][16] configuration option.
 
 For more information about clustering, read [Backend datastore configuration][35] and [Run a Sensu cluster][36].
 
@@ -916,7 +916,7 @@ disable-assets: true{{< /code >}}
 | discover-processes |      |
 --------------|------
 description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the discover-processes flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `discover-processes` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}{{% notice note %}}
 **NOTE**: Process discovery is disabled in this version of Sensu. The discover-processes flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
@@ -1106,7 +1106,7 @@ deregister: true{{< /code >}}
 
 | deregistration-handler |      |
 -------------------------|------
-description              | Name of the event handler to use when processing the agent's deregistration events. This flag overrides any handlers applied by the [`deregistration-handler` backend configuration flag][37].
+description              | Name of the event handler to use when processing the agent's deregistration events. This configuration option overrides any handlers applied by the [`deregistration-handler`][37] backend configuration option.
 type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
@@ -1118,7 +1118,7 @@ deregistration-handler: deregister{{< /code >}}
 
 | detect-cloud-provider  |      |
 -------------------------|------
-description              | `true` to enable cloud provider detection mechanisms. Otherwise, `false`. When this flag is enabled, the agent will attempt to read files, resolve hostnames, and make HTTP requests to determine what cloud environment it is running in.
+description              | `true` to enable cloud provider detection mechanisms. Otherwise, `false`. When this option is enabled, the agent will attempt to read files, resolve hostnames, and make HTTP requests to determine what cloud environment it is running in.
 type                     | Boolean
 default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
@@ -1145,7 +1145,7 @@ keepalive-critical-timeout: 300{{< /code >}}
 
 | keepalive-handlers |      |
 --------------------|------
-description         | [Keepalive event handlers][52] to use for the entity, specified in a comma-delimited list. You can specify any configured handler and invoke the `keepalive-handlers` flag multiple times. If keepalive handlers are not specified, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+description         | [Keepalive event handlers][52] to use for the entity, specified in a comma-delimited list. You can specify any configured handler and invoke the `keepalive-handlers` configuration option multiple times. If keepalive handlers are not specified, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 type                | List
 default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
@@ -1198,7 +1198,7 @@ cert-file: "/path/to/tls/agent.pem"{{< /code >}}
 | insecure-skip-tls-verify |      |
 ---------------------------|------
 description                | Skip SSL verification. {{% notice warning %}}
-**WARNING**: This configuration flag is intended for use in development systems only. Do not use this flag in production.
+**WARNING**: This configuration option is intended for use in development systems only. Do not use this configuration option in production.
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
@@ -1268,7 +1268,7 @@ redact:
 | require-fips |      |
 ------------------|------
 description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu agent startup if `true` but OpenSSL is not running in FIPS mode. {{% notice note %}}
-**NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `require-fips` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
@@ -1282,7 +1282,7 @@ require-fips: true{{< /code >}}
 | require-openssl |      |
 ------------------|------
 description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu agent startup if `true` but Go's standard cryptography library is loaded. {{% notice note %}}
-**NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `--require-openssl` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -125,24 +125,24 @@ If system time is out of sync, it may cause issues with keepalive, metric, and c
 
 Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url` configuration flag][16].
 
-For more information about clustering, read [Backend datastore configuration flags][35] and [Run a Sensu cluster][36].
+For more information about clustering, read [Backend datastore configuration][35] and [Run a Sensu cluster][36].
 
 ## Keepalive monitoring
 
 Sensu keepalives are the heartbeat mechanism used to ensure that all registered agents are operational and able to reach the [Sensu backend][2].
-Sensu agents publish keepalive events containing [entity][3] configuration data to the Sensu backend according to the interval specified by the [`keepalive-interval`][4] configuration flag.
+Sensu agents publish keepalive events containing [entity][3] configuration data to the Sensu backend according to the interval specified by the [`keepalive-interval`][4] configuration option.
 
-If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-critical-timeout`][4] configuration flag, the Sensu backend creates a keepalive **critical** alert in the Sensu web UI.
+If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-critical-timeout`][4] configuration option, the Sensu backend creates a keepalive **critical** alert in the Sensu web UI.
 The `keepalive-critical-timeout` is set to `0` (disabled) by default to help ensure that it will not interfere with your `keepalive-warning-timeout` setting.
 
-If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-warning-timeout`][58] configuration flag, the Sensu backend creates a keepalive **warning** alert in the Sensu web UI.
+If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-warning-timeout`][58] configuration option, the Sensu backend creates a keepalive **warning** alert in the Sensu web UI.
 The value you specify for `keepalive-warning-timeout` must be lower than the value you specify for `keepalive-critical-timeout`.
 
 {{% notice note %}}
-**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
+**NOTE**: If you set the [`deregister` configuration option](#ephemeral-agent-configuration) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
 Deregistration prevents and clears alerts for failing keepalives for agent entities &mdash; the backend does not distinguish between intentional shutdown and failure.
-As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
-If you want to receive alerts for failing keepalives, set the [deregister](#ephemeral-agent-configuration-flags) configuration flag to `false`.
+As a result, if you set `deregister` to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
+If you want to receive alerts for failing keepalives, set the [deregister configuration option](#ephemeral-agent-configuration) to `false`.
 {{% /notice %}}
 
 You can use keepalives to identify unhealthy systems and network partitions, send notifications, and trigger auto-remediation, among other useful actions.
@@ -194,8 +194,8 @@ spec:
 
 {{< /language-toggle >}}
 
-You can also use the [`keepalive-handlers`][53] flag to send keepalive events to any handler you have configured.
-If you do not specify a keepalive handler with the `keepalive-handlers` flag, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+You can also use the [`keepalive-handlers`][53] configuration option to send keepalive events to any handler you have configured.
+If you do not specify a keepalive handler with the `keepalive-handlers` option, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 
 ## Create observability events using service checks
 
@@ -235,7 +235,7 @@ Read the [entities reference][3] and [Monitor external resources][33] for more i
 ## Create observability events using the agent API
 
 The Sensu agent API allows external sources to send monitoring data to Sensu without requiring the external sources to know anything about Sensu's internal implementation.
-The agent API listens on the address and port specified with the [API configuration attributes][18].
+The agent API listens on the address and port specified with the agent [API configuration options][18].
 
 The agent API supports only unsecured HTTP requests (no HTTPS).
 Requests for unknown endpoints will result in an `HTTP 404 Not Found` response.
@@ -249,7 +249,7 @@ In case of a loss of connection with the backend or agent shutdown, the agent pr
 When the connection is reestablished, the agent sends the queued events to the backend.
 
 The agent API `/events` endpoint uses a configurable burst limit and rate limit for relaying events to the backend.
-Read [API configuration flags](#api-configuration-flags) to configure the `events-burst-limit` and `events-rate-limit` flags.
+Read [API configuration](#api-configuration) to configure the `events-burst-limit` and `events-rate-limit` options.
 
 #### Example POST request to events endpoint
 
@@ -419,14 +419,14 @@ For more information about StatsD, read the [StatsD documentation][21].
 
 ### Configure the StatsD listener
 
-To configure the StatsD listener, specify the [`statsd-event-handlers`][22] configuration flag in the [agent configuration][24] and start the agent.
+To configure the StatsD listener, specify the [`statsd-event-handlers`][22] configuration option in the [agent configuration][24] and start the agent.
 For example, to start an agent that sends StatsD metrics to InfluxDB, run:
 
 {{< code shell >}}
 sensu-agent --statsd-event-handlers influx-db
 {{< /code >}}
 
-Use the [StatsD configuration flags][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
+Use the [StatsD configuration options][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
 For example, to start an agent with a customized address and flush interval, run:
 
 {{< code shell >}}
@@ -441,7 +441,7 @@ sensu-agent --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd
 
 Sensu agents listen for external monitoring data using TCP and UDP sockets.
 The agent sockets accept JSON event data and pass events to the Sensu backend event pipeline for processing.
-The TCP and UDP sockets listen on the address and port specified by the [socket configuration flags][17].
+The TCP and UDP sockets listen on the address and port specified by the [socket configuration options][17].
 
 ### Use the TCP socket
 
@@ -636,42 +636,32 @@ However, all registration events are logged in the [Sensu backend log](../backen
 
 As with registration events, the Sensu backend can create and process a deregistration event when the Sensu agent process stops.
 You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
-To enable deregistration events, use the [`deregister` flag][13], and specify the event handler using the [`deregistration-handler` flag][13].
-You can specify a deregistration handler per agent using the [`deregistration-handler` agent flag][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration flag][37].
+To enable deregistration events, use the [`deregister` option][13], and specify the event handler using the [`deregistration-handler` option][13].
+You can specify a deregistration handler per agent using the [`deregistration-handler` agent option][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration option][37].
 
 {{% notice note %}}
 **NOTE**: Deregistration is supported for [agent entities](../../observe-entities/#agent-entities) that have sent at least one keepalive.
 Deregistration is **not** supported for [proxy entities](../../observe-entities/#proxy-entities), which do not send keepalives, and the backend does not automatically create and process deregistration events for proxy entities.
 {{% /notice %}}
 
-## Configuration via flags
+## Agent configuration options
 
-For Linux agents, customize the agent configuration with `sensu-agent start` command line flags or in a `.yml` file.
-The default agent configuration file path for Linux is `/etc/sensu/agent.yml`.
-Configuration via command line flags overrides attributes specified in a configuration file.
-Read [Create overrides][68] to learn more.
+Agent configuration is customizable.
+This section describes each configuration option in more detail, including examples for each [configuration method][70].
 
-For Windows agents, customize the agent configuration in a `.yml` file.
-The default agent configuration file path for Windows is `C:\ProgramData\sensu\config\agent.yml.example`.
-
-Review the [example Sensu agent configuration file][5] for a complete list of flags and default values.
-The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
-
-### Agent configuration flag summary
+You can customize agent configuration with the [agent configuration file][69] (Linux and Windows), [command line flag arguments][24] (Linux), or [environment variables][50] (Linux and Windows).
 
 {{% notice note %}}
-**NOTE**: Process discovery is disabled in this version of Sensu.
-The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**NOTE**: The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 {{% /notice %}}
 
-To view configuration information for the sensu-agent start command, run:
+To view available configuration options for the `sensu-agent start` command, run:
 
 {{< code shell >}}
 sensu-agent start --help
 {{< /code >}}
 
-The response will list command information and configuration flags for sensu-agent start:
+The response will list configuration options as command line flags for `sensu-agent start`:
 
 {{< code text >}}
 start the sensu agent
@@ -733,11 +723,13 @@ Flags:
       --user string                         agent user (default "agent")
 {{< /code >}}
 
-### General configuration flags
-
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+**NOTE**: Process discovery is disabled in this version of Sensu.
+The `--discover-processes` configuration option is not available, and new events will not include data in the `processes` attributes.
+Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
+
+### General configuration
 
 <a id="agent-managed-entity"></a>
 
@@ -750,20 +742,20 @@ default      | false
 environment variable | `SENSU_AGENT_MANAGED_ENTITY`
 command line example   | {{< code shell >}}
 sensu-agent start --agent-managed-entity{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 agent-managed-entity: true{{< /code >}}
 
 <a id="allow-list"></a>
 
 | allow-list |      |
 ------------------|------
-description       | Path to yaml or json file that contains the allow list of check or hook commands the agent can execute. Read [allow list configuration commands][49] and the [example allow list configuration][48] for information about building a configuration file.
+description       | Path to yaml or json file that contains the allow list of check or hook commands the agent can execute. Read [Allow list configuration][49] and the [example allow list configuration][48] for information about building a configuration file.
 type              | String
 default           | `""`
 environment variable | `SENSU_ALLOW_LIST`
 command line example   | {{< code shell >}}
 sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
 
 | annotations|      |
@@ -779,10 +771,12 @@ command line example   | {{< code shell >}}
 sensu-agent start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-agent start --annotations example-key="example value" --annotations example-key2="example value"
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
+
+<a id="assets-burst-limit"></a>
 
 | assets-burst-limit   |      |
 --------------|------
@@ -792,7 +786,7 @@ default       | `100`
 environment variable | `SENSU_ASSETS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --assets-burst-limit 100{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
 
 | assets-rate-limit   |      |
@@ -803,7 +797,7 @@ default       | `1.39`
 environment variable | `SENSU_ASSETS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --assets-rate-limit 1.39{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 <a id="backend-handshake-timeout"></a>
@@ -816,7 +810,7 @@ default       | `15`
 environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-handshake-timeout 20{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
 <a id="backend-heartbeat-interval"></a>
@@ -829,7 +823,7 @@ default       | `30`
 environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
 <a id="backend-heartbeat-timeout"></a>
@@ -842,7 +836,7 @@ default       | `45`
 environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-heartbeat-timeout 60{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-heartbeat-timeout: 60{{< /code >}}
 
 | backend-url |      |
@@ -851,7 +845,9 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
-default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
+default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_URL`
 command line example | {{< language-toggle >}}
 {{< code shell "ws" >}}
@@ -863,7 +859,7 @@ sensu-agent start --backend-url wss://127.0.0.1:8081
 sensu-agent start --backend-url wss://127.0.0.1:8081 --backend-url wss://127.0.0.1:8082
 {{< /code >}}
 {{< /language-toggle >}}
-/etc/sensu/agent.yml example | {{< language-toggle >}}
+agent.yml config file example | {{< language-toggle >}}
 {{< code shell "ws" >}}
 backend-url:
   - "ws://127.0.0.1:8081"
@@ -886,7 +882,7 @@ default       | <ul><li>Linux: `/var/cache/sensu/sensu-agent`</li><li>Windows: `
 environment variable | `SENSU_CACHE_DIR`
 command line example   | {{< code shell >}}
 sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
 <a id="config-file"></a>
@@ -912,7 +908,7 @@ default       | false
 environment variable | `SENSU_DISABLE_ASSETS`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-assets{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
 <a id="discover-processes"></a>
@@ -929,7 +925,7 @@ default       | false
 environment variable | `SENSU_DISCOVER_PROCESSES`
 command line example   | {{< code shell >}}
 sensu-agent start --discover-processes{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 discover-processes: true{{< /code >}}
 
 | labels     |      |
@@ -945,7 +941,7 @@ command line example   | {{< code shell >}}
 sensu-agent start --labels proxy_type=website
 sensu-agent start --labels example_key1="example value" example_key2="example value"
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 labels:
   proxy_type: website
 {{< /code >}}
@@ -960,7 +956,7 @@ default       | `warn`
 environment variable | `SENSU_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-agent start --log-level debug{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 log-level: debug{{< /code >}}
 
 <a id="name-attribute"></a>
@@ -973,7 +969,7 @@ default       | Defaults to hostname (for example, `sensu-centos`).
 environment variable | `SENSU_NAME`
 command line example   | {{< code shell >}}
 sensu-agent start --name agent-01{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 name: "agent-01"{{< /code >}}
 
 <a id="retry-max"></a>
@@ -986,7 +982,7 @@ default       | `120s`
 environment variable | `SENSU_RETRY_MAX`
 command line example   | {{< code shell >}}
 sensu-agent start --retry-max 120s{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 retry-max: 120s{{< /code >}}
 
 <a id="retry-min"></a>
@@ -999,7 +995,7 @@ default       | `1s`
 environment variable | `SENSU_RETRY_MIN`
 command line example   | {{< code shell >}}
 sensu-agent start --retry-min 1s{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 retry-min: 1s{{< /code >}}
 
 <a id="retry-multiplier"></a>
@@ -1014,7 +1010,7 @@ default       | `2.0`
 environment variable | `SENSU_RETRY_MULTIPLIER`
 command line example   | {{< code shell >}}
 sensu-agent start --retry-multiplier 2.0{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 retry-multiplier: 2.0{{< /code >}}
 
 <a id="subscriptions-flag"></a>
@@ -1028,13 +1024,13 @@ command line example   | {{< code shell >}}
 sensu-agent start --subscriptions disk-checks,process-checks
 sensu-agent start --subscriptions disk-checks --subscriptions process-checks
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 subscriptions:
   - disk-checks
   - process-checks
 {{< /code >}}
 
-### API configuration flags
+### API configuration
 
 | api-host    |      |
 --------------|------
@@ -1044,7 +1040,7 @@ default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --api-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 api-host: "127.0.0.1"{{< /code >}}
 
 | api-port    |      |
@@ -1055,7 +1051,7 @@ default       | `3031`
 environment variable | `SENSU_API_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --api-port 3031{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 api-port: 3031{{< /code >}}
 
 | disable-api |      |
@@ -1066,7 +1062,7 @@ default       | `false`
 environment variable | `SENSU_DISABLE_API`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-api{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-api: true{{< /code >}}
 
 | events-burst-limit | |
@@ -1077,7 +1073,7 @@ default       | `10`
 environment variable | `SENSU_EVENTS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --events-burst-limit 20{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 events-burst-limit: 20{{< /code >}}
 
 | events-rate-limit | |
@@ -1088,10 +1084,10 @@ default       | `10.0`
 environment variable | `SENSU_EVENTS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --events-rate-limit 20.0{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 events-rate-limit: 20.0{{< /code >}}
 
-### Ephemeral agent configuration flags
+### Ephemeral agent configuration
 
 | deregister  |      |
 --------------|------
@@ -1103,7 +1099,7 @@ default       | `false`
 environment variable | `SENSU_DEREGISTER`
 command line example   | {{< code shell >}}
 sensu-agent start --deregister{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 deregister: true{{< /code >}}
 
 <a id="agent-deregistration-handler-attribute"></a>
@@ -1115,7 +1111,7 @@ type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
 sensu-agent start --deregistration-handler deregister{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 deregistration-handler: deregister{{< /code >}}
 
 <a id="detect-cloud-provider-flag"></a>
@@ -1128,10 +1124,10 @@ default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
 command line example   | {{< code shell >}}
 sensu-agent start --detect-cloud-provider false{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 detect-cloud-provider: false{{< /code >}}
 
-### Keepalive configuration flags
+### Keepalive configuration
 
 | keepalive-critical-timeout |      |
 --------------------|------
@@ -1142,7 +1138,7 @@ default             | `0`
 environment variable   | `SENSU_KEEPALIVE_CRITICAL_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
 <a id="keepalive-handlers-flag"></a>
@@ -1155,7 +1151,7 @@ default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-handlers slack,email{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-handlers:
 - slack
 - email
@@ -1169,7 +1165,7 @@ default              | `20`
 environment variable   | `SENSU_KEEPALIVE_INTERNAL`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-interval 30{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-interval: 30{{< /code >}}
 
 <a id="keepalive-warning-timeout-flag"></a>
@@ -1183,10 +1179,10 @@ default             | `120`
 environment variable   | `SENSU_KEEPALIVE_WARNING_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-warning-timeout 300{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-warning-timeout: 300{{< /code >}}
 
-### Security configuration flags
+### Security configuration
 
 | cert-file  |      |
 -------------|------
@@ -1196,7 +1192,7 @@ default      | `""`
 environment variable | `SENSU_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --cert-file /path/to/tls/agent.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 cert-file: "/path/to/tls/agent.pem"{{< /code >}}
 
 | insecure-skip-tls-verify |      |
@@ -1209,7 +1205,7 @@ default                    | `false`
 environment variable       | `SENSU_INSECURE_SKIP_TLS_VERIFY`
 command line example   | {{< code shell >}}
 sensu-agent start --insecure-skip-tls-verify{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 | key-file   |      |
@@ -1220,7 +1216,7 @@ default      | `""`
 environment variable | `SENSU_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --key-file /path/to/tls/agent-key.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 key-file: "/path/to/tls/agent-key.pem"{{< /code >}}
 
 | namespace |      |
@@ -1234,8 +1230,10 @@ default        | `default`
 environment variable   | `SENSU_NAMESPACE`
 command line example   | {{< code shell >}}
 sensu-agent start --namespace ops{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 namespace: ops{{< /code >}}
+
+<a id="agent-password-option"></a>
 
 | password    |      |
 --------------|------
@@ -1245,7 +1243,7 @@ default       | `P@ssw0rd!`
 environment variable   | `SENSU_PASSWORD`
 command line example   | {{< code shell >}}
 sensu-agent start --password secure-password{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 password: secure-password{{< /code >}}
 
 | redact      |      |
@@ -1259,7 +1257,7 @@ default       | By default, Sensu redacts the following fields: `password`, `pas
 environment variable   | `SENSU_REDACT`
 command line example   | {{< code shell >}}
 sensu-agent start --redact secret,ec2_access_key{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 redact:
   - secret
   - ec2_access_key
@@ -1278,7 +1276,7 @@ default           | false
 environment variable | `SENSU_REQUIRE_FIPS`
 command line example   | {{< code shell >}}
 sensu-agent start --require-fips{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -1292,7 +1290,7 @@ default           | false
 environment variable | `SENSU_REQUIRE_OPENSSL`
 command line example   | {{< code shell >}}
 sensu-agent start --require-openssl{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -1303,8 +1301,10 @@ default           | `""`
 environment variable   | `SENSU_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 trusted-ca-file: "/path/to/tls/ca.pem"{{< /code >}}
+
+<a id="agent-user-option"></a>
 
 | user |      |
 --------------|------
@@ -1314,10 +1314,10 @@ default       | `agent`
 environment variable   | `SENSU_USER`
 command line example   | {{< code shell >}}
 sensu-agent start --user agent-01{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 user: "agent-01"{{< /code >}}
 
-### Socket configuration flags
+### Socket configuration
 
 | disable-sockets |      |
 ------------------|------
@@ -1327,7 +1327,7 @@ default           | `false`
 environment variable   | `SENSU_DISABLE_SOCKETS`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-sockets{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-sockets: true{{< /code >}}
 
 | socket-host |      |
@@ -1338,7 +1338,7 @@ default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --socket-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 socket-host: "127.0.0.1"{{< /code >}}
 
 | socket-port |      |
@@ -1349,10 +1349,10 @@ default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --socket-port 3030{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 socket-port: 3030{{< /code >}}
 
-### StatsD configuration flags
+### StatsD configuration
 
 | statsd-disable |      |
 -----------------|------
@@ -1362,7 +1362,7 @@ default          | `false`
 environment variable   | `SENSU_STATSD_DISABLE`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-disable{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-disable: true{{< /code >}}
 
 | statsd-event-handlers |      |
@@ -1374,7 +1374,7 @@ command line example   | {{< code shell >}}
 sensu-agent start --statsd-event-handlers influxdb,opentsdb
 sensu-agent start --statsd-event-handlers influxdb --statsd-event-handlers opentsdb
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-event-handlers:
   - influxdb
   - opentsdb
@@ -1388,7 +1388,7 @@ default                  | `10`
 environment variable     | `SENSU_STATSD_FLUSH_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-flush-interval 30{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-flush-interval: 30{{< /code >}}
 
 | statsd-metrics-host |      |
@@ -1399,7 +1399,7 @@ default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-metrics-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-metrics-host: "127.0.0.1"{{< /code >}}
 
 | statsd-metrics-port |      |
@@ -1410,13 +1410,13 @@ default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-metrics-port 8125{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-metrics-port: 8125{{< /code >}}
 
-### Allow list configuration commands
+### Allow list configuration
 
 The allow list includes check and hook commands the agent can execute.
-Use the [allow-list flag][56] to specify the path to the yaml or json file that contains your allow list.
+Use the [`allow-list` configuration option][56] to specify the path to the yaml or json file that contains your allow list.
 
 Use these commands to build your allow list configuration file.
 
@@ -1536,9 +1536,38 @@ sha512: 4f926bf4328...
 
 {{< /language-toggle >}}
 
-## Configuration via environment variables
+## Agent configuration methods
 
-Instead of using configuration flags, you can use environment variables to configure your Sensu agent.
+### Agent configuration file
+
+For Linux and Windows agents, you can customize the agent configuration in a `.yml` configuration file.
+
+The default agent configuration file path for Linux is `/etc/sensu/agent.yml`.
+The default agent configuration file path for Windows is `C:\ProgramData\sensu\config\agent.yml.example`.
+
+To use the `agent.yml` file to configure the agent, list the desired configuration attributes and values.
+Review the [example Sensu agent configuration file][5] for a complete example.
+
+Configuration via command line flags or environment variables overrides any configuration specified in the agent configuration file.
+Read [Create overrides][68] to learn more.
+
+### Command line flags
+
+For Linux agents, you can customize the agent configuration with `sensu-agent start` command line flags.
+
+To use command line flags, specify the desired configuration flags and values along with the `sensu-agent start` command.
+For example:
+
+{{< code shell >}}
+sensu-agent start --name webserver_05 --keepalive-warning-timeout 60 --keepalive-critical-timeout 120
+{{< /code >}}
+
+Configuration via command line flags overrides attributes specified in a configuration file or with environment variables.
+Read [Create overrides][68] to learn more.
+
+### Environment variables
+
+Instead of using the agent configuration file or command line flags, you can use environment variables to configure your Sensu agent.
 Each agent configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
@@ -1616,8 +1645,8 @@ sc.exe start SensuAgent
      {{< /language-toggle >}}
 
 {{% notice note %}}
-**NOTE**: Sensu includes an environment variable for each agent configuration flag.
-They are listed in the [configuration flag description tables](#general-configuration-flags).
+**NOTE**: Sensu includes an environment variable for each agent configuration option.
+They are listed in the [configuration description tables](#general-configuration).
 {{% /notice %}}
 
 ### Format for label and annotation environment variables
@@ -1723,12 +1752,12 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 **NOTE**: If you define the `HTTP_PROXY` and `HTTPS_PROXY` environment variables, the agent WebSocket connection will also use the proxy URL you specify.
 {{% /notice %}}
 
-## Create overrides
+## Create configuration overrides
 
 Sensu has default settings and limits for certain configuration attributes, like the default log level.
 Depending on your environment and preferences, you may want to create overrides for these Sensu-specific defaults and limits.
 
-You can create overrides in several ways:
+You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-agent start`.
 - Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
@@ -1974,7 +2003,7 @@ sensu-agent start --help
 [1]: ../../../operations/deploy-sensu/install-sensu#install-sensu-agents
 [2]: ../backend/
 [3]: ../../observe-entities/entities/
-[4]: #keepalive-configuration-flags
+[4]: #keepalive-configuration
 [5]: ../../../files/windows/agent.yml
 [6]: ../../../sensuctl/
 [7]: ../../observe-events/events/
@@ -1983,18 +2012,18 @@ sensu-agent start --help
 [10]: ../../observe-transform/mutators/
 [11]: https://en.wikipedia.org/wiki/Configuration_management_database
 [12]: https://www.servicenow.com/products/it-operations-management.html
-[13]: #ephemeral-agent-configuration-flags
+[13]: #ephemeral-agent-configuration
 [14]: ../checks/
 [15]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
-[16]: #general-configuration-flags
-[17]: #socket-configuration-flags
-[18]: #api-configuration-flags
+[16]: #general-configuration
+[17]: #socket-configuration
+[18]: #api-configuration
 [19]: https://sourceforge.net/projects/netcat/
 [20]: https://en.wikipedia.org/wiki/Dead_man%27s_switch
 [21]: https://github.com/etsy/statsd
-[22]: #statsd-configuration-flags
+[22]: #statsd-configuration
 [23]: https://github.com/statsd/statsd#key-concepts
-[24]: #configuration-via-flags
+[24]: #command-line-flags
 [25]: ../../../api/#response-filtering
 [26]: ../../../sensuctl/filter-responses/
 [27]: ../tokens/
@@ -2005,9 +2034,9 @@ sensu-agent start --help
 [32]: ../checks/#proxy-entity-name-attribute
 [33]: ../../observe-entities/monitor-external-resources/
 [34]: #backend-heartbeat-interval
-[35]: ../backend#datastore-and-cluster-configuration-flags
+[35]: ../backend/#datastore-and-cluster-configuration
 [36]: ../../../operations/deploy-sensu/cluster-sensu/
-[37]: ../backend#general-configuration-flags
+[37]: ../backend/#general-configuration
 [38]: #name
 [39]: ../../../operations/control-access/rbac/#agent-user
 [40]: ../../observe-process/send-slack-alerts/
@@ -2019,8 +2048,8 @@ sensu-agent start --help
 [46]: ../../../operations/deploy-sensu/secure-sensu/
 [47]: https://en.m.wikipedia.org/wiki/Protocol_Buffers
 [48]: #example-allow-list-configuration
-[49]: #allow-list-configuration-commands
-[50]: #configuration-via-environment-variables
+[49]: #allow-list-configuration
+[50]: #environment-variables
 [51]: #events-post-specification
 [52]: ../../observe-process/handlers/#keepalive-event-handlers
 [53]: #keepalive-handlers-flag
@@ -2032,4 +2061,6 @@ sensu-agent start --help
 [60]: #log-level
 [61]: #retry-min
 [62]: #retry-multiplier
-[68]: #create-overrides
+[68]: #create-configuration-overrides
+[69]: #agent-configuration-file
+[70]: #agent-configuration-methods

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
@@ -215,7 +215,7 @@ Store Flags:
       --etcd-trusted-ca-file string          path to the client server TLS trusted CA cert file
 {{< /code >}}
 
-For more information about the initialization store flags, read [Datastore and cluster configuration flags][72] and [Advanced configuration options][73].
+For more information about the initialization store flags, read [Datastore and cluster configuration][72] and [Advanced configuration options][73].
 
 <a id="ignore-already-initialized"></a>
 
@@ -584,7 +584,7 @@ log-level: "debug"{{< /code >}}
 | metrics-refresh-interval |      |
 -------------|------
 description  | Interval at which Sensu should refresh metrics. In hours, minutes, seconds, or a combination &mdash; for example, `5m`, `1m30s`, and `1h10m30s` are all valid values.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the `metrics-refresh-interval` flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `metrics-refresh-interval` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type         | String
 default      | `1m`
@@ -660,9 +660,9 @@ agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 | agent-burst-limit   |      |
 --------------|------
 description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice note %}}
-**NOTE**: The agent-burst-limit flag is deprecated.
+**NOTE**: The `agent-burst-limit` configuration flag is deprecated.
 {{% /notice %}} {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-burst-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-burst-limit` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer
 default       | `null`
@@ -699,7 +699,7 @@ agent-port: 8081{{< /code >}}
 | agent-rate-limit   |      |
 --------------|------
 description   | Maximum number of agent transport WebSocket connections per second, per backend.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-rate-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-rate-limit` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer
 default       | `null`
@@ -713,7 +713,7 @@ agent-rate-limit: 10{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the `dashboard-cert-file` configuration option is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -725,7 +725,7 @@ cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 | insecure-skip-tls-verify |      |
 ---------------------------|------
 description                | If `true`, skip SSL verification. Otherwise, `false`. {{% notice warning %}}
-**WARNING**: This configuration flag is intended for use in development systems only. Do not use this flag in production.
+**WARNING**: This configuration option is intended for use in development systems only. Do not use this configuration option in production.
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
@@ -766,7 +766,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the `dashboard-key-file` configuration option is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
@@ -780,7 +780,7 @@ key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 | require-fips |      |
 ------------------|------
 description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu backend startup if `true` but OpenSSL is not running in FIPS mode. {{% notice note %}}
-**NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `require-fips` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
@@ -794,7 +794,7 @@ require-fips: true{{< /code >}}
 | require-openssl |      |
 ------------------|------
 description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu backend startup if `true` but Go's standard cryptography library is loaded. {{% notice note %}}
-**NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `--require-openssl` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
@@ -295,23 +295,24 @@ Check scheduling is subscription-based: the backend sends check requests to [sub
 
 For information about creating and managing checks, read the [checks reference][5] and the guides [Monitor server resources with checks][3] and [Collect metrics with checks][4].
 
-## Configuration via flags
+## Backend configuration options
 
-You can specify the backend configuration with either a `/etc/sensu/backend.yml` file or `sensu-backend start` [configuration flags][15].
-The backend requires that the `state-dir` flag is set before starting.
-All other required flags have default values.
-Review the [example backend configuration file][17] for flags and defaults.
-The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
+Backend configuration is customizable.
+This section describes each configuration option in more detail, including examples for each [configuration method][79].
 
-### Configuration summary
+You can customize backend configuration with the [backend configuration file][76], [command line flag arguments][77], or [environment variables][78].
 
-To view configuration information for the sensu-backend start command, run:
+{{% notice note %}}
+**NOTE**: The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
+{{% /notice %}}
+
+To view configuration information for the `sensu-backend start` command, run:
 
 {{< code shell >}}
 sensu-backend start --help
 {{< /code >}}
 
-The response will list command information and configuration flags for sensu-backend start:
+The response will list configuration options as command line flags for `sensu-backend start`:
 
 {{< code text >}}
 start the sensu backend
@@ -400,13 +401,12 @@ Store Flags:
       --no-embed-etcd                             don't embed etcd, use external etcd instead
 {{< /code >}}
 
-For more information about log configuration flags, read [Event logging][65] and [Platform metrics logging][66].
+The backend requires that the [`state-dir`][75] configuration option is set before starting.
+All other required flags have default values.
 
-### General configuration flags
+For more information about log configuration options, read [Event logging][65] and [Platform metrics logging][66].
 
-{{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
-{{% /notice %}}
+### General configuration
 
 | annotations|      |
 -------------|------
@@ -421,7 +421,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-backend start --annotations example-key="example value" --annotations example-key2="example value"
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
@@ -434,7 +434,7 @@ default      | `[::]:8080`
 environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
 command line example   | {{< code shell >}}
 sensu-backend start --api-listen-address [::]:8080{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
 
 <a id="api-request-limit"></a>
@@ -447,18 +447,20 @@ default      | `512000`
 environment variable | `SENSU_BACKEND_API_REQUEST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --api-request-limit 1024000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-request-limit: 1024000{{< /code >}}
 
 | api-url  |      |
 -------------|------
 description  | URL used to connect to the API.
 type         | String
-default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker)
+default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_API_URL`
 command line example   | {{< code shell >}}
 sensu-backend start --api-url http://localhost:8080{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-url: "http://localhost:8080"{{< /code >}}
 
 <a id="api-write-timeout"></a>
@@ -471,7 +473,7 @@ default      | `15s`
 environment variable | `SENSU_BACKEND_API_WRITE_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-backend start --api-write-timeout 15s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-write-timeout: 15s{{< /code >}}
 
 | assets-burst-limit   |      |
@@ -482,7 +484,7 @@ default       | `100`
 environment variable | `SENSU_BACKEND_ASSETS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --assets-burst-limit 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
 
 | assets-rate-limit   |      |
@@ -493,7 +495,7 @@ default       | `1.39`
 environment variable | `SENSU_BACKEND_ASSETS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --assets-rate-limit 1.39{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 | cache-dir   |      |
@@ -504,7 +506,7 @@ default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
 command line example   | {{< code shell >}}
 sensu-backend start --cache-dir /var/cache/sensu-backend{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 cache-dir: "/var/cache/sensu-backend"{{< /code >}}
 
 | config-file |      |
@@ -528,7 +530,7 @@ default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
 command line example   | {{< code shell >}}
 sensu-backend start --debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 debug: true{{< /code >}}
 
 <a id="deregistration-handler-attribute"></a>
@@ -541,7 +543,7 @@ default                  | `""`
 environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
 sensu-backend start --deregistration-handler deregister{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 deregistration-handler: "deregister"{{< /code >}}
 
 | labels     |      |
@@ -557,7 +559,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --labels security_zone=us-west-2a
 sensu-backend start --labels example_key1="example value" example_key2="example value"
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
   example_key1: "example value"
@@ -574,7 +576,7 @@ default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-backend start --log-level debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
 
 <a id="metrics-refresh-interval"></a>
@@ -589,8 +591,10 @@ default      | `1m`
 environment variable | `SENSU_BACKEND_METRICS_REFRESH_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --metrics-refresh-interval 10s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 metrics-refresh-interval: 10s{{< /code >}}
+
+<a id="state-dir-option"></a>
 
 | state-dir  |      |
 -------------|------
@@ -602,10 +606,10 @@ command line example   | {{< code shell >}}
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
 
-### Agent communication configuration flags
+### Agent communication configuration
 
 | agent-auth-cert-file |      |
 -------------|------
@@ -615,7 +619,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-cert-file: /path/to/tls/backend-1.pem{{< /code >}}
 
 | agent-auth-crl-urls |      |
@@ -626,7 +630,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-crl-urls: http://localhost/CARoot.crl{{< /code >}}
 
 | agent-auth-key-file |      |
@@ -637,7 +641,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-key-file: /path/to/tls/backend-1-key.pem{{< /code >}}
 
 | agent-auth-trusted-ca-file |      |
@@ -648,7 +652,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 
 <a id="agent-burst-limit"></a>
@@ -665,7 +669,7 @@ default       | `null`
 environment variable | `SENSU_BACKEND_AGENT_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-burst-limit 10{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-burst-limit: 10{{< /code >}}
 
 | agent-host   |      |
@@ -676,7 +680,7 @@ default        | `[::]`
 environment variable | `SENSU_BACKEND_AGENT_HOST`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-host 127.0.0.1{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-host: "127.0.0.1"{{< /code >}}
 
 | agent-port |      |
@@ -687,7 +691,7 @@ default      | `8081`
 environment variable | `SENSU_BACKEND_AGENT_PORT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-port 8081{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-port: 8081{{< /code >}}
 
 <a id="agent-rate-limit"></a>
@@ -702,10 +706,10 @@ default       | `null`
 environment variable | `SENSU_BACKEND_AGENT_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-rate-limit 10{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-rate-limit: 10{{< /code >}}
 
-### Security configuration flags
+### Security configuration
 
 | cert-file  |      |
 -------------|------
@@ -715,7 +719,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 | insecure-skip-tls-verify |      |
@@ -728,7 +732,7 @@ default                    | `false`
 environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
 command line example   | {{< code shell >}}
 sensu-backend start --insecure-skip-tls-verify{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 <a id="jwt-attributes"></a>
@@ -743,7 +747,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --jwt-private-key-file /path/to/key/private.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 jwt-private-key-file: /path/to/key/private.pem{{< /code >}}
 
 | jwt-public-key-file |      |
@@ -757,7 +761,7 @@ environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
 command line example   | {{< code shell >}}
 sensu-backend start --jwt-public-key-file /path/to/key/public.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
@@ -768,7 +772,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 <a id="fips-openssl"></a>
@@ -784,7 +788,7 @@ default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_FIPS`
 command line example   | {{< code shell >}}
 sensu-backend start --require-fips{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -798,7 +802,7 @@ default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_OPENSSL`
 command line example   | {{< code shell >}}
 sensu-backend start --require-openssl{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -809,20 +813,20 @@ default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 trusted-ca-file: "/path/to/tls/ca.pem"{{< /code >}}
 
-### Web UI configuration flags
+### Web UI configuration
 
 | dashboard-cert-file | |
 -------------|------
-description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` configuration option](#security-configuration) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-cert-file /path/to/tls/separate-webui-cert.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-cert-file: "/path/to/tls/separate-webui-cert.pem"{{< /code >}}
 
 | dashboard-host |      |
@@ -833,18 +837,18 @@ default          | `[::]`
 environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-host 127.0.0.1{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-host: "127.0.0.1"{{< /code >}}
 
 | dashboard-key-file | |
 -------------|------
-description  | Web UI TLS certificate key in PEM format. This key secures communication with the Sensu web UI. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` flag](#security-configuration-flags) for the web UI.
+description  | Web UI TLS certificate key in PEM format. This key secures communication with the Sensu web UI. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` configuration option](#security-configuration) for the web UI.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-key-file /path/to/tls/separate-webui-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-key-file: "/path/to/tls/separate-webui-key.pem"{{< /code >}}
 
 | dashboard-port |      |
@@ -855,7 +859,7 @@ default          | `3000`
 environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-port 3000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-port: 3000{{< /code >}}
 
 <a id="dashboard-write-timeout"></a>
@@ -868,14 +872,10 @@ default      | `15s`
 environment variable | `SENSU_BACKEND_DASHBOARD_WRITE_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-write-timeout 15s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-write-timeout: 15s{{< /code >}}
 
-### Datastore and cluster configuration flags
-
-{{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
-{{% /notice %}}
+### Datastore and cluster configuration
 
 | etcd-advertise-client-urls |      |
 --------------|------
@@ -884,13 +884,15 @@ description   | List of this member's client URLs to advertise to the rest of th
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
-default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
+default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-advertise-client-urls:
   - http://localhost:2378
   - http://localhost:2379
@@ -907,7 +909,7 @@ default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 <a id="etcd-cipher-suites"></a>
@@ -933,7 +935,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -950,7 +952,7 @@ default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-cert-auth{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-client-cert-auth: true{{< /code >}}
 
 <a id="etcd-client-log-level"></a>
@@ -965,7 +967,7 @@ default      | `error`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-log-level error{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-client-log-level: "error"{{< /code >}}
 
 | etcd-client-urls      |      |
@@ -981,11 +983,13 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-urls 'https://10.0.0.1:2379 https://10.1.0.1:2379'
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
+
+<a id="etcd-discovery"></a>
 
 | etcd-discovery        |      |
 ------------------------|------
@@ -998,10 +1002,12 @@ default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-discovery:
   - https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 {{< /code >}}
+
+<a id="etcd-discovery-srv"></a>
 
 | etcd-discovery-srv    |      |
 ------------------------|------
@@ -1014,7 +1020,7 @@ default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-discovery-srv example.org{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-discovery-srv:
   - example.org
 {{< /code >}}
@@ -1026,13 +1032,15 @@ description                        | List of this member's peer URLs to advertis
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
-default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
+default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-advertise-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
@@ -1045,11 +1053,13 @@ description            | Initial cluster configuration for bootstrapping.{{% not
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
-default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
+default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380"{{< /code >}}
 
 | etcd-initial-cluster-state |      |
@@ -1063,7 +1073,7 @@ default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster-state existing{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
@@ -1077,7 +1087,7 @@ default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 | etcd-key-file  |      |
@@ -1090,7 +1100,7 @@ type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 <a id="etcd-listen-client-urls"></a>
@@ -1108,7 +1118,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-listen-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
@@ -1127,7 +1137,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-listen-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
@@ -1143,7 +1153,7 @@ default      | [Backend log level][60] value (or `debug`, if the backend log lev
 environment variable | `SENSU_BACKEND_ETCD_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-log-level debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-log-level: "debug"{{< /code >}}
 
 | etcd-name      |      |
@@ -1157,7 +1167,7 @@ default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-name backend-0{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
@@ -1170,7 +1180,7 @@ type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 | etcd-peer-client-cert-auth |      |
@@ -1184,7 +1194,7 @@ default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-client-cert-auth{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-client-cert-auth: true{{< /code >}}
 
 | etcd-peer-key-file |      |
@@ -1197,7 +1207,7 @@ type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 | etcd-peer-trusted-ca-file |      |
@@ -1210,7 +1220,7 @@ type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | etcd-trusted-ca-file |      |
@@ -1224,7 +1234,7 @@ default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-trusted-ca-file ./ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | no-embed-etcd  |      |
@@ -1238,7 +1248,7 @@ default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
 command line example   | {{< code shell >}}
 sensu-backend start --no-embed-etcd{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 no-embed-etcd: true{{< /code >}}
 
 ### Advanced configuration options
@@ -1258,7 +1268,7 @@ default                | `1000`
 environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-election-timeout 1000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-election-timeout: 1000{{< /code >}}
 
 <a id="etcd-heartbeat-interval"></a>
@@ -1275,7 +1285,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-heartbeat-interval 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-heartbeat-interval: 100{{< /code >}}
 
 | etcd-max-request-bytes |      |
@@ -1290,7 +1300,7 @@ default                | `1572864`
 environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-max-request-bytes 1572864{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-max-request-bytes: 1572864{{< /code >}}
 
 | etcd-quota-backend-bytes |      |
@@ -1305,7 +1315,7 @@ default                | `4294967296`
 environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-quota-backend-bytes 4294967296{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-quota-backend-bytes: 4294967296{{< /code >}}
 
 | eventd-buffer-size   |      |
@@ -1318,7 +1328,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --eventd-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 eventd-buffer-size: 100{{< /code >}}
 
 | eventd-workers       |      |
@@ -1331,7 +1341,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --eventd-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 eventd-workers: 100{{< /code >}}
 
 | keepalived-buffer-size |      |
@@ -1344,7 +1354,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --keepalived-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 keepalived-buffer-size: 100{{< /code >}}
 
 | keepalived-workers |      |
@@ -1356,7 +1366,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --keepalived-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 keepalived-workers: 100{{< /code >}}
 
 | pipelined-buffer-size |      |
@@ -1369,7 +1379,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --pipelined-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 pipelined-buffer-size: 100{{< /code >}}
 
 | pipelined-workers |      |
@@ -1382,12 +1392,38 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --pipelined-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 pipelined-workers: 100{{< /code >}}
 
-## Configuration via environment variables
+## Backend configuration methods
 
-Instead of using configuration flags, you can use environment variables to configure your Sensu backend.
+### Backend configuration file
+
+You can customize the backend configuration in a `.yml` configuration file.
+
+To use the `backend.yml` file to configure the backend, list the desired configuration attributes and values.
+Review the [example Sensu backend configuration file][17] for a complete example.
+
+Configuration via command line flags or environment variables overrides any configuration specified in the backend configuration file.
+Read [Create overrides][74] to learn more.
+
+### Command line flags
+
+You can customize the backend configuration with `sensu-agent start` command line flags.
+
+To use command line flags, specify the desired configuration flags and values along with the `sensu-backend start` command.
+For example:
+
+{{< code shell >}}
+sensu-backend start --deregistration-handler slack_deregister --log-level debug
+{{< /code >}}
+
+Configuration via command line flags overrides attributes specified in a configuration file or with environment variables.
+Read [Create overrides][74] to learn more.
+
+### Environment variables
+
+Instead of using a configuration file or command line flags, you can use environment variables to configure your Sensu backend.
 Each backend configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
@@ -1447,7 +1483,7 @@ sudo systemctl restart sensu-backend
 
 {{% notice note %}}
 **NOTE**: Sensu includes an environment variable for each backend configuration flag.
-They are listed in the [configuration flag description tables](#general-configuration-flags).
+They are listed in the [configuration description tables](#general-configuration).
 {{% /notice %}}
 
 ### Format for label and annotation environment variables
@@ -1525,12 +1561,12 @@ spec:
 Read the [secrets reference](https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/) and [Use Env for secrets management](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management) for details.
 {{% /notice %}}
 
-## Create overrides
+## Create configuration overrides
 
 Sensu has default settings and limits for certain configuration attributes, like the default log level.
 Depending on your environment and preferences, you may want to create overrides for these Sensu-specific defaults and limits.
 
-You can create overrides in several ways:
+You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-backend start`.
 - Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
@@ -1590,7 +1626,7 @@ The event logging functionality provides better performance and reliability than
 To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
 {{% /notice %}}
 
-Use these backend configuration flags to customize event logging:
+Use these backend configuration options to customize event logging:
 
 | event-log-buffer-size |      |
 -----------------------|------
@@ -1600,7 +1636,7 @@ default                | 100000
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-buffer-size 100000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-buffer-size: 100000{{< /code >}}
 
 | event-log-buffer-wait |      |
@@ -1611,7 +1647,7 @@ default                | 10ms
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_WAIT`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-buffer-wait 10ms{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-buffer-wait: 10ms{{< /code >}}
 
 <a id="event-log-file"></a>
@@ -1625,7 +1661,7 @@ type                   | String
 environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-file /var/log/sensu/events.log{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-file: "/var/log/sensu/events.log"{{< /code >}}
 
 <a id="event-log-parallel-encoders"></a>
@@ -1638,7 +1674,7 @@ default                | false
 environment variable   | `SENSU_BACKEND_EVENT_LOG_PARALLEL_ENCODERS`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-parallel-encoders true{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-parallel-encoders: true{{< /code >}}
 
 ### Log rotation
@@ -1696,7 +1732,7 @@ Sensu appends updated metrics at the interval you specify with the platform-metr
 
 To rotate the platform metrics log, use the same methods as for [event log rotation][63].
 
-Use these backend configuration flags to customize platform metrics logging:
+Use these backend configuration options to customize platform metrics logging:
 
 | disable-platform-metrics |      |
 -----------------------|------
@@ -1706,7 +1742,7 @@ default                | false
 environment variable   | `SENSU_BACKEND_DISABLE_PLATFORM_METRICS`
 command line example   | {{< code shell >}}
 sensu-backend start --disable-platform-metrics false{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 disable-platform-metrics: false{{< /code >}}
 
 | platform-metrics-log-file |      |
@@ -1719,7 +1755,7 @@ default                | /var/log/sensu/sensu-backend/stats.log
 environment variable   | `SENSU_BACKEND_PLATFORM_METRICS_LOG_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --platform-metrics-log-file /var/log/sensu/sensu-backend/stats.log{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 platform-metrics-log-file: "/var/log/sensu/sensu-backend/stats.log"{{< /code >}}
 
 | platform-metrics-logging-interval |      |
@@ -1730,7 +1766,7 @@ default                | 60s
 environment variable   | `SENSU_BACKEND_PLATFORM_METRICS_LOGGING_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --platform-metrics-logging-interval 60s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 platform-metrics-logging-interval: 60s{{< /code >}}
 
 ## Service management
@@ -1843,10 +1879,10 @@ sensu-backend start --help
 [9]: ../../observe-filter/filters/
 [10]: ../../observe-transform/mutators/
 [11]: ../../observe-process/handlers/
-[12]: #datastore-and-cluster-configuration-flags
+[12]: #datastore-and-cluster-configuration
 [13]: ../../../operations/deploy-sensu/cluster-sensu/
 [14]: ../../../api/
-[15]: #general-configuration-flags
+[15]: #general-configuration
 [16]: https://etcd.io/docs/current/tuning/#time-parameters
 [17]: ../../../files/backend.yml
 [18]: https://golang.org/pkg/crypto/tls/#pkg-constants
@@ -1881,5 +1917,11 @@ sensu-backend start --help
 [67]: #agent-rate-limit
 [70]: ../../observe-process/pipelines/
 [71]: ../../../guides/
-[72]: #datastore-and-cluster-configuration-flags
+[72]: #datastore-and-cluster-configuration
 [73]: #advanced-configuration-options
+[74]: #create-configuration-overrides
+[75]: #state-dir-option
+[76]: #backend-configuration-file
+[77]: #backend-configuration-options
+[78]: #environment-variables
+[79]: #backend-configuration-methods

--- a/content/sensu-go/6.6/operations/control-access/rbac.md
+++ b/content/sensu-go/6.6/operations/control-access/rbac.md
@@ -169,7 +169,7 @@ By default, the `agent` user belongs to the `system:agent` group.
 The `system:agent` cluster role binding grants the `system:agent` cluster role to the members of this group.
 To grant agent users the permissions they need to report events into any namespace, add agent users to the `system:agent` group.
 
-Configure the `agent` user's credentials with the [`user` and `password` agent configuration flags][41].
+Configure the `agent` user's credentials with the [`user`][41] and [`password`][68] agent configuration options.
 
 ### View users
 
@@ -3280,7 +3280,7 @@ type: Group
 [38]: ../../../observability-pipeline/observe-schedule/rule-templates/
 [39]: ../ad-auth/#ad-groups-prefix
 [40]: ../../deploy-sensu/etcdreplicators/
-[41]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
+[41]: ../../../observability-pipeline/observe-schedule/agent/#agent-password-option
 [42]: ../../deploy-sensu/install-sensu/#install-the-sensu-backend
 [43]: ../../../observability-pipeline/observe-process/sumo-logic-metrics-handlers/
 [44]: ../../../observability-pipeline/observe-process/tcp-stream-handlers/
@@ -3307,3 +3307,4 @@ type: Group
 [65]: #spec-attributes-for-role-binding-and-cluster-role-binding-resources
 [66]: #role_ref-attributes
 [67]: #subjects-attributes
+[68]: ../../../observability-pipeline/observe-schedule/agent/#agent-user-option

--- a/content/sensu-go/6.6/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/deployment-architecture.md
@@ -158,7 +158,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 
 [1]: ../hardware-requirements/#backend-recommended-configuration
 [2]: ../../../api/
-[3]: ../../../observability-pipeline/observe-schedule/agent/#general-configuration-flags
 [4]: https://etcd.io/docs/
 [5]: https://etcd.io/docs/current/op-guide/security/
 [6]: ../secure-sensu/

--- a/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
@@ -560,7 +560,7 @@ sensuctl license info
 [4]: ../../../sensuctl/
 [5]: ../../../platforms/
 [6]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
-[7]: ../../../observability-pipeline/observe-schedule/agent#configuration-via-flags
+[7]: ../../../observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [8]: ../secure-sensu/
 [9]: ../../../observability-pipeline/observe-schedule/monitor-server-resources/
 [10]: ../../../observability-pipeline/observe-process/send-slack-alerts/

--- a/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
@@ -76,7 +76,7 @@ etcd-peer-client-cert-auth: "true"
    Because etcd does not require authentication by default, you must set the `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` parameters to `true` to secure Sensu's embedded etcd datastore against unauthorized access.
 
 {{% notice note %}}
-**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags) includes more information about each etcd store parameter.
+**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration) includes more information about each etcd store parameter.
 {{% /notice %}}
 
 ## Secure the Sensu agent API, HTTP API, and web UI
@@ -118,7 +118,7 @@ After you restart the `sensu-backend` service, the parameters will load and you 
 Configuring these attributes will also ensure that agents can communicate securely.
 
 {{% notice note %}}
-**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#security-configuration-flags) includes more information about each API and web UI security configuration parameter.
+**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#security-configuration) includes more information about each API and web UI security configuration parameter.
 {{% /notice %}}
 
 ### Specify a separate web UI certificate and key
@@ -135,7 +135,7 @@ dashboard-key-file: "/etc/sensu/tls/separate-webui-key.pem"
 
 {{% notice note %}}
 **NOTE**: If you do not specify a separate certificate and key for the web UI with `dashboard-cert-file` and `dashboard-key-file`, Sensu uses the certificate and key specified for the `cert-file` and `key-file` parameters for the web UI.
-The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#web-ui-configuration-flags) includes more information about the `dashboard-cert-file` and `dashboard-key-file` web UI configuration parameters.
+The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#web-ui-configuration) includes more information about the `dashboard-cert-file` and `dashboard-key-file` web UI configuration parameters.
 {{% /notice %}}
 
 ## Secure Sensu agent-to-server communication
@@ -262,7 +262,6 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [3]: ../../control-access/rbac/
 [4]: ../generate-certificates/#create-a-certificate-authority-ca
 [6]: https://etcd.io/docs/latest/op-guide/security/
-[7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/
 [12]: ../generate-certificates/

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -233,7 +233,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 Read the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml`).
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml` or `C:\ProgramData\sensu\config\agent.yml.example`).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
@@ -582,7 +582,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [53]: ../../deploy-sensu/install-sensu#install-sensuctl
 [54]: ../../control-access/rbac/#resources
 [55]: ../../deploy-sensu/install-sensu#install-sensu-agents
-[56]: ../../../observability-pipeline/observe-schedule/agent#configuration-via-flags
+[56]: ../../../observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [57]: ../../../observability-pipeline/observe-schedule/collect-metrics-with-checks/
 [58]: ../../../observability-pipeline/observe-schedule/checks#metadata-attributes
 [59]: https://bonsai.sensu.io/assets?q=eventfilter

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -241,7 +241,7 @@ api-port: 3031
 socket-port: 3030
 {{< /code >}}
 
-You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
+You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` configuration options.
 
 Sensu should now be installed and functional.
 The next step is to translate your Sensu Core configuration to Sensu Go.

--- a/content/sensu-go/6.6/operations/maintain-sensu/tune.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/tune.md
@@ -21,14 +21,14 @@ These pages describe common problems and solutions, planning and optimization co
 
 If you use embedded etcd for storage, you might notice high network or storage latency.
 
-To make etcd more latency-tolerant, increase the values for the [etcd election timeout][1] and [etcd heartbeat interval][2] backend configuration flags.
+To make etcd more latency-tolerant, increase the values for the [`etcd election timeout`][1] and [`etcd heartbeat interval`][2] backend configuration options.
 For example, you might increase `etcd-election-timeout` from 1000 to 5000 and `etcd-heartbeat-interval` from 100 to 500.
 
 Read the [etcd tuning documentation][3] for etcd-specific tuning best practices.
 
 ## Advanced backend configuration options for etcd
 
-The [backend reference][11] describes other advanced configuration flags in addition to etcd election timeout and heartbeat interval.
+The [backend reference][11] describes other advanced configuration options in addition to etcd election timeout and heartbeat interval.
 
 Adjust these values with caution.
 Improper adjustment can increase memory and CPU usage or result in a non-functioning Sensu instance.
@@ -50,16 +50,16 @@ Read the [PostgreSQL parameters documentation][5] for information about setting 
 ## Agent reconnection rate
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-rate-limit backend configuration flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-rate-limit` backend configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 It may take several minutes for all agents to reconnect after a sensu-backend restart, especially if you have a large number of agents.
 The agent reconnection rate depends on deployment variables like the number of CPUs, disk space, network speeds, whether you're using a load balancer, and even physical distance between agents and backends.
 
 Although many variables affect the agent reconnection rate, a reasonable estimate is approximately 100 agents per backend per second.
-If you observe slower agent reconnection rates in your Sensu deployment, consider using the [agent-rate-limit][14] backend configuration flag.
+If you observe slower agent reconnection rates in your Sensu deployment, consider using If you observe slower agent reconnection rates in your Sensu deployment, consider using the [`agent-rate-limit`][14] backend configuration option.
 
-The [agent-rate-limit][14] backend configuration flag allows you to set the maximum number of agent transport WebSocket connections per second, per backend.
+The [`agent-rate-limit`][14] backend configuration option allows you to set the maximum number of agent transport WebSocket connections per second, per backend.
 Set the agent-rate-limit to 100 to improve agent reconnection rate and reduce the time required for all of your agents to reconnect after a backend restart.
 
 ## Splay and proxy check scheduling

--- a/content/sensu-go/6.6/platforms.md
+++ b/content/sensu-go/6.6/platforms.md
@@ -175,7 +175,7 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.6.6/sensu-go_6.6
 
 Builds that support the Federal Information Processing Standard (FIPS) for Federal Risk and Authorization Management Program (FedRAMP) compliance are available for Linux `amd64`.
 
-Sensu FIPS builds with [FIPS-mode configuration flags][51] are linked with the FIPS 140-2 validated cryptographic library.
+Sensu FIPS builds with [FIPS-mode configuration options][51] are linked with the FIPS 140-2 validated cryptographic library.
 You can run Red Hat Enterprise Linux (RHEL) with the FIPS-mode kernel option to enforce FIPS systemwide &mdash; Sensu FIPS builds comply with this mode.
 
 [Contact Sensu][50] to request builds with FIPS support.

--- a/content/sensu-go/6.6/plugins/assets.md
+++ b/content/sensu-go/6.6/plugins/assets.md
@@ -293,14 +293,14 @@ When Sensu finds a matching build, it downloads the build artifact from the spec
 If the asset definition includes headers, they are passed along as part of the HTTP request.
 If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
 
-Set the backend or agent's local cache path with the `--cache-dir` flag.
-Disable dynamic runtime assets for an agent with the agent `--disable-assets` [configuration flag][30].
+Set the backend or agent's local cache path with the `cache-dir` configuration option.
+Disable dynamic runtime assets for an agent with the agent [`disable-assets`][30] configuration option.
 
 {{% notice note %}}
-**NOTE**: Dynamic runtime asset builds are unpacked into the cache directory that is configured with the `--cache-dir` flag.
+**NOTE**: Dynamic runtime asset builds are unpacked into the cache directory that is configured with the `cache-dir` configuration option.
 {{% /notice %}}
 
-Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][40] and [backend][41] to configure a global rate limit for fetching dynamic runtime assets.
+Use the `assets-rate-limit` and `assets-burst-limit` configuration options for the [agent][40] and [backend][41] to configure a global rate limit for fetching dynamic runtime assets.
 
 ### Dynamic runtime asset build execution
 

--- a/content/sensu-go/6.6/plugins/assets.md
+++ b/content/sensu-go/6.6/plugins/assets.md
@@ -1306,7 +1306,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 [37]: https://bonsai.sensu.io/sign-in
 [38]: https://bonsai.sensu.io/new
 [39]: ../../web-ui/search#search-for-labels
-[40]: ../../observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[40]: ../../observability-pipeline/observe-schedule/agent/#assets-burst-limit
 [41]: ../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
 [42]: #filters-attribute
 [43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime

--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -237,7 +237,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.6.0.
 - ([Commercial feature][259]) The web UI now supports ANSI color codes, which improves check output readability when it includes color.
 - ([Commercial feature][259]) Added support for sorting for the PostgreSQL event store. In addition, GraphQL can now use the PostgreSQL event store to sort events and get the total event count.
 - Logged metrics now include a backend label. This makes it possible to associate metrics from the [metrics log][258] file with the backend they were generated on.
-- Sensu no longer applies zero values for [etcd configuration flags][260]. This prevents overwriting the etcd-provided default values with null, zero, slice, or empty values.
+- Sensu no longer applies zero values for [etcd configuration options][260]. This prevents overwriting the etcd-provided default values with null, zero, slice, or empty values.
 
 **FIXES**
 - When sensu-go cannot connect to etcd, the connection error is now logged along with context errors.
@@ -615,7 +615,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.1.
 - ([Commercial feature][193]) In the web UI, fixed a bug that allowed users to edit Sensu [agent-managed entities][204].
 - Fixed a bug that generated a small amount of extra etcd or PostgreSQL traffic upon keepalive failure.
 - In silenced entries, the `expire` field now represents the configured number of seconds until the entry should be deleted rather than the entry's remaining duration.
-- Labels and annotations can now be configured with [flags][205] for sensu-agent.
+- Labels and annotations are now [configuration options][205] for sensu-agent.
 
 ## 6.2.0 release notes
 
@@ -968,7 +968,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration flags][142] to populate the `processes` field in entity.system if enabled.
+- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
 - ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
@@ -1033,7 +1033,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
-- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][136] and [backend][137].
+- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-burst-limit` and `--assets-rate-limit` flags for the [agent][136] and [backend][137].
 - Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
@@ -1267,7 +1267,7 @@ Users will need to [run 'sensu-backend init'][102] on every new installation and
 - Added a new flag,`--etcd-client-urls`, which should be used with sensu-backend when it is not operating as an etcd member.
 The flag is also used by the new `sensu-backend init` subcommand.
 - Added the ['sensu-backend init' subcommand][102].
-- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][100] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
+- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][292] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
 - Added [`--keepalive-critical-timeout`][101] to define the time after which a critical keepalive event should be created for an agent and [`--keepalive-warning-timeout`][101], which is an alias of `--keepalive-timeout` for backward compatibility.
 
 **IMPROVEMENTS:**
@@ -2072,7 +2072,7 @@ To get started with Sensu Go:
 [26]: /sensu-go/5.4/observability-pipeline/observe-schedule/agent/#events-post
 [27]: /sensu-go/5.5/operations/monitor-sensu/tessen/
 [28]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service/
-[29]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[29]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#general-configuration
 [30]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets
 [31]: /sensu-go/5.4/api/other/metrics/
 [32]: /sensu-go/5.6/web-ui/
@@ -2083,7 +2083,7 @@ To get started with Sensu Go:
 [37]: /sensu-go/5.6/operations/control-access/
 [38]: /sensu-go/5.6/operations/control-access/ldap-auth/#ldap-binding-attributes
 [39]: /sensu-go/5.6/operations/control-access/ad-auth/#ad-binding-attributes
-[40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration
 [41]: /sensu-go/5.7/operations/deploy-sensu/install-sensu/#install-sensu-agents
 [42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/
 [43]: /sensu-go/5.7/api/#response-filtering
@@ -2143,8 +2143,8 @@ To get started with Sensu Go:
 [97]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler/
 [98]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler/
 [99]: /sensu-go/5.2/commercial/
-[100]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags
-[101]: /sensu-go/5.16/observability-pipeline/observe-schedule/agent/#keepalive-configuration-flags
+[100]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery
+[101]: /sensu-go/5.16/observability-pipeline/observe-schedule/agent/#keepalive-configuration
 [102]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#initialization
 [103]: /sensu-go/5.16/web-ui/
 [104]: /sensu-go/5.16/
@@ -2177,13 +2177,13 @@ To get started with Sensu Go:
 [133]: /sensu-go/5.19/platforms/
 [134]: /sensu-go/5.19/operations/deploy-sensu/install-sensu/
 [135]: /sensu-go/5.19/web-ui/
-[136]: /sensu-go/5.19/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[136]: /sensu-go/5.19/observability-pipeline/observe-schedule/agent/#assets-burst-limit
 [137]: /sensu-go/5.19/observability-pipeline/observe-schedule/backend/#configuration-via-flags
 [138]: /sensu-go/5.20/api#field-selector
 [139]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#log-rotation
 [140]: /sensu-go/5.20/operations/maintain-sensu/troubleshoot/#increment-log-level-verbosity
 [141]: /sensu-go/5.20/commercial/
-[142]: /sensu-go/5.20/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[142]: /sensu-go/5.20/observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [143]: /sensu-go/5.20/observability-pipeline/observe-entities/entities/#processes-attributes
 [144]: /sensu-go/5.20/sensuctl/create-manage-resources/#supported-resource-types
 [145]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#configuration-summary
@@ -2244,7 +2244,7 @@ To get started with Sensu Go:
 [202]: /sensu-go/6.2/sensuctl/#first-time-setup-and-authentication
 [203]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#agent-managed-entity
 [204]: /sensu-go/6.2/observability-pipeline/observe-entities/entities/#manage-agent-entities-via-the-agent
-[205]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[205]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [206]: /sensu-go/5.21/observability-pipeline/observe-schedule/backend/#log-rotation
 [207]: /sensu-go/6.3/commercial/
 [208]: /sensu-go/6.3/observability-pipeline/observe-schedule/backend/#agent-burst-limit
@@ -2268,6 +2268,7 @@ To get started with Sensu Go:
 [226]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-log-parallel-encoders
 [227]: /sensu-go/6.4/api/other/metrics/
 [228]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-logging
+[229]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery-srv
 [229]: /sensu-go/6.5/commercial/
 [230]: /sensu-go/6.5/observability-pipeline/observe-process/sumo-logic-metrics-handlers/
 [231]: /sensu-go/6.5/observability-pipeline/observe-process/tcp-stream-handlers/
@@ -2298,7 +2299,7 @@ To get started with Sensu Go:
 [257]: /sensu-go/6.5/observability-pipeline/observe-schedule/backend/#dashboard-write-timeout
 [258]: /sensu-go/6.6/observability-pipeline/observe-schedule/backend/#platform-metrics-logging
 [259]: /sensu-go/6.6/commercial/
-[260]: /sensu-go/6.6/observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags
+[260]: /sensu-go/6.6/observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration
 [261]: /sensu-go/6.6/web-ui/view-manage-resources/#manage-entities
 [262]: /sensu-go/6.6/observability-pipeline/observe-schedule/backend/#etcd-client-log-level
 [263]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
@@ -2306,3 +2307,4 @@ To get started with Sensu Go:
 [265]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
 [266]: /sensu-go/6.6/web-ui/search/#events-and-entities-search-limits
 [267]: /sensu-go/latest/operations/deploy-sensu/datastore/#strict-attribute
+[292]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery-srv

--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -168,7 +168,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.6.4.
 
 **December 16, 2021** &mdash; The latest release of Sensu Go, version 6.6.3, is now available for download.
 
-Sensu Go 6.6.3 includes improvements to reduce load on clusters and support cluster recovery, as well as a backend configuration flag for specifying the internal etcd client log level. Fixes in this patch release will help prevent backend crashes when keepalive leases are revoked and when the backend cannot write to the event log file. In addition, this patch fixes issues that could result in a leaked etcd lease and keep the backend from terminating correctly.
+Sensu Go 6.6.3 includes improvements to reduce load on clusters and support cluster recovery, as well as a backend configuration option for specifying the internal etcd client log level. Fixes in this patch release will help prevent backend crashes when keepalive leases are revoked and when the backend cannot write to the event log file. In addition, this patch fixes issues that could result in a leaked etcd lease and keep the backend from terminating correctly.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.6.3.
 
@@ -176,9 +176,9 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.6.3.
 
 - ([Commercial feature][259]) In the web UI, the default polling interval on the [entities page][261] is now 30 seconds to help reduce load on clusters. Search results for entities are limited to the first 500 matching entities. Also, the web UI response time and memory usage is substantially improved when opening the entities page in the default state (loading the first page of results, with no search filter applied).
 - ([Commercial feature][259]) In the web UI, for instances that use etcd for event storage, search results for events are limited to 25,000 matching events.
-- Added the [etcd-client-log-level][262] configuration flag for setting the log level of the etcd client used internally within sensu-backend.
+- Added the [`etcd-client-log-level`][262] configuration option for setting the log level of the etcd client used internally within sensu-backend.
 - The agentd daemon now starts up after all other daemons, which improves cluster recovery after the loss of a backend.
-- When using external etcd (the no-embed-etcd backend configuration flag is set to `true`), sensu-backend now crashes when its daemons do not stop within 30 seconds, which can happen due to an intentional shutdown or when database unavailability triggers an internal restart.
+- When using external etcd (the `no-embed-etcd` backend configuration option is set to `true`), sensu-backend now crashes when its daemons do not stop within 30 seconds, which can happen due to an intentional shutdown or when database unavailability triggers an internal restart.
 When using embedded etcd, sensu-backend will still try to avoid crashing to prevent member corruption.
 
 **FIXES**
@@ -247,13 +247,13 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.6.0.
 
 **November 22, 2021** &mdash; The latest release of Sensu Go, version 6.5.5, is now available for download.
 
-The Sensu Go 6.5.5 patch release adds two backend configuration flags for configuring the API and web UI HTTP servers' write timeouts and three new GraphQL duration metrics for the metrics log. This release also delivers several bug fixes, including fixes for sensu-backend and sensu-agent panics and failed keepalive lease grant operations.
+The Sensu Go 6.5.5 patch release adds two backend configuration options for configuring the API and web UI HTTP servers' write timeouts and three new GraphQL duration metrics for the metrics log. This release also delivers several bug fixes, including fixes for sensu-backend and sensu-agent panics and failed keepalive lease grant operations.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.5.5.
 
 **IMPROVEMENTS**
-- Added the [api-write-timeout][256] and [dashboard-write-timeout][257] backend configuration flags.
-These flags allow you to configure the timeout for the respective HTTP servers' response writes, which is helpful when requests might take more than a few seconds to complete.
+- Added the [api-write-timeout][256] and [dashboard-write-timeout][257] backend configuration options.
+These options allow you to configure the timeout for the respective HTTP servers' response writes, which is helpful when requests might take more than a few seconds to complete.
 - Added graphql_duration_seconds, graphql_duration_seconds_sum, and graphql_duration_seconds_count to the [metrics log][238]. Also added objectives (0.5, 0.9, 0.99) to the graphql_duration_seconds metric.
 - Added Prometheus metrics for tracking lease operations, with labels for operation type and status, and added sensu_go_lease_ops to the [metrics log][238].
 
@@ -372,16 +372,16 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.5.0.
 - New [pipelines][233] resource allows you to specify event filters, mutators, and handlers in a single workflow instead of listing filters and mutators in handler definitions. You can reference pipelines in your check definitions. The [`/pipelines` API endpoint][234] provides HTTP access for retrieving pipeline data and configuring pipelines, and you can use [sensuctl][235] to manage pipelines. [Upgrade your Sensu agents][1] to Sensu Go 6.5.0 to use pipelines resources.
 - [JavaScript mutators][246] are now available. JavaScript mutators are evaluated by the Otto JavaScript VM as JavaScript programs, which enables greater throughput at scale than pipe mutators.
 - Check definitions now include the [pipelines attribute][236] for specifying pipeline resources to use for the check's observability events.
-- Added [platform metrics logging][238] to log core Sensu metrics in InfluxDB Line Protocol format, along with the `disable-platform-metrics`, `platform-metrics-log-file`, and `platform-metrics-logging-interval` backend configuration flags for managing the platform metrics logging feature.
+- Added [platform metrics logging][238] to log core Sensu metrics in InfluxDB Line Protocol format, along with the `disable-platform-metrics`, `platform-metrics-log-file`, and `platform-metrics-logging-interval` backend configuration options for managing the platform metrics logging feature.
 - [Event logging][237] is no longer a commercial-only feature.
 - You can now set sensuctl environment variables for a [single sensuctl command][243] or with [sensuctl configure][244].
 
 **IMPROVEMENTS:**
 
-- Added environment variables `SENSU_BACKEND_ETCD_CLIENT_USERNAME` and `SENSU_BACKEND_ETCD_CLIENT_PASSWORD` for [connecting to external etcd via username and password authentication][245] instead of certificate authentication. There are no corresponding configuration flags &mdash; these configuration options must be set via environment variables.
+- Added environment variables `SENSU_BACKEND_ETCD_CLIENT_USERNAME` and `SENSU_BACKEND_ETCD_CLIENT_PASSWORD` for [connecting to external etcd via username and password authentication][245] instead of certificate authentication. There are no corresponding command line flags &mdash; these configuration options must be set via environment variables.
 - You can now add an [API key][248] when you initialize the backend to make automated cluster setup and deployment more straightforward.
 - Events now include the name of the agent that processed the event in the [`processed_by` attribute][251] to help you determine which agent processed an event executed by a proxy check request or a POST request to the events API.
-- Added the [`ignore-already-initialized` backend flag][253], which you can use to suppress the "already initialized" response and return an exit code 0 if a cluster has already been initialized.
+- Added the [`ignore-already-initialized`][253] backend configuration option, which you can use to suppress the "already initialized" response and return an exit code 0 if a cluster has already been initialized.
 - Upgraded Go version from 1.16.5 to 1.17.1.
 
 **SECURITY:**
@@ -495,7 +495,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.3.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][207]) Added [business service monitoring (BSM)][210] to provide high-level visibility into the current health of any number of business services, with a [built-in aggregate check rule template][211].
-- ([Commercial feature][207]) Added support for agent transport rate limiting via [`agent-burst-limit`][208] and [`agent-rate-limit`][209] backend configuration flags.
+- ([Commercial feature][207]) Added support for agent transport rate limiting via [`agent-burst-limit`][208] and [`agent-rate-limit`][209] backend configuration options.
 - ([Commercial feature][207]) Added the `event-log-buffer-wait` backend configuration flag, which allows you to specify how long the event logger will wait for the writer to consume events from the buffer when the buffer is full.
 - Added the entity class [service][213], which represents a business service for the business service monitoring (BSM) feature.
 
@@ -738,7 +738,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.1.0.
 - ([Commercial feature][172]) Added the [Sensu SaltStack Enterprise Handler][183] for launching
 SaltStack Enterprise Jobs for automated remediation.
 - ([Commercial feature][172]) The Alpine-based Docker image now has multi-architecture support with support for the linux/386, linux/amd64, linux/arm64, linux/arm/v6, linux/arm/v7, linux/ppc64le, and linux/s390x platforms.
-- The backend flag [`--api-request-limit`][173] is now available to configure the maximum API request body size (in bytes).
+- The backend configuration option [`api-request-limit`][173] is now available to configure the maximum API request body size (in bytes).
 - In the [REST API][174], most configuration resources now support the PATCH method for making updates.
 - Added new handler and check plugins: [Sensu Go Elasticsearch Handler][184], [Sensu Rundeck Handler][185], and [Sensu Kubernetes Events Check][186].
 
@@ -907,7 +907,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.21.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][158]) Added [entity count and limit][156] for each entity class in the tabular title in the response for `sensuctl license info` (in addition to the total entity count and limit).
-- ([Commercial feature][158]) Added Linux amd64 OpenSSL-linked binaries for the Sensu agent and backend, with accompanying `--require-fips` and `--require-openssl` flags for the [agent][161] and [backend][160].
+- ([Commercial feature][158]) Added Linux amd64 OpenSSL-linked binaries for the Sensu agent and backend, with accompanying `require-fips` and `require-openssl` configuration options for the [agent][161] and [backend][160].
 - Added `sensuctl user hash-password` command to generate password hashes.
 - Added the ability to reset passwords via the backend API and `sensuctl user reset-password`.
 
@@ -968,9 +968,9 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
+- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` option to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
-- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
+- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration option for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
 - ([Commercial feature][141]) Added a PostgreSQL metrics suite so metricsd can collect metrics about events stored in PostgreSQL.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
@@ -1033,7 +1033,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
-- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-burst-limit` and `--assets-rate-limit` flags for the [agent][136] and [backend][137].
+- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `assets-burst-limit` and `assets-rate-limit` configuration options for the [agent][136] and [backend][137].
 - Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
@@ -1203,7 +1203,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][106]) Added [HTTP API for secrets management][108], with Sensu's `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
-- Added the `keepalive-handlers` agent configuration flag to specify the keepalive handlers to use for an entity's events.
+- Added the `keepalive-handlers` agent configuration option to specify the keepalive handlers to use for an entity's events.
 
 **IMPROVEMENTS:**
 
@@ -1247,7 +1247,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.16.1.
 **December 16, 2019** &mdash; The latest release of Sensu Go, version 5.16.0, is now available for download.
 This is another important release, with many new features, improvements, and fixes.
 We introduced an initialization subcommand for **new** installations that allows you to specify an admin username and password instead of using a pre-defined default.
-We also added new backend flags to help you take advantage of etcd auto-discovery features and agent flags you can use to define a timeout period for critical and warning keepalive events.
+We also added new backend configuration options to help you take advantage of etcd auto-discovery features and agent configuration options you can use to define a timeout period for critical and warning keepalive events.
 
 New web UI features include a switcher that makes it easier to switch between namespaces in the dashboard, breadcrumbs on every page, OIDC authentication in the dashboard, a drawer that replaces the app bar to make more room for content, and more.
 
@@ -1264,11 +1264,11 @@ Users will need to [run 'sensu-backend init'][102] on every new installation and
 
 - ([Commercial feature][105]) Users can now authenticate with OIDC in the dashboard.
 - ([Commercial feature][105]) Label selectors now match the event's check and entity labels.
-- Added a new flag,`--etcd-client-urls`, which should be used with sensu-backend when it is not operating as an etcd member.
-The flag is also used by the new `sensu-backend init` subcommand.
+- Added a new configuration option, `etcd-client-urls`, to use with sensu-backend when it is not operating as an etcd member.
+The configuration option is also used by the new `sensu-backend init` subcommand.
 - Added the ['sensu-backend init' subcommand][102].
-- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][292] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
-- Added [`--keepalive-critical-timeout`][101] to define the time after which a critical keepalive event should be created for an agent and [`--keepalive-warning-timeout`][101], which is an alias of `--keepalive-timeout` for backward compatibility.
+- Added the [`etcd-discovery`][100] and [`etcd-discovery-srv`][292] configuration options to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
+- Added the [`keepalive-critical-timeout`][101] configuration option to define the time after which a critical keepalive event should be created for an agent and the [`keepalive-warning-timeout`][101] configuration option, which is an alias of `keepalive-timeout` for backward compatibility.
 
 **IMPROVEMENTS:**
 
@@ -1552,7 +1552,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.11.0.
 Read the [sensuctl reference][72] for more information.
 - Assets now include a `headers` attribute to include HTTP headers in requests to retrieve assets, allowing you to access secured assets.
 Read the [asset reference][70] for examples.
-- Sensu agents now support the `disable-assets` configuration flag, allowing you to disable asset retrieval for individual agents.
+- Sensu agents now support the `disable-assets` configuration option, allowing you to disable asset retrieval for individual agents.
 Read the [agent reference][71] for examples.
 - Sensu [binary-only distributions][69] are now available as zip files.
 
@@ -1659,7 +1659,7 @@ If you're upgrading a Sensu cluster from 5.7.0 or earlier, read the [instruction
 Read the [web UI docs][54] to get started using the Sensu web UI.
 - ([Commercial feature][53]) Manage your Sensu event handlers from your browser: Sensu's web UI now supports creating, editing, and deleting handlers.
 Read the [web UI docs][54] to get started using the Sensu web UI.
-- ([Commercial feature][53]) Sensu now supports event logging to a file using the `event-log-file` and `event-log-buffer-size` configuration flags.
+- ([Commercial feature][53]) Sensu now supports event logging to a file using the `event-log-file` and `event-log-buffer-size` configuration options.
 You can use this event log file as an input source for your favorite data lake solution.
 Read the [backend reference][55] for more information.
 
@@ -1830,7 +1830,7 @@ Read the [/metrics API documentation][31] for more information.
 **IMPROVEMENTS:**
 
 - Sensu now lets you specify a separate TLS certificate and key to secure the dashboard.
-Read the [backend reference][24] to configure the `dashboard-cert-file` and `dashboard-key-file` flags, and check out the [guide to securing Sensu][25] for the complete guide to making your Sensu instance production-ready.
+Read the [backend reference][24] to configure the `dashboard-cert-file` and `dashboard-key-file` options, and check out the [guide to securing Sensu][25] for the complete guide to making your Sensu instance production-ready.
 - The Sensu agent events API now queues events before sending them to the backend, making the agent events API more robust and preventing data loss in the event of a loss of connection with the backend or agent shutdown.
 Read the [agent reference][26] for more information.
 
@@ -1877,7 +1877,7 @@ You can now use the dashboard to review check details like command, subscription
 
 - Sensu Go 5.3.0 fixes all known TLS vulnerabilities affecting the backend, including increasing the minimum supported TLS version to 1.2 and removing all ciphers except those with perfect forward secrecy.
 - Sensu now enforces uniform TLS configuration for all three backend components: `apid`, `agentd`, and `dashboardd`.
-- The backend no longer requires the `trusted-ca-file` flag when using TLS.
+- The backend no longer requires the `trusted-ca-file` configuration option when using TLS.
 - The backend no longer loads server TLS configuration for the HTTP client.
 
 **FIXES:**
@@ -2001,7 +2001,7 @@ Read the [upgrade guide][3] for more information.
 
 **NEW FEATURES:**
 
-- Sensu [agents][4] now include `trusted-ca-file` and `insecure-skip-tls-verify` configuration flags, giving you more flexibility with certificates when connecting agents to the backend over TLS.
+- Sensu [agents][4] now include `trusted-ca-file` and `insecure-skip-tls-verify` configuration options, giving you more flexibility with certificates when connecting agents to the backend over TLS.
 
 **IMPROVEMENTS:**
 

--- a/content/sensu-go/6.6/sensuctl/_index.md
+++ b/content/sensu-go/6.6/sensuctl/_index.md
@@ -495,7 +495,7 @@ source ~/.zshrc
 
 [1]: ../operations/control-access/rbac/
 [2]: ../operations/deploy-sensu/install-sensu/#install-sensuctl
-[3]: ../observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[3]: ../observability-pipeline/observe-schedule/backend/
 [4]: ../operations/deploy-sensu/cluster-sensu/
 [5]: create-manage-resources/#create-resources
 [6]: #sensu-backend-url

--- a/content/sensu-go/6.7/api/_index.md
+++ b/content/sensu-go/6.7/api/_index.md
@@ -85,7 +85,7 @@ Beta APIs are more stable than alpha versions, but they offer similarly short-li
 ## Request size limit
 
 The default limit for API request body size is 0.512 MB.
-Use the [`--api-request-limit` backend configuration flag][21] to customize the API request body size limit if needed.
+Use the [`api-request-limit` backend configuration option][21] to customize the API request body size limit if needed.
 
 ## Access control
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
@@ -1926,7 +1926,7 @@ status: Ss
 [31]: ../#agent-entities
 [32]: ../#proxy-entities
 [33]: ../../../web-ui/view-manage-resources/#manage-entities
-[34]: ../../observe-schedule/agent/#ephemeral-agent-configuration-flags
+[34]: ../../observe-schedule/agent/#ephemeral-agent-configuration
 [35]: ../../observe-schedule/agent/#config-file
 [36]: ../../../api/core/entities/
 [37]: ../../../sensuctl/create-manage-resources/#update-resources

--- a/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-entities/entities.md
@@ -222,9 +222,9 @@ If you change an agent entity's class to `proxy`, the backend will revert the ch
 ### Manage agent entities via the agent
 
 If you prefer, you can manage agent entities via the agent rather than the backend.
-To do this, add the [`agent-managed-entity` flag][16] when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
+To do this, add the [`agent-managed-entity`][16] configuration option when you start the Sensu agent or set `agent-managed-entity: true` in your `agent.yml` file.
 
-When you start an agent with the `--agent-managed-entity` flag or set `agent-managed-entity: true` in `agent.yml`, the agent becomes responsible for managing its entity configuration.
+When you start an agent with the `agent-managed-entity` configuration option set to `true`, the agent becomes responsible for managing its entity configuration.
 An entity managed by this agent will include the label `sensu.io/managed_by: sensu-agent`.
 You cannot update these agent-managed entities via the Sensu backend REST API.
 To change an agent's configuration, restart the agent.
@@ -1372,7 +1372,7 @@ arm_version: 7
 
 cloud_provider | 
 ---------------|------ 
-description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`--detect-cloud-provider` flag][25] is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
+description    | Entity's cloud provider environment. Automatically populated upon agent startup if the [`detect-cloud-provider`][25] configuration option is set. Returned empty unless the agent runs on Amazon Elastic Compute Cloud (EC2), Google Cloud Platform (GCP), or Microsoft Azure. {{% notice note %}}
 **NOTE**: This feature can result in several HTTP requests or DNS lookups being performed, so it may not be appropriate for all environments.
 {{% /notice %}}
 required       | false 
@@ -1733,7 +1733,7 @@ name: eth0
 ### Processes attributes
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes` flag](../../observe-schedule/agent/#discover-processes) in the packaged Sensu Go distribution.
+**COMMERCIAL FEATURE**: Access processes attributes with the [`discover-processes`](../../observe-schedule/agent/#discover-processes) configuration option in the packaged Sensu Go distribution.
 For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -37,7 +37,7 @@ Instead, you must configure event handlers to send the data to a storage solutio
 
 ## Configure the StatsD listener
 
-Use flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
+Use configuration flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
 
 The following flags allow you to configure event handlers, flush interval, address, and port:
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/handlers.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/handlers.md
@@ -284,8 +284,8 @@ spec:
 
 {{< /language-toggle >}}
 
-You can also use the [`keepalive-handlers`][19] flag to send keepalive events to any handler you have configured.
-If you do not specify a keepalive handler with the `keepalive-handlers` flag, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+You can also use the [`keepalive-handlers`][19] configuration option to send keepalive events to any handler you have configured.
+If you do not specify a keepalive handler with the `keepalive-handlers` configuration option, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 
 ## Handler specification
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -123,7 +123,7 @@ If system time is out of sync, it may cause issues with keepalive, metric, and c
 
 ## Agent connection to a cluster
 
-Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url` configuration flag][16].
+Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url`][16] configuration option.
 
 For more information about clustering, read [Backend datastore configuration][35] and [Run a Sensu cluster][36].
 
@@ -945,7 +945,7 @@ disable-assets: true{{< /code >}}
 | discover-processes |      |
 --------------|------
 description   | When set to `true`, the agent populates the `processes` field in `entity.system` and updates every 20 seconds.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the discover-processes flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `discover-processes` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}{{% notice note %}}
 **NOTE**: Process discovery is disabled in this version of Sensu. The discover-processes flag is not available, and new events will not include data in the `processes` attributes. Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
@@ -1148,7 +1148,7 @@ deregister: true{{< /code >}}
 
 | deregistration-handler |      |
 -------------------------|------
-description              | Name of the event handler to use when processing the agent's deregistration events. This flag overrides any handlers applied by the [`deregistration-handler` backend configuration flag][37].
+description              | Name of the event handler to use when processing the agent's deregistration events. This configuration option overrides any handlers applied by the [`deregistration-handler`][37] backend configuration option.
 type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
@@ -1160,7 +1160,7 @@ deregistration-handler: deregister{{< /code >}}
 
 | detect-cloud-provider  |      |
 -------------------------|------
-description              | `true` to enable cloud provider detection mechanisms. Otherwise, `false`. When this flag is enabled, the agent will attempt to read files, resolve hostnames, and make HTTP requests to determine what cloud environment it is running in.
+description              | `true` to enable cloud provider detection mechanisms. Otherwise, `false`. When this option is enabled, the agent will attempt to read files, resolve hostnames, and make HTTP requests to determine what cloud environment it is running in.
 type                     | Boolean
 default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
@@ -1187,7 +1187,7 @@ keepalive-critical-timeout: 300{{< /code >}}
 
 | keepalive-handlers |      |
 --------------------|------
-description         | [Keepalive event handlers][52] to use for the entity, specified in a comma-delimited list. You can specify any configured handler and invoke the `keepalive-handlers` flag multiple times. If keepalive handlers are not specified, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+description         | [Keepalive event handlers][52] to use for the entity, specified in a comma-delimited list. You can specify any configured handler and invoke the `keepalive-handlers` configuration option multiple times. If keepalive handlers are not specified, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 type                | List
 default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
@@ -1214,7 +1214,7 @@ keepalive-interval: 30{{< /code >}}
 
 | keepalive-pipelines |      |
 --------------------|------
-description         | [Pipelines][63] to use for processing keepalive events, specified in a comma-delimited list. If keepalive pipelines are not specified, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.<br><br>To specify pipelines for the `keepalive-pipelines` flag, use the [fully qualified name][65] for pipeline resources (`core/v2.Pipeline`) plus the pipeline name.
+description         | [Pipelines][63] to use for processing keepalive events, specified in a comma-delimited list. If keepalive pipelines are not specified, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.<br><br>To specify pipelines for the `keepalive-pipelines` configuration option, use the [fully qualified name][65] for pipeline resources (`core/v2.Pipeline`) plus the pipeline name.
 type                | List
 default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_PIPELINES`
@@ -1256,7 +1256,7 @@ cert-file: "/path/to/tls/agent.pem"{{< /code >}}
 | insecure-skip-tls-verify |      |
 ---------------------------|------
 description                | Skip SSL verification. {{% notice warning %}}
-**WARNING**: This configuration flag is intended for use in development systems only. Do not use this flag in production.
+**WARNING**: This configuration option is intended for use in development systems only. Do not use this configuration option in production.
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
@@ -1326,7 +1326,7 @@ redact:
 | require-fips |      |
 ------------------|------
 description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu agent startup if `true` but OpenSSL is not running in FIPS mode. {{% notice note %}}
-**NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `require-fips` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
@@ -1340,7 +1340,7 @@ require-fips: true{{< /code >}}
 | require-openssl |      |
 ------------------|------
 description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu agent startup if `true` but Go's standard cryptography library is loaded. {{% notice note %}}
-**NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `--require-openssl` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -125,24 +125,24 @@ If system time is out of sync, it may cause issues with keepalive, metric, and c
 
 Agents can connect to a Sensu cluster by specifying any Sensu backend URL in the cluster in the [`backend-url` configuration flag][16].
 
-For more information about clustering, read [Backend datastore configuration flags][35] and [Run a Sensu cluster][36].
+For more information about clustering, read [Backend datastore configuration][35] and [Run a Sensu cluster][36].
 
 ## Keepalive monitoring
 
 Sensu keepalives are the heartbeat mechanism used to ensure that all registered agents are operational and able to reach the [Sensu backend][2].
-Sensu agents publish keepalive events containing [entity][3] configuration data to the Sensu backend according to the interval specified by the [`keepalive-interval`][4] configuration flag.
+Sensu agents publish keepalive events containing [entity][3] configuration data to the Sensu backend according to the interval specified by the [`keepalive-interval`][4] configuration option.
 
-If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-critical-timeout`][4] configuration flag, the Sensu backend creates a keepalive **critical** alert in the Sensu web UI.
+If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-critical-timeout`][4] configuration option, the Sensu backend creates a keepalive **critical** alert in the Sensu web UI.
 The `keepalive-critical-timeout` is set to `0` (disabled) by default to help ensure that it will not interfere with your `keepalive-warning-timeout` setting.
 
-If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-warning-timeout`][58] configuration flag, the Sensu backend creates a keepalive **warning** alert in the Sensu web UI.
+If a Sensu agent fails to send keepalive events over the period specified by the [`keepalive-warning-timeout`][58] configuration option, the Sensu backend creates a keepalive **warning** alert in the Sensu web UI.
 The value you specify for `keepalive-warning-timeout` must be lower than the value you specify for `keepalive-critical-timeout`.
 
 {{% notice note %}}
-**NOTE**: If you set the [deregister flag](#ephemeral-agent-configuration-flags) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
+**NOTE**: If you set the [`deregister` configuration option](#ephemeral-agent-configuration) to `true`, when a Sensu agent process stops, the Sensu backend will deregister the corresponding entity.<br><br>
 Deregistration prevents and clears alerts for failing keepalives for agent entities &mdash; the backend does not distinguish between intentional shutdown and failure.
-As a result, if you set the deregister flag to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
-If you want to receive alerts for failing keepalives, set the [deregister](#ephemeral-agent-configuration-flags) configuration flag to `false`.
+As a result, if you set `deregister` to `true` and an agent process stops for any reason, you will not receive alerts for keepalive events in the web UI.<br><br>
+If you want to receive alerts for failing keepalives, set the [deregister configuration option](#ephemeral-agent-configuration) to `false`.
 {{% /notice %}}
 
 You can use keepalives to identify unhealthy systems and network partitions, send notifications, and trigger auto-remediation, among other useful actions.
@@ -159,9 +159,9 @@ Process keepalive events with a [pipeline][66] or [handler][67].
 
 #### Keepalive pipelines
 
-Use the [`keepalive-pipelines`][64] configuration flag to send keepalive events to any [pipeline][63] you have configured.
+Use the [`keepalive-pipelines`][64] configuration option to send keepalive events to any [pipeline][63] you have configured.
 
-To specify pipelines for the `keepalive-pipelines` flag, use the [fully qualified name][65] for pipelines (`core/v2.Pipeline`) plus the pipeline name (e.g. `slack` or `store-keepalives`).
+To specify pipelines for the `keepalive-pipelines` option, use the [fully qualified name][65] for pipelines (`core/v2.Pipeline`) plus the pipeline name (e.g. `slack` or `store-keepalives`).
 For example:
 
 {{< language-toggle >}}
@@ -178,7 +178,7 @@ keepalive-pipelines:
 
 {{< /language-toggle >}}
 
-If you do not specify a pipeline with the `keepalive-pipelines` flag, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI for keepalives.
+If you do not specify a pipeline with the `keepalive-pipelines` option, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI for keepalives.
 
 #### Keepalive handlers
 
@@ -221,8 +221,8 @@ spec:
 
 {{< /language-toggle >}}
 
-You can also use the [`keepalive-handlers`][53] flag to send keepalive events to any handler you have configured.
-If you do not specify a keepalive handler with the `keepalive-handlers` flag, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
+You can also use the [`keepalive-handlers`][53] configuration option to send keepalive events to any handler you have configured.
+If you do not specify a keepalive handler with the `keepalive-handlers` option, the Sensu backend will use the default `keepalive` handler and create an event in sensuctl and the Sensu web UI.
 
 ## Create observability events using service checks
 
@@ -262,7 +262,7 @@ Read the [entities reference][3] and [Monitor external resources][33] for more i
 ## Create observability events using the agent API
 
 The Sensu agent API allows external sources to send monitoring data to Sensu without requiring the external sources to know anything about Sensu's internal implementation.
-The agent API listens on the address and port specified with the [API configuration attributes][18].
+The agent API listens on the address and port specified with the agent [API configuration options][18].
 
 The agent API supports only unsecured HTTP requests (no HTTPS).
 Requests for unknown endpoints will result in an `HTTP 404 Not Found` response.
@@ -276,7 +276,7 @@ In case of a loss of connection with the backend or agent shutdown, the agent pr
 When the connection is reestablished, the agent sends the queued events to the backend.
 
 The agent API `/events` endpoint uses a configurable burst limit and rate limit for relaying events to the backend.
-Read [API configuration flags](#api-configuration-flags) to configure the `events-burst-limit` and `events-rate-limit` flags.
+Read [API configuration](#api-configuration) to configure the `events-burst-limit` and `events-rate-limit` options.
 
 #### Example POST request to events endpoint
 
@@ -446,14 +446,14 @@ For more information about StatsD, read the [StatsD documentation][21].
 
 ### Configure the StatsD listener
 
-To configure the StatsD listener, specify the [`statsd-event-handlers`][22] configuration flag in the [agent configuration][24] and start the agent.
+To configure the StatsD listener, specify the [`statsd-event-handlers`][22] configuration option in the [agent configuration][24] and start the agent.
 For example, to start an agent that sends StatsD metrics to InfluxDB, run:
 
 {{< code shell >}}
 sensu-agent --statsd-event-handlers influx-db
 {{< /code >}}
 
-Use the [StatsD configuration flags][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
+Use the [StatsD configuration options][22] to change the default settings for the StatsD listener address, port, and [flush interval][23].
 For example, to start an agent with a customized address and flush interval, run:
 
 {{< code shell >}}
@@ -468,7 +468,7 @@ sensu-agent --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd
 
 Sensu agents listen for external monitoring data using TCP and UDP sockets.
 The agent sockets accept JSON event data and pass events to the Sensu backend event pipeline for processing.
-The TCP and UDP sockets listen on the address and port specified by the [socket configuration flags][17].
+The TCP and UDP sockets listen on the address and port specified by the [socket configuration options][17].
 
 ### Use the TCP socket
 
@@ -663,42 +663,32 @@ However, all registration events are logged in the [Sensu backend log](../backen
 
 As with registration events, the Sensu backend can create and process a deregistration event when the Sensu agent process stops.
 You can use deregistration events to trigger a handler that updates external CMDBs or performs an action to update ephemeral infrastructures.
-To enable deregistration events, use the [`deregister` flag][13], and specify the event handler using the [`deregistration-handler` flag][13].
-You can specify a deregistration handler per agent using the [`deregistration-handler` agent flag][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration flag][37].
+To enable deregistration events, use the [`deregister` option][13], and specify the event handler using the [`deregistration-handler` option][13].
+You can specify a deregistration handler per agent using the [`deregistration-handler` agent option][13] or by setting a default for all agents using the [`deregistration-handler` backend configuration option][37].
 
 {{% notice note %}}
 **NOTE**: Deregistration is supported for [agent entities](../../observe-entities/#agent-entities) that have sent at least one keepalive.
 Deregistration is **not** supported for [proxy entities](../../observe-entities/#proxy-entities), which do not send keepalives, and the backend does not automatically create and process deregistration events for proxy entities.
 {{% /notice %}}
 
-## Configuration via flags
+## Agent configuration options
 
-For Linux agents, customize the agent configuration with `sensu-agent start` command line flags or in a `.yml` file.
-The default agent configuration file path for Linux is `/etc/sensu/agent.yml`.
-Configuration via command line flags overrides attributes specified in a configuration file.
-Read [Create overrides][68] to learn more.
+Agent configuration is customizable.
+This section describes each configuration option in more detail, including examples for each [configuration method][70].
 
-For Windows agents, customize the agent configuration in a `.yml` file.
-The default agent configuration file path for Windows is `C:\ProgramData\sensu\config\agent.yml.example`.
-
-Review the [example Sensu agent configuration file][5] for a complete list of flags and default values.
-The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
-
-### Agent configuration flag summary
+You can customize agent configuration with the [agent configuration file][69] (Linux and Windows), [command line flag arguments][24] (Linux), or [environment variables][50] (Linux and Windows).
 
 {{% notice note %}}
-**NOTE**: Process discovery is disabled in this version of Sensu.
-The `--discover-processes` flag is not available, and new events will not include data in the `processes` attributes.
-Instead, the field will be empty: `"processes": null`.
+**NOTE**: The agent loads configuration upon startup, so you must restart the agent for any configuration updates to take effect.
 {{% /notice %}}
 
-To view configuration information for the sensu-agent start command, run:
+To view available configuration options for the `sensu-agent start` command, run:
 
 {{< code shell >}}
 sensu-agent start --help
 {{< /code >}}
 
-The response will list command information and configuration flags for sensu-agent start:
+The response will list configuration options as command line flags for `sensu-agent start`:
 
 {{< code text >}}
 start the sensu agent
@@ -762,11 +752,13 @@ Flags:
       --user string                         agent user (default "agent")
 {{< /code >}}
 
-### General configuration flags
-
 {{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+**NOTE**: Process discovery is disabled in this version of Sensu.
+The `--discover-processes` configuration option is not available, and new events will not include data in the `processes` attributes.
+Instead, the field will be empty: `"processes": null`.
 {{% /notice %}}
+
+### General configuration
 
 <a id="agent-managed-entity"></a>
 
@@ -779,20 +771,20 @@ default      | false
 environment variable | `SENSU_AGENT_MANAGED_ENTITY`
 command line example   | {{< code shell >}}
 sensu-agent start --agent-managed-entity{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 agent-managed-entity: true{{< /code >}}
 
 <a id="allow-list"></a>
 
 | allow-list |      |
 ------------------|------
-description       | Path to yaml or json file that contains the allow list of check or hook commands the agent can execute. Read [allow list configuration commands][49] and the [example allow list configuration][48] for information about building a configuration file.
+description       | Path to yaml or json file that contains the allow list of check or hook commands the agent can execute. Read [Allow list configuration][49] and the [example allow list configuration][48] for information about building a configuration file.
 type              | String
 default           | `""`
 environment variable | `SENSU_ALLOW_LIST`
 command line example   | {{< code shell >}}
 sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
 
 | annotations|      |
@@ -808,10 +800,12 @@ command line example   | {{< code shell >}}
 sensu-agent start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-agent start --annotations example-key="example value" --annotations example-key2="example value"
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
+
+<a id="assets-burst-limit"></a>
 
 | assets-burst-limit   |      |
 --------------|------
@@ -821,7 +815,7 @@ default       | `100`
 environment variable | `SENSU_ASSETS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --assets-burst-limit 100{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
 
 | assets-rate-limit   |      |
@@ -832,7 +826,7 @@ default       | `1.39`
 environment variable | `SENSU_ASSETS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --assets-rate-limit 1.39{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 <a id="backend-handshake-timeout"></a>
@@ -845,7 +839,7 @@ default       | `15`
 environment variable | `SENSU_BACKEND_HANDSHAKE_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-handshake-timeout 20{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-handshake-timeout: 20{{< /code >}}
 
 <a id="backend-heartbeat-interval"></a>
@@ -858,7 +852,7 @@ default       | `30`
 environment variable | `SENSU_BACKEND_HEARTBEAT_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-heartbeat-interval 45{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-heartbeat-interval: 45{{< /code >}}
 
 <a id="backend-heartbeat-timeout"></a>
@@ -871,7 +865,7 @@ default       | `45`
 environment variable | `SENSU_BACKEND_HEARTBEAT_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --backend-heartbeat-timeout 60{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 backend-heartbeat-timeout: 60{{< /code >}}
 
 | backend-url |      |
@@ -880,7 +874,9 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
-default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker)
+default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_URL`
 command line example | {{< language-toggle >}}
 {{< code shell "ws" >}}
@@ -892,7 +888,7 @@ sensu-agent start --backend-url wss://127.0.0.1:8081
 sensu-agent start --backend-url wss://127.0.0.1:8081 --backend-url wss://127.0.0.1:8082
 {{< /code >}}
 {{< /language-toggle >}}
-/etc/sensu/agent.yml example | {{< language-toggle >}}
+agent.yml config file example | {{< language-toggle >}}
 {{< code shell "ws" >}}
 backend-url:
   - "ws://127.0.0.1:8081"
@@ -915,7 +911,7 @@ default       | <ul><li>Linux: `/var/cache/sensu/sensu-agent`</li><li>Windows: `
 environment variable | `SENSU_CACHE_DIR`
 command line example   | {{< code shell >}}
 sensu-agent start --cache-dir /cache/sensu-agent{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 cache-dir: "/cache/sensu-agent"{{< /code >}}
 
 <a id="config-file"></a>
@@ -941,7 +937,7 @@ default       | false
 environment variable | `SENSU_DISABLE_ASSETS`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-assets{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-assets: true{{< /code >}}
 
 <a id="discover-processes"></a>
@@ -958,7 +954,7 @@ default       | false
 environment variable | `SENSU_DISCOVER_PROCESSES`
 command line example   | {{< code shell >}}
 sensu-agent start --discover-processes{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 discover-processes: true{{< /code >}}
 
 | labels     |      |
@@ -974,7 +970,7 @@ command line example   | {{< code shell >}}
 sensu-agent start --labels proxy_type=website
 sensu-agent start --labels example_key1="example value" example_key2="example value"
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 labels:
   proxy_type: website
 {{< /code >}}
@@ -989,7 +985,7 @@ default       | `warn`
 environment variable | `SENSU_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-agent start --log-level debug{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 log-level: debug{{< /code >}}
 
 <a id="max-session-length-attribute"></a>
@@ -1002,7 +998,7 @@ default       | Defaults to no maximum.
 environment variable | `SENSU_MAX_SESSION_LENGTH`
 command line example   | {{< code shell >}}
 sensu-agent start --max-session-length 15m{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 max-session-length: 15m{{< /code >}}
 
 <a id="name-attribute"></a>
@@ -1015,7 +1011,7 @@ default       | Defaults to hostname (for example, `sensu-centos`).
 environment variable | `SENSU_NAME`
 command line example   | {{< code shell >}}
 sensu-agent start --name agent-01{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 name: "agent-01"{{< /code >}}
 
 <a id="retry-max"></a>
@@ -1028,7 +1024,7 @@ default       | `120s`
 environment variable | `SENSU_RETRY_MAX`
 command line example   | {{< code shell >}}
 sensu-agent start --retry-max 120s{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 retry-max: 120s{{< /code >}}
 
 <a id="retry-min"></a>
@@ -1041,7 +1037,7 @@ default       | `1s`
 environment variable | `SENSU_RETRY_MIN`
 command line example   | {{< code shell >}}
 sensu-agent start --retry-min 1s{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 retry-min: 1s{{< /code >}}
 
 <a id="retry-multiplier"></a>
@@ -1056,7 +1052,7 @@ default       | `2.0`
 environment variable | `SENSU_RETRY_MULTIPLIER`
 command line example   | {{< code shell >}}
 sensu-agent start --retry-multiplier 2.0{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 retry-multiplier: 2.0{{< /code >}}
 
 <a id="subscriptions-flag"></a>
@@ -1070,13 +1066,13 @@ command line example   | {{< code shell >}}
 sensu-agent start --subscriptions disk-checks,process-checks
 sensu-agent start --subscriptions disk-checks --subscriptions process-checks
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 subscriptions:
   - disk-checks
   - process-checks
 {{< /code >}}
 
-### API configuration flags
+### API configuration
 
 | api-host    |      |
 --------------|------
@@ -1086,7 +1082,7 @@ default       | `127.0.0.1`
 environment variable | `SENSU_API_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --api-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 api-host: "127.0.0.1"{{< /code >}}
 
 | api-port    |      |
@@ -1097,7 +1093,7 @@ default       | `3031`
 environment variable | `SENSU_API_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --api-port 3031{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 api-port: 3031{{< /code >}}
 
 | disable-api |      |
@@ -1108,7 +1104,7 @@ default       | `false`
 environment variable | `SENSU_DISABLE_API`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-api{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-api: true{{< /code >}}
 
 | events-burst-limit | |
@@ -1119,7 +1115,7 @@ default       | `10`
 environment variable | `SENSU_EVENTS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --events-burst-limit 20{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 events-burst-limit: 20{{< /code >}}
 
 | events-rate-limit | |
@@ -1130,10 +1126,10 @@ default       | `10.0`
 environment variable | `SENSU_EVENTS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-agent start --events-rate-limit 20.0{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 events-rate-limit: 20.0{{< /code >}}
 
-### Ephemeral agent configuration flags
+### Ephemeral agent configuration
 
 | deregister  |      |
 --------------|------
@@ -1145,7 +1141,7 @@ default       | `false`
 environment variable | `SENSU_DEREGISTER`
 command line example   | {{< code shell >}}
 sensu-agent start --deregister{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 deregister: true{{< /code >}}
 
 <a id="agent-deregistration-handler-attribute"></a>
@@ -1157,7 +1153,7 @@ type                     | String
 environment variable     | `SENSU_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
 sensu-agent start --deregistration-handler deregister{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 deregistration-handler: deregister{{< /code >}}
 
 <a id="detect-cloud-provider-flag"></a>
@@ -1170,10 +1166,10 @@ default                  | `false`
 environment variable     | `SENSU_DETECT_CLOUD_PROVIDER`
 command line example   | {{< code shell >}}
 sensu-agent start --detect-cloud-provider false{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 detect-cloud-provider: false{{< /code >}}
 
-### Keepalive configuration flags
+### Keepalive configuration
 
 | keepalive-critical-timeout |      |
 --------------------|------
@@ -1184,7 +1180,7 @@ default             | `0`
 environment variable   | `SENSU_KEEPALIVE_CRITICAL_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-critical-timeout 300{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-critical-timeout: 300{{< /code >}}
 
 <a id="keepalive-handlers-flag"></a>
@@ -1197,7 +1193,7 @@ default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_HANDLERS`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-handlers slack,email{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-handlers:
 - slack
 - email
@@ -1211,7 +1207,7 @@ default              | `20`
 environment variable   | `SENSU_KEEPALIVE_INTERNAL`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-interval 30{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-interval: 30{{< /code >}}
 
 <a id="keepalive-pipelines-flag"></a>
@@ -1224,7 +1220,7 @@ default             | `keepalive`
 environment variable   | `SENSU_KEEPALIVE_PIPELINES`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-pipelines core/v2.Pipeline.slack,core/v2.Pipeline.store-keepalives{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-pipelines:
 - core/v2.Pipeline.slack
 - core/v2.Pipeline.store-keepalives
@@ -1241,10 +1237,10 @@ default             | `120`
 environment variable   | `SENSU_KEEPALIVE_WARNING_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-warning-timeout 300{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 keepalive-warning-timeout: 300{{< /code >}}
 
-### Security configuration flags
+### Security configuration
 
 | cert-file  |      |
 -------------|------
@@ -1254,7 +1250,7 @@ default      | `""`
 environment variable | `SENSU_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --cert-file /path/to/tls/agent.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 cert-file: "/path/to/tls/agent.pem"{{< /code >}}
 
 | insecure-skip-tls-verify |      |
@@ -1267,7 +1263,7 @@ default                    | `false`
 environment variable       | `SENSU_INSECURE_SKIP_TLS_VERIFY`
 command line example   | {{< code shell >}}
 sensu-agent start --insecure-skip-tls-verify{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 | key-file   |      |
@@ -1278,7 +1274,7 @@ default      | `""`
 environment variable | `SENSU_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --key-file /path/to/tls/agent-key.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 key-file: "/path/to/tls/agent-key.pem"{{< /code >}}
 
 | namespace |      |
@@ -1292,8 +1288,10 @@ default        | `default`
 environment variable   | `SENSU_NAMESPACE`
 command line example   | {{< code shell >}}
 sensu-agent start --namespace ops{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 namespace: ops{{< /code >}}
+
+<a id="agent-password-option"></a>
 
 | password    |      |
 --------------|------
@@ -1303,7 +1301,7 @@ default       | `P@ssw0rd!`
 environment variable   | `SENSU_PASSWORD`
 command line example   | {{< code shell >}}
 sensu-agent start --password secure-password{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 password: secure-password{{< /code >}}
 
 | redact      |      |
@@ -1317,7 +1315,7 @@ default       | By default, Sensu redacts the following fields: `password`, `pas
 environment variable   | `SENSU_REDACT`
 command line example   | {{< code shell >}}
 sensu-agent start --redact secret,ec2_access_key{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 redact:
   - secret
   - ec2_access_key
@@ -1336,7 +1334,7 @@ default           | false
 environment variable | `SENSU_REQUIRE_FIPS`
 command line example   | {{< code shell >}}
 sensu-agent start --require-fips{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -1350,7 +1348,7 @@ default           | false
 environment variable | `SENSU_REQUIRE_OPENSSL`
 command line example   | {{< code shell >}}
 sensu-agent start --require-openssl{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -1361,8 +1359,10 @@ default           | `""`
 environment variable   | `SENSU_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-agent start --trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 trusted-ca-file: "/path/to/tls/ca.pem"{{< /code >}}
+
+<a id="agent-user-option"></a>
 
 | user |      |
 --------------|------
@@ -1372,10 +1372,10 @@ default       | `agent`
 environment variable   | `SENSU_USER`
 command line example   | {{< code shell >}}
 sensu-agent start --user agent-01{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 user: "agent-01"{{< /code >}}
 
-### Socket configuration flags
+### Socket configuration
 
 | disable-sockets |      |
 ------------------|------
@@ -1385,7 +1385,7 @@ default           | `false`
 environment variable   | `SENSU_DISABLE_SOCKETS`
 command line example   | {{< code shell >}}
 sensu-agent start --disable-sockets{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 disable-sockets: true{{< /code >}}
 
 | socket-host |      |
@@ -1396,7 +1396,7 @@ default       | `127.0.0.1`
 environment variable   | `SENSU_SOCKET_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --socket-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 socket-host: "127.0.0.1"{{< /code >}}
 
 | socket-port |      |
@@ -1407,10 +1407,10 @@ default       | `3030`
 environment variable   | `SENSU_SOCKET_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --socket-port 3030{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 socket-port: 3030{{< /code >}}
 
-### StatsD configuration flags
+### StatsD configuration
 
 | statsd-disable |      |
 -----------------|------
@@ -1420,7 +1420,7 @@ default          | `false`
 environment variable   | `SENSU_STATSD_DISABLE`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-disable{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-disable: true{{< /code >}}
 
 | statsd-event-handlers |      |
@@ -1432,7 +1432,7 @@ command line example   | {{< code shell >}}
 sensu-agent start --statsd-event-handlers influxdb,opentsdb
 sensu-agent start --statsd-event-handlers influxdb --statsd-event-handlers opentsdb
 {{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-event-handlers:
   - influxdb
   - opentsdb
@@ -1446,7 +1446,7 @@ default                  | `10`
 environment variable     | `SENSU_STATSD_FLUSH_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-flush-interval 30{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-flush-interval: 30{{< /code >}}
 
 | statsd-metrics-host |      |
@@ -1457,7 +1457,7 @@ default               | `127.0.0.1`
 environment variable   | `SENSU_STATSD_METRICS_HOST`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-metrics-host 127.0.0.1{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-metrics-host: "127.0.0.1"{{< /code >}}
 
 | statsd-metrics-port |      |
@@ -1468,13 +1468,13 @@ default               | `8125`
 environment variable   | `SENSU_STATSD_METRICS_PORT`
 command line example   | {{< code shell >}}
 sensu-agent start --statsd-metrics-port 8125{{< /code >}}
-/etc/sensu/agent.yml example | {{< code shell >}}
+agent.yml config file example | {{< code shell >}}
 statsd-metrics-port: 8125{{< /code >}}
 
-### Allow list configuration commands
+### Allow list configuration
 
 The allow list includes check and hook commands the agent can execute.
-Use the [allow-list flag][56] to specify the path to the yaml or json file that contains your allow list.
+Use the [`allow-list` configuration option][56] to specify the path to the yaml or json file that contains your allow list.
 
 Use these commands to build your allow list configuration file.
 
@@ -1543,7 +1543,7 @@ sha512: 4f926bf4328...
 {{< /code >}}
 {{< /language-toggle >}}
 
-#### example allow list configuration
+#### Example allow list configuration
 
 {{< language-toggle >}}
 
@@ -1594,9 +1594,38 @@ sha512: 4f926bf4328...
 
 {{< /language-toggle >}}
 
-## Configuration via environment variables
+## Agent configuration methods
 
-Instead of using configuration flags, you can use environment variables to configure your Sensu agent.
+### Agent configuration file
+
+For Linux and Windows agents, you can customize the agent configuration in a `.yml` configuration file.
+
+The default agent configuration file path for Linux is `/etc/sensu/agent.yml`.
+The default agent configuration file path for Windows is `C:\ProgramData\sensu\config\agent.yml.example`.
+
+To use the `agent.yml` file to configure the agent, list the desired configuration attributes and values.
+Review the [example Sensu agent configuration file][5] for a complete example.
+
+Configuration via command line flags or environment variables overrides any configuration specified in the agent configuration file.
+Read [Create overrides][68] to learn more.
+
+### Command line flags
+
+For Linux agents, you can customize the agent configuration with `sensu-agent start` command line flags.
+
+To use command line flags, specify the desired configuration flags and values along with the `sensu-agent start` command.
+For example:
+
+{{< code shell >}}
+sensu-agent start --name webserver_05 --keepalive-warning-timeout 60 --keepalive-critical-timeout 120
+{{< /code >}}
+
+Configuration via command line flags overrides attributes specified in a configuration file or with environment variables.
+Read [Create overrides][68] to learn more.
+
+### Environment variables
+
+Instead of using the agent configuration file or command line flags, you can use environment variables to configure your Sensu agent.
 Each agent configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
@@ -1674,8 +1703,8 @@ sc.exe start SensuAgent
      {{< /language-toggle >}}
 
 {{% notice note %}}
-**NOTE**: Sensu includes an environment variable for each agent configuration flag.
-They are listed in the [configuration flag description tables](#general-configuration-flags).
+**NOTE**: Sensu includes an environment variable for each agent configuration option.
+They are listed in the [configuration description tables](#general-configuration).
 {{% /notice %}}
 
 ### Format for label and annotation environment variables
@@ -1781,12 +1810,12 @@ You can then use `HTTP_PROXY` and `HTTPS_PROXY` to add dynamic runtime assets, r
 **NOTE**: If you define the `HTTP_PROXY` and `HTTPS_PROXY` environment variables, the agent WebSocket connection will also use the proxy URL you specify.
 {{% /notice %}}
 
-## Create overrides
+## Create configuration overrides
 
 Sensu has default settings and limits for certain configuration attributes, like the default log level.
 Depending on your environment and preferences, you may want to create overrides for these Sensu-specific defaults and limits.
 
-You can create overrides in several ways:
+You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-agent start`.
 - Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
@@ -2032,7 +2061,7 @@ sensu-agent start --help
 [1]: ../../../operations/deploy-sensu/install-sensu#install-sensu-agents
 [2]: ../backend/
 [3]: ../../observe-entities/entities/
-[4]: #keepalive-configuration-flags
+[4]: #keepalive-configuration
 [5]: ../../../files/windows/agent.yml
 [6]: ../../../sensuctl/
 [7]: ../../observe-events/events/
@@ -2041,18 +2070,18 @@ sensu-agent start --help
 [10]: ../../observe-transform/mutators/
 [11]: https://en.wikipedia.org/wiki/Configuration_management_database
 [12]: https://www.servicenow.com/products/it-operations-management.html
-[13]: #ephemeral-agent-configuration-flags
+[13]: #ephemeral-agent-configuration
 [14]: ../checks/
 [15]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
-[16]: #general-configuration-flags
-[17]: #socket-configuration-flags
-[18]: #api-configuration-flags
+[16]: #general-configuration
+[17]: #socket-configuration
+[18]: #api-configuration
 [19]: https://sourceforge.net/projects/netcat/
 [20]: https://en.wikipedia.org/wiki/Dead_man%27s_switch
 [21]: https://github.com/etsy/statsd
-[22]: #statsd-configuration-flags
+[22]: #statsd-configuration
 [23]: https://github.com/statsd/statsd#key-concepts
-[24]: #configuration-via-flags
+[24]: #command-line-flags
 [25]: ../../../api/#response-filtering
 [26]: ../../../sensuctl/filter-responses/
 [27]: ../tokens/
@@ -2063,9 +2092,9 @@ sensu-agent start --help
 [32]: ../checks/#proxy-entity-name-attribute
 [33]: ../../observe-entities/monitor-external-resources/
 [34]: #backend-heartbeat-interval
-[35]: ../backend#datastore-and-cluster-configuration-flags
+[35]: ../backend/#datastore-and-cluster-configuration
 [36]: ../../../operations/deploy-sensu/cluster-sensu/
-[37]: ../backend#general-configuration-flags
+[37]: ../backend/#general-configuration
 [38]: #name
 [39]: ../../../operations/control-access/rbac/#agent-user
 [40]: ../../observe-process/send-slack-alerts/
@@ -2077,8 +2106,8 @@ sensu-agent start --help
 [46]: ../../../operations/deploy-sensu/secure-sensu/
 [47]: https://en.m.wikipedia.org/wiki/Protocol_Buffers
 [48]: #example-allow-list-configuration
-[49]: #allow-list-configuration-commands
-[50]: #configuration-via-environment-variables
+[49]: #allow-list-configuration
+[50]: #environment-variables
 [51]: #events-post-specification
 [52]: ../../observe-process/handlers/#keepalive-event-handlers
 [53]: #keepalive-handlers-flag
@@ -2095,4 +2124,7 @@ sensu-agent start --help
 [65]: ../../../sensuctl/create-manage-resources/#supported-resource-types
 [66]: #keepalive-pipelines
 [67]: #keepalive-handlers
-[68]: #create-overrides
+[68]: #create-configuration-overrides
+[69]: #agent-configuration-file
+[70]: #agent-configuration-methods
+[70]: #agent-configuration-methods

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
@@ -306,23 +306,24 @@ Check scheduling is subscription-based: the backend sends check requests to [sub
 
 For information about creating and managing checks, read the [checks reference][5] and the guides [Monitor server resources with checks][3] and [Collect metrics with checks][4].
 
-## Configuration via flags
+## Backend configuration options
 
-You can specify the backend configuration with either a `/etc/sensu/backend.yml` file or `sensu-backend start` [configuration flags][15].
-The backend requires that the `state-dir` flag is set before starting.
-All other required flags have default values.
-Review the [example backend configuration file][17] for flags and defaults.
-The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
+Backend configuration is customizable.
+This section describes each configuration option in more detail, including examples for each [configuration method][79].
 
-### Configuration summary
+You can customize backend configuration with the [backend configuration file][76], [command line flag arguments][77], or [environment variables][78].
 
-To view configuration information for the sensu-backend start command, run:
+{{% notice note %}}
+**NOTE**: The backend loads configuration upon startup, so you must restart the backend for any configuration updates to take effect.
+{{% /notice %}}
+
+To view configuration information for the `sensu-backend start` command, run:
 
 {{< code shell >}}
 sensu-backend start --help
 {{< /code >}}
 
-The response will list command information and configuration flags for sensu-backend start:
+The response will list configuration options as command line flags for `sensu-backend start`:
 
 {{< code text >}}
 start the sensu backend
@@ -412,13 +413,12 @@ Store Flags:
       --no-embed-etcd                             don't embed etcd, use external etcd instead
 {{< /code >}}
 
-For more information about log configuration flags, read [Event logging][65] and [Platform metrics logging][66].
+The backend requires that the [`state-dir`][75] configuration option is set before starting.
+All other required flags have default values.
 
-### General configuration flags
+For more information about log configuration options, read [Event logging][65] and [Platform metrics logging][66].
 
-{{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
-{{% /notice %}}
+### General configuration
 
 | annotations|      |
 -------------|------
@@ -433,7 +433,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --annotations sensu.io/plugins/slack/config/webhook-url=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 sensu-backend start --annotations example-key="example value" --annotations example-key2="example value"
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 annotations:
   sensu.io/plugins/slack/config/webhook-url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
 {{< /code >}}
@@ -446,7 +446,7 @@ default      | `[::]:8080`
 environment variable | `SENSU_BACKEND_API_LISTEN_ADDRESS`
 command line example   | {{< code shell >}}
 sensu-backend start --api-listen-address [::]:8080{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-listen-address: "[::]:8080"{{< /code >}}
 
 <a id="api-request-limit"></a>
@@ -459,18 +459,20 @@ default      | `512000`
 environment variable | `SENSU_BACKEND_API_REQUEST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --api-request-limit 1024000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-request-limit: 1024000{{< /code >}}
 
 | api-url  |      |
 -------------|------
 description  | URL used to connect to the API.
 type         | String
-default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker)
+default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_API_URL`
 command line example   | {{< code shell >}}
 sensu-backend start --api-url http://localhost:8080{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-url: "http://localhost:8080"{{< /code >}}
 
 <a id="api-write-timeout"></a>
@@ -483,7 +485,7 @@ default      | `15s`
 environment variable | `SENSU_BACKEND_API_WRITE_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-backend start --api-write-timeout 15s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 api-write-timeout: 15s{{< /code >}}
 
 | assets-burst-limit   |      |
@@ -494,7 +496,7 @@ default       | `100`
 environment variable | `SENSU_BACKEND_ASSETS_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --assets-burst-limit 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 assets-burst-limit: 100{{< /code >}}
 
 | assets-rate-limit   |      |
@@ -505,7 +507,7 @@ default       | `1.39`
 environment variable | `SENSU_BACKEND_ASSETS_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --assets-rate-limit 1.39{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 assets-rate-limit: 1.39{{< /code >}}
 
 | cache-dir   |      |
@@ -516,7 +518,7 @@ default       | `/var/cache/sensu/sensu-backend`
 environment variable | `SENSU_BACKEND_CACHE_DIR`
 command line example   | {{< code shell >}}
 sensu-backend start --cache-dir /var/cache/sensu-backend{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 cache-dir: "/var/cache/sensu-backend"{{< /code >}}
 
 | config-file |      |
@@ -540,7 +542,7 @@ default     | `false`
 environment variable | `SENSU_BACKEND_DEBUG`
 command line example   | {{< code shell >}}
 sensu-backend start --debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 debug: true{{< /code >}}
 
 <a id="deregistration-handler-attribute"></a>
@@ -553,7 +555,7 @@ default                  | `""`
 environment variable     | `SENSU_BACKEND_DEREGISTRATION_HANDLER`
 command line example   | {{< code shell >}}
 sensu-backend start --deregistration-handler deregister{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 deregistration-handler: "deregister"{{< /code >}}
 
 | labels     |      |
@@ -569,7 +571,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --labels security_zone=us-west-2a
 sensu-backend start --labels example_key1="example value" example_key2="example value"
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 labels:
   security_zone: "us-west-2a"
   example_key1: "example value"
@@ -586,7 +588,7 @@ default      | `warn`
 environment variable | `SENSU_BACKEND_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-backend start --log-level debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 log-level: "debug"{{< /code >}}
 
 <a id="metrics-refresh-interval"></a>
@@ -601,8 +603,10 @@ default      | `1m`
 environment variable | `SENSU_BACKEND_METRICS_REFRESH_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --metrics-refresh-interval 10s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 metrics-refresh-interval: 10s{{< /code >}}
+
+<a id="state-dir-option"></a>
 
 | state-dir  |      |
 -------------|------
@@ -614,10 +618,10 @@ command line example   | {{< code shell >}}
 sensu-backend start --state-dir /var/lib/sensu/sensu-backend
 sensu-backend start -d /var/lib/sensu/sensu-backend
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 state-dir: "/var/lib/sensu/sensu-backend"{{< /code >}}
 
-### Agent communication configuration flags
+### Agent communication configuration
 
 | agent-auth-cert-file |      |
 -------------|------
@@ -627,7 +631,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-cert-file: /path/to/tls/backend-1.pem{{< /code >}}
 
 | agent-auth-crl-urls |      |
@@ -638,7 +642,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_CRL_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-crl-urls http://localhost/CARoot.crl{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-crl-urls: http://localhost/CARoot.crl{{< /code >}}
 
 | agent-auth-key-file |      |
@@ -649,7 +653,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-key-file: /path/to/tls/backend-1-key.pem{{< /code >}}
 
 | agent-auth-trusted-ca-file |      |
@@ -660,7 +664,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_AGENT_AUTH_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-auth-trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 
 <a id="agent-burst-limit"></a>
@@ -677,7 +681,7 @@ default       | `null`
 environment variable | `SENSU_BACKEND_AGENT_BURST_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-burst-limit 10{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-burst-limit: 10{{< /code >}}
 
 | agent-host   |      |
@@ -688,7 +692,7 @@ default        | `[::]`
 environment variable | `SENSU_BACKEND_AGENT_HOST`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-host 127.0.0.1{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-host: "127.0.0.1"{{< /code >}}
 
 | agent-port |      |
@@ -699,7 +703,7 @@ default      | `8081`
 environment variable | `SENSU_BACKEND_AGENT_PORT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-port 8081{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-port: 8081{{< /code >}}
 
 <a id="agent-rate-limit"></a>
@@ -714,10 +718,10 @@ default       | `null`
 environment variable | `SENSU_BACKEND_AGENT_RATE_LIMIT`
 command line example   | {{< code shell >}}
 sensu-backend start --agent-rate-limit 10{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 agent-rate-limit: 10{{< /code >}}
 
-### Security configuration flags
+### Security configuration
 
 | cert-file  |      |
 -------------|------
@@ -727,7 +731,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 | insecure-skip-tls-verify |      |
@@ -740,7 +744,7 @@ default                    | `false`
 environment variable | `SENSU_BACKEND_INSECURE_SKIP_TLS_VERIFY`
 command line example   | {{< code shell >}}
 sensu-backend start --insecure-skip-tls-verify{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 insecure-skip-tls-verify: true{{< /code >}}
 
 <a id="jwt-attributes"></a>
@@ -755,7 +759,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_JWT_PRIVATE_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --jwt-private-key-file /path/to/key/private.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 jwt-private-key-file: /path/to/key/private.pem{{< /code >}}
 
 | jwt-public-key-file |      |
@@ -769,7 +773,7 @@ environment variable | `SENSU_BACKEND_JWT_PUBLIC_KEY_FILE`
 required     | false, unless `jwt-private-key-file` is defined
 command line example   | {{< code shell >}}
 sensu-backend start --jwt-public-key-file /path/to/key/public.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
@@ -780,7 +784,7 @@ default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 <a id="fips-openssl"></a>
@@ -796,7 +800,7 @@ default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_FIPS`
 command line example   | {{< code shell >}}
 sensu-backend start --require-fips{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 require-fips: true{{< /code >}}
 
 | require-openssl |      |
@@ -810,7 +814,7 @@ default           | false
 environment variable | `SENSU_BACKEND_REQUIRE_OPENSSL`
 command line example   | {{< code shell >}}
 sensu-backend start --require-openssl{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 require-openssl: true{{< /code >}}
 
 | trusted-ca-file |      |
@@ -821,20 +825,20 @@ default           | `""`
 environment variable | `SENSU_BACKEND_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --trusted-ca-file /path/to/tls/ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 trusted-ca-file: "/path/to/tls/ca.pem"{{< /code >}}
 
-### Web UI configuration flags
+### Web UI configuration
 
 | dashboard-cert-file | |
 -------------|------
-description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` flag](#security-configuration-flags) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Web UI TLS certificate in PEM format. This certificate secures communication with the Sensu web UI. If the `dashboard-cert-file` is not provided in the backend configuration, Sensu uses the certificate specified in the [`cert-file` configuration option](#security-configuration) for the web UI. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-cert-file /path/to/tls/separate-webui-cert.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-cert-file: "/path/to/tls/separate-webui-cert.pem"{{< /code >}}
 
 | dashboard-host |      |
@@ -845,18 +849,18 @@ default          | `[::]`
 environment variable | `SENSU_BACKEND_DASHBOARD_HOST`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-host 127.0.0.1{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-host: "127.0.0.1"{{< /code >}}
 
 | dashboard-key-file | |
 -------------|------
-description  | Web UI TLS certificate key in PEM format. This key secures communication with the Sensu web UI. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` flag](#security-configuration-flags) for the web UI.
+description  | Web UI TLS certificate key in PEM format. This key secures communication with the Sensu web UI. If the `dashboard-key-file` is not provided in the backend configuration, Sensu uses the key specified in the [`key-file` configuration option](#security-configuration) for the web UI.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_DASHBOARD_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-key-file /path/to/tls/separate-webui-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-key-file: "/path/to/tls/separate-webui-key.pem"{{< /code >}}
 
 | dashboard-port |      |
@@ -867,7 +871,7 @@ default          | `3000`
 environment variable | `SENSU_BACKEND_DASHBOARD_PORT`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-port 3000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-port: 3000{{< /code >}}
 
 <a id="dashboard-write-timeout"></a>
@@ -880,14 +884,10 @@ default      | `15s`
 environment variable | `SENSU_BACKEND_DASHBOARD_WRITE_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-backend start --dashboard-write-timeout 15s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 dashboard-write-timeout: 15s{{< /code >}}
 
-### Datastore and cluster configuration flags
-
-{{% notice note %}}
-**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
-{{% /notice %}}
+### Datastore and cluster configuration
 
 | etcd-advertise-client-urls |      |
 --------------|------
@@ -896,13 +896,15 @@ description   | List of this member's client URLs to advertise to the rest of th
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
-default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker)
+default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378,http://localhost:2379
 sensu-backend start --etcd-advertise-client-urls http://localhost:2378 --etcd-advertise-client-urls http://localhost:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-advertise-client-urls:
   - http://localhost:2378
   - http://localhost:2379
@@ -919,7 +921,7 @@ default          | `""`
 environment variable | `SENSU_BACKEND_ETCD_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 <a id="etcd-cipher-suites"></a>
@@ -945,7 +947,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 sensu-backend start --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --etcd-cipher-suites TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-cipher-suites:
   - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -962,7 +964,7 @@ default                 | `false`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_CERT_AUTH`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-cert-auth{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-client-cert-auth: true{{< /code >}}
 
 <a id="etcd-client-log-level"></a>
@@ -975,7 +977,7 @@ default      | `error`
 environment variable | `SENSU_BACKEND_ETCD_CLIENT_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-log-level error{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-client-log-level: "error"{{< /code >}}
 
 | etcd-client-urls      |      |
@@ -991,11 +993,13 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-client-urls 'https://10.0.0.1:2379 https://10.1.0.1:2379'
 sensu-backend start --etcd-client-urls https://10.0.0.1:2379 --etcd-client-urls https://10.1.0.1:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
 {{< /code >}}
+
+<a id="etcd-discovery"></a>
 
 | etcd-discovery        |      |
 ------------------------|------
@@ -1008,10 +1012,12 @@ default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-discovery:
   - https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 {{< /code >}}
+
+<a id="etcd-discovery-srv"></a>
 
 | etcd-discovery-srv    |      |
 ------------------------|------
@@ -1024,7 +1030,7 @@ default                 | ""
 environment variable | `SENSU_BACKEND_ETCD_DISCOVERY_SRV`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-discovery-srv example.org{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-discovery-srv:
   - example.org
 {{< /code >}}
@@ -1036,13 +1042,15 @@ description                        | List of this member's peer URLs to advertis
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
-default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker)
+default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-initial-advertise-peer-urls https://10.0.0.1:2380 --etcd-initial-advertise-peer-urls https://10.1.0.1:2380
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-advertise-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
@@ -1055,11 +1063,13 @@ description            | Initial cluster configuration for bootstrapping.{{% not
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
-default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker)
+default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+**NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
+{{% /notice %}}
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster: "backend-0=https://10.0.0.1:2380,backend-1=https://10.1.0.1:2380,backend-2=https://10.2.0.1:2380"{{< /code >}}
 
 | etcd-initial-cluster-state |      |
@@ -1073,7 +1083,7 @@ default                      | `new`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_STATE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster-state existing{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster-state: "existing"{{< /code >}}
 
 | etcd-initial-cluster-token |      |
@@ -1087,7 +1097,7 @@ default                      | `""`
 environment variable         | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER_TOKEN`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-initial-cluster-token unique_token_for_this_cluster{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-initial-cluster-token: "unique_token_for_this_cluster"{{< /code >}}
 
 | etcd-key-file  |      |
@@ -1100,7 +1110,7 @@ type             | String
 environment variable | `SENSU_BACKEND_ETCD_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 <a id="etcd-listen-client-urls"></a>
@@ -1118,7 +1128,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379 --etcd-listen-client-urls https://10.1.0.1:2379
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-listen-client-urls:
   - https://10.0.0.1:2379
   - https://10.1.0.1:2379
@@ -1137,7 +1147,7 @@ command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380 --etcd-listen-peer-urls https://10.1.0.1:2380
 {{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-listen-peer-urls:
   - https://10.0.0.1:2380
   - https://10.1.0.1:2380
@@ -1153,7 +1163,7 @@ default      | [Backend log level][60] value (or `debug`, if the backend log lev
 environment variable | `SENSU_BACKEND_ETCD_LOG_LEVEL`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-log-level debug{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-log-level: "debug"{{< /code >}}
 
 | etcd-name      |      |
@@ -1167,7 +1177,7 @@ default          | `default`
 environment variable | `SENSU_BACKEND_ETCD_NAME`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-name backend-0{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-name: "backend-0"{{< /code >}}
 
 | etcd-peer-cert-file |      |
@@ -1180,7 +1190,7 @@ type                  | String
 environment variable  | `SENSU_BACKEND_ETCD_PEER_CERT_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-cert-file /path/to/tls/backend-1.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 
 | etcd-peer-client-cert-auth |      |
@@ -1194,7 +1204,7 @@ default                      | `false`
 environment variable         | `SENSU_BACKEND_ETCD_PEER_CLIENT_CERT_AUTH`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-client-cert-auth{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-client-cert-auth: true{{< /code >}}
 
 | etcd-peer-key-file |      |
@@ -1207,7 +1217,7 @@ type                 | String
 environment variable | `SENSU_BACKEND_ETCD_PEER_KEY_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-key-file /path/to/tls/backend-1-key.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 
 | etcd-peer-trusted-ca-file |      |
@@ -1220,7 +1230,7 @@ type                        | String
 environment variable        | `SENSU_BACKEND_ETCD_PEER_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-peer-trusted-ca-file ./ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-peer-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | etcd-trusted-ca-file |      |
@@ -1234,7 +1244,7 @@ default                | `""`
 environment variable   | `SENSU_BACKEND_ETCD_TRUSTED_CA_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-trusted-ca-file ./ca.pem{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 <a id="etcd-unsafe-no-fsync"></a>
@@ -1250,7 +1260,7 @@ default                | `false`
 environment variable   | `SENSU_BACKEND_ETCD_UNSAFE_NO_FSYNC`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-unsafe-no-fsync{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-unsafe-no-fsync: true{{< /code >}}
 
 | no-embed-etcd  |      |
@@ -1264,7 +1274,7 @@ default          | `false`
 environment variable | `SENSU_BACKEND_NO_EMBED_ETCD`
 command line example   | {{< code shell >}}
 sensu-backend start --no-embed-etcd{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 no-embed-etcd: true{{< /code >}}
 
 ### Advanced configuration options
@@ -1284,7 +1294,7 @@ default                | `3000`
 environment variable   | `SENSU_BACKEND_ETCD_ELECTION_TIMEOUT`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-election-timeout 3000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-election-timeout: 3000{{< /code >}}
 
 <a id="etcd-heartbeat-interval"></a>
@@ -1301,7 +1311,7 @@ default                | `300`
 environment variable   | `SENSU_BACKEND_ETCD_HEARTBEAT_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-heartbeat-interval 300{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-heartbeat-interval: 300{{< /code >}}
 
 | etcd-max-request-bytes |      |
@@ -1316,7 +1326,7 @@ default                | `1572864`
 environment variable   | `SENSU_BACKEND_ETCD_MAX_REQUEST_BYTES`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-max-request-bytes 1572864{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-max-request-bytes: 1572864{{< /code >}}
 
 | etcd-quota-backend-bytes |      |
@@ -1331,7 +1341,7 @@ default                | `4294967296`
 environment variable   | `SENSU_BACKEND_ETCD_QUOTA_BACKEND_BYTES`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-quota-backend-bytes 4294967296{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 etcd-quota-backend-bytes: 4294967296{{< /code >}}
 
 | eventd-buffer-size   |      |
@@ -1344,7 +1354,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --eventd-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 eventd-buffer-size: 100{{< /code >}}
 
 | eventd-workers       |      |
@@ -1357,7 +1367,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_EVENTD_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --eventd-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 eventd-workers: 100{{< /code >}}
 
 | keepalived-buffer-size |      |
@@ -1370,7 +1380,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --keepalived-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 keepalived-buffer-size: 100{{< /code >}}
 
 | keepalived-workers |      |
@@ -1382,7 +1392,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_KEEPALIVED_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --keepalived-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 keepalived-workers: 100{{< /code >}}
 
 | pipelined-buffer-size |      |
@@ -1395,7 +1405,7 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --pipelined-buffer-size 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 pipelined-buffer-size: 100{{< /code >}}
 
 | pipelined-workers |      |
@@ -1408,12 +1418,38 @@ default                | `100`
 environment variable   | `SENSU_BACKEND_PIPELINED_WORKERS`
 command line example   | {{< code shell >}}
 sensu-backend start --pipelined-workers 100{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 pipelined-workers: 100{{< /code >}}
 
-## Configuration via environment variables
+## Backend configuration methods
 
-Instead of using configuration flags, you can use environment variables to configure your Sensu backend.
+### Backend configuration file
+
+You can customize the backend configuration in a `.yml` configuration file.
+
+To use the `backend.yml` file to configure the backend, list the desired configuration attributes and values.
+Review the [example Sensu backend configuration file][17] for a complete example.
+
+Configuration via command line flags or environment variables overrides any configuration specified in the backend configuration file.
+Read [Create overrides][74] to learn more.
+
+### Command line flags
+
+You can customize the backend configuration with `sensu-agent start` command line flags.
+
+To use command line flags, specify the desired configuration flags and values along with the `sensu-backend start` command.
+For example:
+
+{{< code shell >}}
+sensu-backend start --deregistration-handler slack_deregister --log-level debug
+{{< /code >}}
+
+Configuration via command line flags overrides attributes specified in a configuration file or with environment variables.
+Read [Create overrides][74] to learn more.
+
+### Environment variables
+
+Instead of using a configuration file or command line flags, you can use environment variables to configure your Sensu backend.
 Each backend configuration flag has an associated environment variable.
 You can also create your own environment variables, as long as you name them correctly and save them in the correct place.
 Here's how.
@@ -1473,7 +1509,7 @@ sudo systemctl restart sensu-backend
 
 {{% notice note %}}
 **NOTE**: Sensu includes an environment variable for each backend configuration flag.
-They are listed in the [configuration flag description tables](#general-configuration-flags).
+They are listed in the [configuration description tables](#general-configuration).
 {{% /notice %}}
 
 ### Format for label and annotation environment variables
@@ -1551,12 +1587,12 @@ spec:
 Read the [secrets reference](https://docs.sensu.io/sensu-go/latest/operations/manage-secrets/secrets/) and [Use Env for secrets management](../../../operations/manage-secrets/secrets-management/#use-env-for-secrets-management) for details.
 {{% /notice %}}
 
-## Create overrides
+## Create configuration overrides
 
 Sensu has default settings and limits for certain configuration attributes, like the default log level.
 Depending on your environment and preferences, you may want to create overrides for these Sensu-specific defaults and limits.
 
-You can create overrides in several ways:
+You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-backend start`.
 - Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
@@ -1616,7 +1652,7 @@ The event logging functionality provides better performance and reliability than
 To write Sensu service logs to flat files on disk, read [Log Sensu services with systemd](../../../operations/monitor-sensu/log-sensu-systemd/).
 {{% /notice %}}
 
-Use these backend configuration flags to customize event logging:
+Use these backend configuration options to customize event logging:
 
 | event-log-buffer-size |      |
 -----------------------|------
@@ -1626,7 +1662,7 @@ default                | 100000
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_SIZE`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-buffer-size 100000{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-buffer-size: 100000{{< /code >}}
 
 | event-log-buffer-wait |      |
@@ -1637,7 +1673,7 @@ default                | 10ms
 environment variable   | `SENSU_BACKEND_EVENT_LOG_BUFFER_WAIT`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-buffer-wait 10ms{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-buffer-wait: 10ms{{< /code >}}
 
 <a id="event-log-file"></a>
@@ -1651,7 +1687,7 @@ type                   | String
 environment variable   | `SENSU_BACKEND_EVENT_LOG_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-file /var/log/sensu/events.log{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-file: "/var/log/sensu/events.log"{{< /code >}}
 
 <a id="event-log-parallel-encoders"></a>
@@ -1664,7 +1700,7 @@ default                | false
 environment variable   | `SENSU_BACKEND_EVENT_LOG_PARALLEL_ENCODERS`
 command line example   | {{< code shell >}}
 sensu-backend start --event-log-parallel-encoders true{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 event-log-parallel-encoders: true{{< /code >}}
 
 ### Log rotation
@@ -1722,7 +1758,7 @@ Sensu appends updated metrics at the interval you specify with the platform-metr
 
 To rotate the platform metrics log, use the same methods as for [event log rotation][63].
 
-Use these backend configuration flags to customize platform metrics logging:
+Use these backend configuration options to customize platform metrics logging:
 
 | disable-platform-metrics |      |
 -----------------------|------
@@ -1732,7 +1768,7 @@ default                | false
 environment variable   | `SENSU_BACKEND_DISABLE_PLATFORM_METRICS`
 command line example   | {{< code shell >}}
 sensu-backend start --disable-platform-metrics false{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 disable-platform-metrics: false{{< /code >}}
 
 | platform-metrics-log-file |      |
@@ -1745,7 +1781,7 @@ default                | /var/log/sensu/sensu-backend/stats.log
 environment variable   | `SENSU_BACKEND_PLATFORM_METRICS_LOG_FILE`
 command line example   | {{< code shell >}}
 sensu-backend start --platform-metrics-log-file /var/log/sensu/sensu-backend/stats.log{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 platform-metrics-log-file: "/var/log/sensu/sensu-backend/stats.log"{{< /code >}}
 
 | platform-metrics-logging-interval |      |
@@ -1756,7 +1792,7 @@ default                | 60s
 environment variable   | `SENSU_BACKEND_PLATFORM_METRICS_LOGGING_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-backend start --platform-metrics-logging-interval 60s{{< /code >}}
-/etc/sensu/backend.yml example | {{< code shell >}}
+backend.yml config file example | {{< code shell >}}
 platform-metrics-logging-interval: 60s{{< /code >}}
 
 ## Service management
@@ -1869,10 +1905,10 @@ sensu-backend start --help
 [9]: ../../observe-filter/filters/
 [10]: ../../observe-transform/mutators/
 [11]: ../../observe-process/handlers/
-[12]: #datastore-and-cluster-configuration-flags
+[12]: #datastore-and-cluster-configuration
 [13]: ../../../operations/deploy-sensu/cluster-sensu/
 [14]: ../../../api/
-[15]: #general-configuration-flags
+[15]: #general-configuration
 [16]: https://etcd.io/docs/current/tuning/#time-parameters
 [17]: ../../../files/backend.yml
 [18]: https://golang.org/pkg/crypto/tls/#pkg-constants
@@ -1909,5 +1945,11 @@ sensu-backend start --help
 [69]: ../../observe-entities/entities/#backend-entities
 [70]: ../../observe-process/pipelines/
 [71]: ../../../guides/
-[72]: #datastore-and-cluster-configuration-flags
+[72]: #datastore-and-cluster-configuration
 [73]: #advanced-configuration-options
+[74]: #create-configuration-overrides
+[75]: #state-dir-option
+[76]: #backend-configuration-file
+[77]: #backend-configuration-options
+[78]: #environment-variables
+[79]: #backend-configuration-methods

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
@@ -215,7 +215,7 @@ Store Flags:
       --etcd-trusted-ca-file string          path to the client server TLS trusted CA cert file
 {{< /code >}}
 
-For more information about the initialization store flags, read [Datastore and cluster configuration flags][72] and [Advanced configuration options][73].
+For more information about the initialization store flags, read [Datastore and cluster configuration][72] and [Advanced configuration options][73].
 
 <a id="ignore-already-initialized"></a>
 
@@ -596,7 +596,7 @@ log-level: "debug"{{< /code >}}
 | metrics-refresh-interval |      |
 -------------|------
 description  | Interval at which Sensu should refresh metrics. In hours, minutes, seconds, or a combination &mdash; for example, `5m`, `1m30s`, and `1h10m30s` are all valid values.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the `metrics-refresh-interval` flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `metrics-refresh-interval` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type         | String
 default      | `1m`
@@ -672,9 +672,9 @@ agent-auth-trusted-ca-file: /path/to/tls/ca.pem{{< /code >}}
 | agent-burst-limit   |      |
 --------------|------
 description   | Maximum amount of burst allowed in a rate interval for agent transport WebSocket connections. {{% notice note %}}
-**NOTE**: The agent-burst-limit flag is deprecated.
+**NOTE**: The `agent-burst-limit` configuration flag is deprecated.
 {{% /notice %}} {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-burst-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-burst-limit` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer
 default       | `null`
@@ -711,7 +711,7 @@ agent-port: 8081{{< /code >}}
 | agent-rate-limit   |      |
 --------------|------
 description   | Maximum number of agent transport WebSocket connections per second, per backend.{{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-rate-limit flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-rate-limit` configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 type          | Integer
 default       | `null`
@@ -725,7 +725,7 @@ agent-rate-limit: 10{{< /code >}}
 
 | cert-file  |      |
 -------------|------
-description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the flag `dashboard-cert-file` is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
+description  | Path to the primary backend certificate file. Specifies a fallback SSL/TLS certificate if the `dashboard-cert-file` configuration option is not used. This certificate secures communications between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API. Sensu supports certificate bundles (or chains) as long as the server (or leaf) certificate is the *first* certificate in the bundle.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_CERT_FILE`
@@ -737,7 +737,7 @@ cert-file: "/path/to/tls/backend-1.pem"{{< /code >}}
 | insecure-skip-tls-verify |      |
 ---------------------------|------
 description                | If `true`, skip SSL verification. Otherwise, `false`. {{% notice warning %}}
-**WARNING**: This configuration flag is intended for use in development systems only. Do not use this flag in production.
+**WARNING**: This configuration option is intended for use in development systems only. Do not use this configuration option in production.
 {{% /notice %}}
 type                       | Boolean
 default                    | `false`
@@ -778,7 +778,7 @@ jwt-public-key-file: /path/to/key/public.pem{{< /code >}}
 
 | key-file   |      |
 -------------|------
-description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the flag `dashboard-key-file` is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
+description  | Path to the primary backend key file. Specifies a fallback SSL/TLS key if the `dashboard-key-file` configuration option is not used. This key secures communication between the Sensu web UI and end user web browsers, as well as communication between sensuctl and the Sensu API.
 type         | String
 default      | `""`
 environment variable | `SENSU_BACKEND_KEY_FILE`
@@ -792,7 +792,7 @@ key-file: "/path/to/tls/backend-1-key.pem"{{< /code >}}
 | require-fips |      |
 ------------------|------
 description       | Require Federal Information Processing Standard (FIPS) support in OpenSSL. Logs an error at Sensu backend startup if `true` but OpenSSL is not running in FIPS mode. {{% notice note %}}
-**NOTE**: The `--require-fips` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `require-fips` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean
@@ -806,7 +806,7 @@ require-fips: true{{< /code >}}
 | require-openssl |      |
 ------------------|------
 description       | Use OpenSSL instead of Go's standard cryptography library. Logs an error at Sensu backend startup if `true` but Go's standard cryptography library is loaded. {{% notice note %}}
-**NOTE**: The `--require-openssl` flag is only available within the Linux amd64 OpenSSL-linked binary.
+**NOTE**: The `--require-openssl` configuration option is only available within the Linux amd64 OpenSSL-linked binary.
 [Contact Sensu](https://sensu.io/contact) to request the builds for OpenSSL with FIPS support.
 {{% /notice %}}
 type              | Boolean

--- a/content/sensu-go/6.7/operations/control-access/rbac.md
+++ b/content/sensu-go/6.7/operations/control-access/rbac.md
@@ -169,7 +169,7 @@ By default, the `agent` user belongs to the `system:agent` group.
 The `system:agent` cluster role binding grants the `system:agent` cluster role to the members of this group.
 To grant agent users the permissions they need to report events into any namespace, add agent users to the `system:agent` group.
 
-Configure the `agent` user's credentials with the [`user` and `password` agent configuration flags][41].
+Configure the `agent` user's credentials with the [`user`][41] and [`password`][68] agent configuration options.
 
 ### View users
 
@@ -3280,7 +3280,7 @@ type: Group
 [38]: ../../../observability-pipeline/observe-schedule/rule-templates/
 [39]: ../ad-auth/#ad-groups-prefix
 [40]: ../../deploy-sensu/etcdreplicators/
-[41]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
+[41]: ../../../observability-pipeline/observe-schedule/agent/#agent-password-option
 [42]: ../../deploy-sensu/install-sensu/#install-the-sensu-backend
 [43]: ../../../observability-pipeline/observe-process/sumo-logic-metrics-handlers/
 [44]: ../../../observability-pipeline/observe-process/tcp-stream-handlers/
@@ -3307,3 +3307,5 @@ type: Group
 [65]: #spec-attributes-for-role-binding-and-cluster-role-binding-resources
 [66]: #role_ref-attributes
 [67]: #subjects-attributes
+[68]: ../../../observability-pipeline/observe-schedule/agent/#agent-user-option
+[68]: ../../../observability-pipeline/observe-schedule/agent/#agent-user-option

--- a/content/sensu-go/6.7/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/deployment-architecture.md
@@ -158,7 +158,6 @@ Under normal conditions, sensuctl communications and browser access to the web U
 
 [1]: ../hardware-requirements/#backend-recommended-configuration
 [2]: ../../../api/
-[3]: ../../../observability-pipeline/observe-schedule/agent/#general-configuration-flags
 [4]: https://etcd.io/docs/
 [5]: https://etcd.io/docs/current/op-guide/security/
 [6]: ../secure-sensu/

--- a/content/sensu-go/6.7/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/install-sensu.md
@@ -560,7 +560,7 @@ sensuctl license info
 [4]: ../../../sensuctl/
 [5]: ../../../platforms/
 [6]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
-[7]: ../../../observability-pipeline/observe-schedule/agent#configuration-via-flags
+[7]: ../../../observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [8]: ../secure-sensu/
 [9]: ../../../observability-pipeline/observe-schedule/monitor-server-resources/
 [10]: ../../../observability-pipeline/observe-process/send-slack-alerts/

--- a/content/sensu-go/6.7/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/secure-sensu.md
@@ -76,7 +76,7 @@ etcd-peer-client-cert-auth: "true"
    Because etcd does not require authentication by default, you must set the `etcd-client-cert-auth` and `etcd-peer-client-cert-auth` parameters to `true` to secure Sensu's embedded etcd datastore against unauthorized access.
 
 {{% notice note %}}
-**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags) includes more information about each etcd store parameter.
+**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration) includes more information about each etcd store parameter.
 {{% /notice %}}
 
 ## Secure the Sensu agent API, HTTP API, and web UI
@@ -118,7 +118,7 @@ After you restart the `sensu-backend` service, the parameters will load and you 
 Configuring these attributes will also ensure that agents can communicate securely.
 
 {{% notice note %}}
-**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#security-configuration-flags) includes more information about each API and web UI security configuration parameter.
+**NOTE**: The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#security-configuration) includes more information about each API and web UI security configuration parameter.
 {{% /notice %}}
 
 ### Specify a separate web UI certificate and key
@@ -135,7 +135,7 @@ dashboard-key-file: "/etc/sensu/tls/separate-webui-key.pem"
 
 {{% notice note %}}
 **NOTE**: If you do not specify a separate certificate and key for the web UI with `dashboard-cert-file` and `dashboard-key-file`, Sensu uses the certificate and key specified for the `cert-file` and `key-file` parameters for the web UI.
-The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#web-ui-configuration-flags) includes more information about the `dashboard-cert-file` and `dashboard-key-file` web UI configuration parameters.
+The [Sensu backend reference](../../../observability-pipeline/observe-schedule/backend/#web-ui-configuration) includes more information about the `dashboard-cert-file` and `dashboard-key-file` web UI configuration parameters.
 {{% /notice %}}
 
 ## Secure Sensu agent-to-server communication
@@ -262,7 +262,6 @@ The last step before you deploy Sensu is to [set up a Sensu cluster][10].
 [3]: ../../control-access/rbac/
 [4]: ../generate-certificates/#create-a-certificate-authority-ca
 [6]: https://etcd.io/docs/latest/op-guide/security/
-[7]: ../../../observability-pipeline/observe-schedule/agent/#security-configuration-flags
 [9]: https://github.com/cloudflare/cfssl
 [10]: ../cluster-sensu/
 [12]: ../generate-certificates/

--- a/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
@@ -243,7 +243,7 @@ api-port: 3031
 socket-port: 3030
 {{< /code >}}
 
-You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` flags.
+You can also disable these features in the agent configuration using the `disable-socket` and `disable-api` configuration options.
 
 Sensu should now be installed and functional.
 The next step is to translate your Sensu Core configuration to Sensu Go.

--- a/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
@@ -235,7 +235,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
 Read the [installation guide][55] to install, configure, and start Sensu agents.
 
-If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml`).
+If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml` or `C:\ProgramData\sensu\config\agent.yml.example`).
 This prevents the Sensu Go agent API and socket from conflicting with the Sensu Core client API and socket.
 
 {{< code yml >}}
@@ -584,7 +584,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [53]: ../../deploy-sensu/install-sensu#install-sensuctl
 [54]: ../../control-access/rbac/#resources
 [55]: ../../deploy-sensu/install-sensu#install-sensu-agents
-[56]: ../../../observability-pipeline/observe-schedule/agent#configuration-via-flags
+[56]: ../../../observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [57]: ../../../observability-pipeline/observe-schedule/collect-metrics-with-checks/
 [58]: ../../../observability-pipeline/observe-schedule/checks#metadata-attributes
 [59]: https://bonsai.sensu.io/assets?q=eventfilter

--- a/content/sensu-go/6.7/operations/maintain-sensu/tune.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/tune.md
@@ -21,14 +21,14 @@ These pages describe common problems and solutions, planning and optimization co
 
 If you use embedded etcd for storage, you might notice high network or storage latency.
 
-To make etcd more latency-tolerant, increase the values for the [etcd election timeout][1] and [etcd heartbeat interval][2] backend configuration flags.
+To make etcd more latency-tolerant, increase the values for the [`etcd election timeout`][1] and [`etcd heartbeat interval`][2] backend configuration options.
 For example, you might increase `etcd-election-timeout` from 3000 to 5000 and `etcd-heartbeat-interval` from 300 to 500.
 
 Read the [etcd tuning documentation][3] for etcd-specific tuning best practices.
 
 ## Advanced backend configuration options for etcd
 
-The [backend reference][11] describes other advanced configuration flags in addition to etcd election timeout and heartbeat interval.
+The [backend reference][11] describes other advanced configuration options in addition to etcd election timeout and heartbeat interval.
 
 Adjust these values with caution.
 Improper adjustment can increase memory and CPU usage or result in a non-functioning Sensu instance.
@@ -50,16 +50,16 @@ Read the [PostgreSQL parameters documentation][5] for information about setting 
 ## Agent reconnection rate
 
 {{% notice commercial %}}
-**COMMERCIAL FEATURE**: Access the agent-rate-limit backend configuration flag in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
+**COMMERCIAL FEATURE**: Access the `agent-rate-limit` backend configuration option in the packaged Sensu Go distribution. For more information, read [Get started with commercial features](../../../commercial/).
 {{% /notice %}}
 
 It may take several minutes for all agents to reconnect after a sensu-backend restart, especially if you have a large number of agents.
 The agent reconnection rate depends on deployment variables like the number of CPUs, disk space, network speeds, whether you're using a load balancer, and even physical distance between agents and backends.
 
 Although many variables affect the agent reconnection rate, a reasonable estimate is approximately 100 agents per backend per second.
-If you observe slower agent reconnection rates in your Sensu deployment, consider using the [agent-rate-limit][14] backend configuration flag.
+If you observe slower agent reconnection rates in your Sensu deployment, consider using the [`agent-rate-limit`][14] backend configuration option.
 
-The [agent-rate-limit][14] backend configuration flag allows you to set the maximum number of agent transport WebSocket connections per second, per backend.
+The [`agent-rate-limit`][14] backend configuration option allows you to set the maximum number of agent transport WebSocket connections per second, per backend.
 Set the agent-rate-limit to 100 to improve agent reconnection rate and reduce the time required for all of your agents to reconnect after a backend restart.
 
 ## Splay and proxy check scheduling

--- a/content/sensu-go/6.7/platforms.md
+++ b/content/sensu-go/6.7/platforms.md
@@ -183,7 +183,7 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.7.3/sensu-go_6.7
 
 Builds that support the Federal Information Processing Standard (FIPS) for Federal Risk and Authorization Management Program (FedRAMP) compliance are available for Linux `amd64`.
 
-Sensu FIPS builds with [FIPS-mode configuration flags][51] are linked with the FIPS 140-2 validated cryptographic library.
+Sensu FIPS builds with [FIPS-mode configuration options][51] are linked with the FIPS 140-2 validated cryptographic library.
 You can run Red Hat Enterprise Linux (RHEL) with the FIPS-mode kernel option to enforce FIPS systemwide &mdash; Sensu FIPS builds comply with this mode.
 
 [Contact Sensu][50] to request builds with FIPS support.

--- a/content/sensu-go/6.7/plugins/assets.md
+++ b/content/sensu-go/6.7/plugins/assets.md
@@ -1310,7 +1310,7 @@ You must remove the archive and downloaded files from the asset cache manually.
 [37]: https://bonsai.sensu.io/sign-in
 [38]: https://bonsai.sensu.io/new
 [39]: ../../web-ui/search#search-for-labels
-[40]: ../../observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[40]: ../../observability-pipeline/observe-schedule/agent/#assets-burst-limit
 [41]: ../../observability-pipeline/observe-schedule/backend/#configuration-via-flags
 [42]: #filters-attribute
 [43]: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime

--- a/content/sensu-go/6.7/plugins/assets.md
+++ b/content/sensu-go/6.7/plugins/assets.md
@@ -296,14 +296,14 @@ When Sensu finds a matching build, it downloads the build artifact from the spec
 If the asset definition includes headers, they are passed along as part of the HTTP request.
 If the downloaded artifact's SHA512 checksum matches the checksum provided by the build, it is unpacked into the Sensu service's local cache directory.
 
-Set the backend or agent's local cache path with the `--cache-dir` flag.
-Disable dynamic runtime assets for an agent with the agent `--disable-assets` [configuration flag][30].
+Set the backend or agent's local cache path with the `cache-dir` configuration option.
+Disable dynamic runtime assets for an agent with the agent [`disable-assets`][30] configuration option.
 
 {{% notice note %}}
-**NOTE**: Dynamic runtime asset builds are unpacked into the cache directory that is configured with the `--cache-dir` flag.
+**NOTE**: Dynamic runtime asset builds are unpacked into the cache directory that is configured with the `cache-dir` configuration option.
 {{% /notice %}}
 
-Use the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][40] and [backend][41] to configure a global rate limit for fetching dynamic runtime assets.
+Use the `assets-rate-limit` and `assets-burst-limit` configuration options for the [agent][40] and [backend][41] to configure a global rate limit for fetching dynamic runtime assets.
 
 ### Dynamic runtime asset build execution
 

--- a/content/sensu-go/6.7/release-notes.md
+++ b/content/sensu-go/6.7/release-notes.md
@@ -179,7 +179,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.7.0.
 
 - ([Commercial feature][268]) Added the [Sensu Catalog][269], an online marketplace for monitoring and observability integrations that allows you to find, configure, and install integrations directly from the Sensu [web UI][270].
 - Added [metric threshold evaluation][285] to provide real-time alerts based on the metrics your Sensu checks collect.
-- Added the [keepalive-pipelines][276] agent configuration flag, which allows you to specify [pipelines][275] for processing keepalive events. 
+- Added the [`keepalive-pipelines`][276] agent configuration option, which allows you to specify [pipelines][275] for processing keepalive events. 
 - Added the check [`subdues` attribute][277], which you can use to schedule alert-free periods of time directly in check definitions.
 
 **IMPROVEMENTS:**
@@ -193,7 +193,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.7.0.
 - The [`sensu.CheckDependencies`][284] Sensu query expression now supports arrays of strings and arrays of objects.
 - On backend startup, Sensu now creates the [`sensu-system` namespace][279] and a [backend entity][278] to log secrets provider errors and help prevent spamming the event bus with backend events.
 - For connections with faulty TLS configurations, error log entries now include a `source` property that lists the corresponding agent's IP address and port to identify which agent generated each log entry for troubleshooting.
-- Increased the default values for the backend configuration flags [etcd-election-timeout][272] (from 1000 to 3000) and [etcd-heartbeat-interval][273] (from 100 to 300).
+- Increased the default values for the backend configuration options [etcd-election-timeout][272] (from 1000 to 3000) and [etcd-heartbeat-interval][273] (from 100 to 300).
 - Upgraded etcd version from `3.5.0` to `3.5.2`.
 
 **FIXES:**
@@ -271,7 +271,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.6.4.
 
 **December 16, 2021** &mdash; The latest release of Sensu Go, version 6.6.3, is now available for download.
 
-Sensu Go 6.6.3 includes improvements to reduce load on clusters and support cluster recovery, as well as a backend configuration flag for specifying the internal etcd client log level. Fixes in this patch release will help prevent backend crashes when keepalive leases are revoked and when the backend cannot write to the event log file. In addition, this patch fixes issues that could result in a leaked etcd lease and keep the backend from terminating correctly.
+Sensu Go 6.6.3 includes improvements to reduce load on clusters and support cluster recovery, as well as a backend configuration option for specifying the internal etcd client log level. Fixes in this patch release will help prevent backend crashes when keepalive leases are revoked and when the backend cannot write to the event log file. In addition, this patch fixes issues that could result in a leaked etcd lease and keep the backend from terminating correctly.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.6.3.
 
@@ -279,9 +279,9 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.6.3.
 
 - ([Commercial feature][259]) In the web UI, the default polling interval on the [entities page][261] is now 30 seconds to help reduce load on clusters. Search results for entities are limited to the first 500 matching entities. Also, the web UI response time and memory usage is substantially improved when opening the entities page in the default state (loading the first page of results, with no search filter applied).
 - ([Commercial feature][259]) In the web UI, for instances that use etcd for event storage, search results for events are limited to 25,000 matching events.
-- Added the [etcd-client-log-level][262] configuration flag for setting the log level of the etcd client used internally within sensu-backend.
+- Added the [`etcd-client-log-level`][262] configuration option for setting the log level of the etcd client used internally within sensu-backend.
 - The agentd daemon now starts up after all other daemons, which improves cluster recovery after the loss of a backend.
-- When using external etcd (the no-embed-etcd backend configuration flag is set to `true`), sensu-backend now crashes when its daemons do not stop within 30 seconds, which can happen due to an intentional shutdown or when database unavailability triggers an internal restart.
+- When using external etcd (the `no-embed-etcd` backend configuration option is set to `true`), sensu-backend now crashes when its daemons do not stop within 30 seconds, which can happen due to an intentional shutdown or when database unavailability triggers an internal restart.
 When using embedded etcd, sensu-backend will still try to avoid crashing to prevent member corruption.
 
 **FIXES**
@@ -350,13 +350,13 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.6.0.
 
 **November 22, 2021** &mdash; The latest release of Sensu Go, version 6.5.5, is now available for download.
 
-The Sensu Go 6.5.5 patch release adds two backend configuration flags for configuring the API and web UI HTTP servers' write timeouts and three new GraphQL duration metrics for the metrics log. This release also delivers several bug fixes, including fixes for sensu-backend and sensu-agent panics and failed keepalive lease grant operations.
+The Sensu Go 6.5.5 patch release adds two backend configuration options for configuring the API and web UI HTTP servers' write timeouts and three new GraphQL duration metrics for the metrics log. This release also delivers several bug fixes, including fixes for sensu-backend and sensu-agent panics and failed keepalive lease grant operations.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.5.5.
 
 **IMPROVEMENTS**
-- Added the [api-write-timeout][256] and [dashboard-write-timeout][257] backend configuration flags.
-These flags allow you to configure the timeout for the respective HTTP servers' response writes, which is helpful when requests might take more than a few seconds to complete.
+- Added the [api-write-timeout][256] and [dashboard-write-timeout][257] backend configuration options.
+These options allow you to configure the timeout for the respective HTTP servers' response writes, which is helpful when requests might take more than a few seconds to complete.
 - Added graphql_duration_seconds, graphql_duration_seconds_sum, and graphql_duration_seconds_count to the [metrics log][238]. Also added objectives (0.5, 0.9, 0.99) to the graphql_duration_seconds metric.
 - Added Prometheus metrics for tracking lease operations, with labels for operation type and status, and added sensu_go_lease_ops to the [metrics log][238].
 
@@ -475,16 +475,16 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.5.0.
 - New [pipelines][233] resource allows you to specify event filters, mutators, and handlers in a single workflow instead of listing filters and mutators in handler definitions. You can reference pipelines in your check definitions. The [`/pipelines` API endpoint][234] provides HTTP access for retrieving pipeline data and configuring pipelines, and you can use [sensuctl][235] to manage pipelines. [Upgrade your Sensu agents][1] to Sensu Go 6.5.0 to use pipelines resources.
 - [JavaScript mutators][246] are now available. JavaScript mutators are evaluated by the Otto JavaScript VM as JavaScript programs, which enables greater throughput at scale than pipe mutators.
 - Check definitions now include the [pipelines attribute][236] for specifying pipeline resources to use for the check's observability events.
-- Added [platform metrics logging][238] to log core Sensu metrics in InfluxDB Line Protocol format, along with the `disable-platform-metrics`, `platform-metrics-log-file`, and `platform-metrics-logging-interval` backend configuration flags for managing the platform metrics logging feature.
+- Added [platform metrics logging][238] to log core Sensu metrics in InfluxDB Line Protocol format, along with the `disable-platform-metrics`, `platform-metrics-log-file`, and `platform-metrics-logging-interval` backend configuration options for managing the platform metrics logging feature.
 - [Event logging][237] is no longer a commercial-only feature.
 - You can now set sensuctl environment variables for a [single sensuctl command][243] or with [sensuctl configure][244].
 
 **IMPROVEMENTS:**
 
-- Added environment variables `SENSU_BACKEND_ETCD_CLIENT_USERNAME` and `SENSU_BACKEND_ETCD_CLIENT_PASSWORD` for [connecting to external etcd via username and password authentication][245] instead of certificate authentication. There are no corresponding configuration flags &mdash; these configuration options must be set via environment variables.
+- Added environment variables `SENSU_BACKEND_ETCD_CLIENT_USERNAME` and `SENSU_BACKEND_ETCD_CLIENT_PASSWORD` for [connecting to external etcd via username and password authentication][245] instead of certificate authentication. There are no corresponding command line flags &mdash; these configuration options must be set via environment variables.
 - You can now add an [API key][248] when you initialize the backend to make automated cluster setup and deployment more straightforward.
 - Events now include the name of the agent that processed the event in the [`processed_by` attribute][251] to help you determine which agent processed an event executed by a proxy check request or a POST request to the events API.
-- Added the [`ignore-already-initialized` backend flag][253], which you can use to suppress the "already initialized" response and return an exit code 0 if a cluster has already been initialized.
+- Added the [`ignore-already-initialized`][253] backend configuration option, which you can use to suppress the "already initialized" response and return an exit code 0 if a cluster has already been initialized.
 - Upgraded Go version from 1.16.5 to 1.17.1.
 
 **SECURITY:**
@@ -598,7 +598,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.3.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][207]) Added [business service monitoring (BSM)][210] to provide high-level visibility into the current health of any number of business services, with a [built-in aggregate check rule template][211].
-- ([Commercial feature][207]) Added support for agent transport rate limiting via [`agent-burst-limit`][208] and [`agent-rate-limit`][209] backend configuration flags.
+- ([Commercial feature][207]) Added support for agent transport rate limiting via [`agent-burst-limit`][208] and [`agent-rate-limit`][209] backend configuration options.
 - ([Commercial feature][207]) Added the `event-log-buffer-wait` backend configuration flag, which allows you to specify how long the event logger will wait for the writer to consume events from the buffer when the buffer is full.
 - Added the entity class [service][213], which represents a business service for the business service monitoring (BSM) feature.
 
@@ -841,7 +841,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.1.0.
 - ([Commercial feature][172]) Added the [Sensu SaltStack Enterprise Handler][183] for launching
 SaltStack Enterprise Jobs for automated remediation.
 - ([Commercial feature][172]) The Alpine-based Docker image now has multi-architecture support with support for the linux/386, linux/amd64, linux/arm64, linux/arm/v6, linux/arm/v7, linux/ppc64le, and linux/s390x platforms.
-- The backend flag [`--api-request-limit`][173] is now available to configure the maximum API request body size (in bytes).
+- The backend configuration option [`api-request-limit`][173] is now available to configure the maximum API request body size (in bytes).
 - In the [REST API][174], most configuration resources now support the PATCH method for making updates.
 - Added new handler and check plugins: [Sensu Go Elasticsearch Handler][184], [Sensu Rundeck Handler][185], and [Sensu Kubernetes Events Check][186].
 
@@ -1010,7 +1010,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.21.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][158]) Added [entity count and limit][156] for each entity class in the tabular title in the response for `sensuctl license info` (in addition to the total entity count and limit).
-- ([Commercial feature][158]) Added Linux amd64 OpenSSL-linked binaries for the Sensu agent and backend, with accompanying `--require-fips` and `--require-openssl` flags for the [agent][161] and [backend][160].
+- ([Commercial feature][158]) Added Linux amd64 OpenSSL-linked binaries for the Sensu agent and backend, with accompanying `require-fips` and `require-openssl` configuration options for the [agent][161] and [backend][160].
 - Added `sensuctl user hash-password` command to generate password hashes.
 - Added the ability to reset passwords via the backend API and `sensuctl user reset-password`.
 
@@ -1071,9 +1071,9 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
+- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` option to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
-- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
+- ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration option for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
 - ([Commercial feature][141]) Added a PostgreSQL metrics suite so metricsd can collect metrics about events stored in PostgreSQL.
 - ([Commercial feature][141]) Added [entity class limits][151] to the license.
@@ -1136,7 +1136,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
-- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-burst-limit` and `--assets-rate-limit` flags for the [agent][136] and [backend][137].
+- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `assets-burst-limit` and `assets-rate-limit` configuration options for the [agent][136] and [backend][137].
 - Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
@@ -1306,7 +1306,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.17.0.
 **NEW FEATURES:**
 
 - ([Commercial feature][106]) Added [HTTP API for secrets management][108], with Sensu's `Env` secrets provider and support for HashiCorp Vault secrets management. The secrets provider resource is implemented for checks, mutators, and handlers.
-- Added the `keepalive-handlers` agent configuration flag to specify the keepalive handlers to use for an entity's events.
+- Added the `keepalive-handlers` agent configuration option to specify the keepalive handlers to use for an entity's events.
 
 **IMPROVEMENTS:**
 
@@ -1350,7 +1350,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.16.1.
 **December 16, 2019** &mdash; The latest release of Sensu Go, version 5.16.0, is now available for download.
 This is another important release, with many new features, improvements, and fixes.
 We introduced an initialization subcommand for **new** installations that allows you to specify an admin username and password instead of using a pre-defined default.
-We also added new backend flags to help you take advantage of etcd auto-discovery features and agent flags you can use to define a timeout period for critical and warning keepalive events.
+We also added new backend configuration options to help you take advantage of etcd auto-discovery features and agent configuration options you can use to define a timeout period for critical and warning keepalive events.
 
 New web UI features include a switcher that makes it easier to switch between namespaces in the dashboard, breadcrumbs on every page, OIDC authentication in the dashboard, a drawer that replaces the app bar to make more room for content, and more.
 
@@ -1367,11 +1367,11 @@ Users will need to [run 'sensu-backend init'][102] on every new installation and
 
 - ([Commercial feature][105]) Users can now authenticate with OIDC in the dashboard.
 - ([Commercial feature][105]) Label selectors now match the event's check and entity labels.
-- Added a new flag,`--etcd-client-urls`, which should be used with sensu-backend when it is not operating as an etcd member.
-The flag is also used by the new `sensu-backend init` subcommand.
+- Added a new configuration option, `etcd-client-urls`, to use with sensu-backend when it is not operating as an etcd member.
+The configuration option is also used by the new `sensu-backend init` subcommand.
 - Added the ['sensu-backend init' subcommand][102].
-- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][292] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
-- Added [`--keepalive-critical-timeout`][101] to define the time after which a critical keepalive event should be created for an agent and [`--keepalive-warning-timeout`][101], which is an alias of `--keepalive-timeout` for backward compatibility.
+- Added the [`etcd-discovery`][100] and [`etcd-discovery-srv`][292] configuration options to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
+- Added the [`keepalive-critical-timeout`][101] configuration option to define the time after which a critical keepalive event should be created for an agent and the [`keepalive-warning-timeout`][101] configuration option, which is an alias of `keepalive-timeout` for backward compatibility.
 
 **IMPROVEMENTS:**
 
@@ -1655,7 +1655,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.11.0.
 Read the [sensuctl reference][72] for more information.
 - Assets now include a `headers` attribute to include HTTP headers in requests to retrieve assets, allowing you to access secured assets.
 Read the [asset reference][70] for examples.
-- Sensu agents now support the `disable-assets` configuration flag, allowing you to disable asset retrieval for individual agents.
+- Sensu agents now support the `disable-assets` configuration option, allowing you to disable asset retrieval for individual agents.
 Read the [agent reference][71] for examples.
 - Sensu [binary-only distributions][69] are now available as zip files.
 
@@ -1762,7 +1762,7 @@ If you're upgrading a Sensu cluster from 5.7.0 or earlier, read the [instruction
 Read the [web UI docs][54] to get started using the Sensu web UI.
 - ([Commercial feature][53]) Manage your Sensu event handlers from your browser: Sensu's web UI now supports creating, editing, and deleting handlers.
 Read the [web UI docs][54] to get started using the Sensu web UI.
-- ([Commercial feature][53]) Sensu now supports event logging to a file using the `event-log-file` and `event-log-buffer-size` configuration flags.
+- ([Commercial feature][53]) Sensu now supports event logging to a file using the `event-log-file` and `event-log-buffer-size` configuration options.
 You can use this event log file as an input source for your favorite data lake solution.
 Read the [backend reference][55] for more information.
 
@@ -1933,7 +1933,7 @@ Read the [/metrics API documentation][31] for more information.
 **IMPROVEMENTS:**
 
 - Sensu now lets you specify a separate TLS certificate and key to secure the dashboard.
-Read the [backend reference][24] to configure the `dashboard-cert-file` and `dashboard-key-file` flags, and check out the [guide to securing Sensu][25] for the complete guide to making your Sensu instance production-ready.
+Read the [backend reference][24] to configure the `dashboard-cert-file` and `dashboard-key-file` options, and check out the [guide to securing Sensu][25] for the complete guide to making your Sensu instance production-ready.
 - The Sensu agent events API now queues events before sending them to the backend, making the agent events API more robust and preventing data loss in the event of a loss of connection with the backend or agent shutdown.
 Read the [agent reference][26] for more information.
 
@@ -1980,7 +1980,7 @@ You can now use the dashboard to review check details like command, subscription
 
 - Sensu Go 5.3.0 fixes all known TLS vulnerabilities affecting the backend, including increasing the minimum supported TLS version to 1.2 and removing all ciphers except those with perfect forward secrecy.
 - Sensu now enforces uniform TLS configuration for all three backend components: `apid`, `agentd`, and `dashboardd`.
-- The backend no longer requires the `trusted-ca-file` flag when using TLS.
+- The backend no longer requires the `trusted-ca-file` configuration option when using TLS.
 - The backend no longer loads server TLS configuration for the HTTP client.
 
 **FIXES:**
@@ -2104,7 +2104,7 @@ Read the [upgrade guide][3] for more information.
 
 **NEW FEATURES:**
 
-- Sensu [agents][4] now include `trusted-ca-file` and `insecure-skip-tls-verify` configuration flags, giving you more flexibility with certificates when connecting agents to the backend over TLS.
+- Sensu [agents][4] now include `trusted-ca-file` and `insecure-skip-tls-verify` configuration options, giving you more flexibility with certificates when connecting agents to the backend over TLS.
 
 **IMPROVEMENTS:**
 

--- a/content/sensu-go/6.7/release-notes.md
+++ b/content/sensu-go/6.7/release-notes.md
@@ -340,7 +340,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.6.0.
 - ([Commercial feature][259]) The web UI now supports ANSI color codes, which improves check output readability when it includes color.
 - ([Commercial feature][259]) Added support for sorting for the PostgreSQL event store. In addition, GraphQL can now use the PostgreSQL event store to sort events and get the total event count.
 - Logged metrics now include a backend label. This makes it possible to associate metrics from the [metrics log][258] file with the backend they were generated on.
-- Sensu no longer applies zero values for [etcd configuration flags][260]. This prevents overwriting the etcd-provided default values with null, zero, slice, or empty values.
+- Sensu no longer applies zero values for [etcd configuration options][260]. This prevents overwriting the etcd-provided default values with null, zero, slice, or empty values.
 
 **FIXES**
 - When sensu-go cannot connect to etcd, the connection error is now logged along with context errors.
@@ -718,7 +718,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.2.1.
 - ([Commercial feature][193]) In the web UI, fixed a bug that allowed users to edit Sensu [agent-managed entities][204].
 - Fixed a bug that generated a small amount of extra etcd or PostgreSQL traffic upon keepalive failure.
 - In silenced entries, the `expire` field now represents the configured number of seconds until the entry should be deleted rather than the entry's remaining duration.
-- Labels and annotations can now be configured with [flags][205] for sensu-agent.
+- Labels and annotations are now [configuration options][205] for sensu-agent.
 
 ## 6.2.0 release notes
 
@@ -1071,7 +1071,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.20.0.
 
 **NEW FEATURES:**
 
-- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration flags][142] to populate the `processes` field in entity.system if enabled.
+- ([Commercial feature][141]) Added a [`processes` field ][143] to the system type to store agent local processes for entities and events and a `discover-processes` flag to the [agent configuration options][142] to populate the `processes` field in entity.system if enabled.
 - ([Commercial feature][141]) Added a new resource, `GlobalConfig`, that you can use to [customize your web UI configuration][148].
 - ([Commercial feature][141]) Added metricsd to collect metrics for the [web UI][153] and the [`metrics-refresh-interval`][224] backend configuration flag for setting the interval at which Sensu should refresh metrics.
 - ([Commercial feature][141]) Added process and additional system information to the entity details view in the [web UI][153].
@@ -1136,7 +1136,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.19.3.
 
 - In the [web UI][135], color-blindness modes are now available.
 - In the [web UI][135], labels and annotations with links to images will now be displayed inline.
-- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-rate-limit` and `--assets-burst-limit` flags for the [agent][136] and [backend][137].
+- Adds a global rate limit for fetching assets to prevent abusive asset retries, which you can configure with the `--assets-burst-limit` and `--assets-rate-limit` flags for the [agent][136] and [backend][137].
 - Adds support for restarting the backend via SIGHUP.
 - Adds a timeout flag to `sensu-backend init`.
 - Deprecated flags for `sensuctl silenced update` subcommand have been removed.
@@ -1370,7 +1370,7 @@ Users will need to [run 'sensu-backend init'][102] on every new installation and
 - Added a new flag,`--etcd-client-urls`, which should be used with sensu-backend when it is not operating as an etcd member.
 The flag is also used by the new `sensu-backend init` subcommand.
 - Added the ['sensu-backend init' subcommand][102].
-- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][100] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
+- Added the [`--etcd-discovery`][100] and [`--etcd-discovery-srv`][292] flags to sensu-backend, which allow users to take advantage of the embedded etcd's auto-discovery features.
 - Added [`--keepalive-critical-timeout`][101] to define the time after which a critical keepalive event should be created for an agent and [`--keepalive-warning-timeout`][101], which is an alias of `--keepalive-timeout` for backward compatibility.
 
 **IMPROVEMENTS:**
@@ -2175,7 +2175,7 @@ To get started with Sensu Go:
 [26]: /sensu-go/5.4/observability-pipeline/observe-schedule/agent/#events-post
 [27]: /sensu-go/5.5/operations/monitor-sensu/tessen/
 [28]: https://sensu.io/blog/announcing-tessen-the-sensu-call-home-service/
-[29]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[29]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#general-configuration
 [30]: /sensu-go/5.5/observability-pipeline/observe-schedule/agent/#creating-monitoring-events-using-the-agent-tcp-and-udp-sockets
 [31]: /sensu-go/5.4/api/other/metrics/
 [32]: /sensu-go/5.6/web-ui/
@@ -2186,7 +2186,7 @@ To get started with Sensu Go:
 [37]: /sensu-go/5.6/operations/control-access/
 [38]: /sensu-go/5.6/operations/control-access/ldap-auth/#ldap-binding-attributes
 [39]: /sensu-go/5.6/operations/control-access/ad-auth/#ad-binding-attributes
-[40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[40]: /sensu-go/5.6/observability-pipeline/observe-schedule/agent/#general-configuration
 [41]: /sensu-go/5.7/operations/deploy-sensu/install-sensu/#install-sensu-agents
 [42]: /sensu-go/5.7/observability-pipeline/observe-schedule/agent/
 [43]: /sensu-go/5.7/api/#response-filtering
@@ -2246,8 +2246,8 @@ To get started with Sensu Go:
 [97]: https://bonsai.sensu.io/assets/sensu/sensu-servicenow-handler/
 [98]: https://bonsai.sensu.io/assets/sensu/sensu-jira-handler/
 [99]: /sensu-go/5.2/commercial/
-[100]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags
-[101]: /sensu-go/5.16/observability-pipeline/observe-schedule/agent/#keepalive-configuration-flags
+[100]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery
+[101]: /sensu-go/5.16/observability-pipeline/observe-schedule/agent/#keepalive-configuration
 [102]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#initialization
 [103]: /sensu-go/5.16/web-ui/
 [104]: /sensu-go/5.16/
@@ -2280,13 +2280,13 @@ To get started with Sensu Go:
 [133]: /sensu-go/5.19/platforms/
 [134]: /sensu-go/5.19/operations/deploy-sensu/install-sensu/
 [135]: /sensu-go/5.19/web-ui/
-[136]: /sensu-go/5.19/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[136]: /sensu-go/5.19/observability-pipeline/observe-schedule/agent/#assets-burst-limit
 [137]: /sensu-go/5.19/observability-pipeline/observe-schedule/backend/#configuration-via-flags
 [138]: /sensu-go/5.20/api#field-selector
 [139]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#log-rotation
 [140]: /sensu-go/5.20/operations/maintain-sensu/troubleshoot/#increment-log-level-verbosity
 [141]: /sensu-go/5.20/commercial/
-[142]: /sensu-go/5.20/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[142]: /sensu-go/5.20/observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [143]: /sensu-go/5.20/observability-pipeline/observe-entities/entities/#processes-attributes
 [144]: /sensu-go/5.20/sensuctl/create-manage-resources/#supported-resource-types
 [145]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#configuration-summary
@@ -2347,7 +2347,7 @@ To get started with Sensu Go:
 [202]: /sensu-go/6.2/sensuctl/#first-time-setup-and-authentication
 [203]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#agent-managed-entity
 [204]: /sensu-go/6.2/observability-pipeline/observe-entities/entities/#manage-agent-entities-via-the-agent
-[205]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#configuration-via-flags
+[205]: /sensu-go/6.2/observability-pipeline/observe-schedule/agent/#agent-configuration-options
 [206]: /sensu-go/5.21/observability-pipeline/observe-schedule/backend/#log-rotation
 [207]: /sensu-go/6.3/commercial/
 [208]: /sensu-go/6.3/observability-pipeline/observe-schedule/backend/#agent-burst-limit
@@ -2371,6 +2371,7 @@ To get started with Sensu Go:
 [226]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-log-parallel-encoders
 [227]: /sensu-go/6.4/api/other/metrics/
 [228]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-logging
+[229]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery-srv
 [229]: /sensu-go/6.5/commercial/
 [230]: /sensu-go/6.5/observability-pipeline/observe-process/sumo-logic-metrics-handlers/
 [231]: /sensu-go/6.5/observability-pipeline/observe-process/tcp-stream-handlers/
@@ -2401,7 +2402,7 @@ To get started with Sensu Go:
 [257]: /sensu-go/6.5/observability-pipeline/observe-schedule/backend/#dashboard-write-timeout
 [258]: /sensu-go/6.6/observability-pipeline/observe-schedule/backend/#platform-metrics-logging
 [259]: /sensu-go/6.6/commercial/
-[260]: /sensu-go/6.6/observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration-flags
+[260]: /sensu-go/6.6/observability-pipeline/observe-schedule/backend/#datastore-and-cluster-configuration
 [261]: /sensu-go/6.6/web-ui/view-manage-resources/#manage-entities
 [262]: /sensu-go/6.6/observability-pipeline/observe-schedule/backend/#etcd-client-log-level
 [263]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
@@ -2433,3 +2434,4 @@ To get started with Sensu Go:
 [289]: /sensu-go/6.7/web-ui/sensu-catalog/#duplicate-integrations-and-existing-resources
 [290]: /sensu-go/6.7/web-ui/sensu-catalog/
 [291]: /sensu-go/6.7/observability-pipeline/observe-events/events/#check-scope
+[292]: /sensu-go/5.16/observability-pipeline/observe-schedule/backend/#etcd-discovery-srv

--- a/content/sensu-go/6.7/sensuctl/_index.md
+++ b/content/sensu-go/6.7/sensuctl/_index.md
@@ -495,7 +495,7 @@ source ~/.zshrc
 
 [1]: ../operations/control-access/rbac/
 [2]: ../operations/deploy-sensu/install-sensu/#install-sensuctl
-[3]: ../observability-pipeline/observe-schedule/agent/#general-configuration-flags
+[3]: ../observability-pipeline/observe-schedule/backend/
 [4]: ../operations/deploy-sensu/cluster-sensu/
 [5]: create-manage-resources/#create-resources
 [6]: #sensu-backend-url


### PR DESCRIPTION
## Description
A bit of reorganization work in the agent and backend references:

- Renames "Configuration flags" sections to "Configuration options"
- Adds a "Configuration methods" section that describes the config file, command line flags, and environment variables methods for customizing configuration
- Moves some info around to the right place (e.g. notes about SENSU_HOSTNAME placeholder for Docker; statement about restarting the agent/backend for config changes)
- In config option description tables, renames the config file example label from `/etc/sensu/agent.yml example` to `agent.yml config file example` (`/etc/sensu/backend.yml example` to `backend.yml config file example` in backend ref)

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3945

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>