### PR TITLE
Add RHEL/CentOS 9 to platforms page

### DIFF
--- a/content/sensu-go/6.7/platforms.md
+++ b/content/sensu-go/6.7/platforms.md
@@ -31,7 +31,9 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 | `arm64` | {{< check >}} | {{< check >}} | {{< check >}} |
 | `ppc64le` | {{< check >}} | {{< check >}} | {{< check >}} |
 
-As of Sensu Go 6.7.3, supported packages for the Sensu backend also include **Ubuntu 22.04** (`amd64`, `arm64`, `ppe64le`).
+As of Sensu Go 6.7.2, supported packages for the Sensu backend also include **Ubuntu 22.04** (`amd64`, `arm64`, `ppe64le`).
+
+As of Sensu Go 6.7.3, supported packages for the Sensu backend also include **RHEL/CentOS 9** (`amd64`, `arm64`, `ppe64le`).
 
 ### Sensu agent
 
@@ -43,7 +45,9 @@ As of Sensu Go 6.7.3, supported packages for the Sensu backend also include **Ub
 | `ppc64le` | {{< check >}} | {{< check >}} | {{< check >}} | | |
 | `s390x` | {{< check >}} | {{< check >}} | {{< check >}} | | |
 
-As of Sensu Go 6.7.3, supported packages for the Sensu agent also include **Ubuntu 22.04** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
+As of Sensu Go 6.7.2, supported packages for the Sensu agent also include **Ubuntu 22.04** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
+
+As of Sensu Go 6.7.3, supported packages for the Sensu backend also include **RHEL/CentOS 9** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
 
 ### Sensuctl command line tool
 
@@ -55,7 +59,9 @@ As of Sensu Go 6.7.3, supported packages for the Sensu agent also include **Ubun
 | `ppc64le` | {{< check >}} | {{< check >}} | {{< check >}} | | |
 | `s390x` | {{< check >}} | {{< check >}} | {{< check >}} | | |
 
-As of Sensu Go 6.7.3, supported packages for the sensuctl command line tool also include **Ubuntu 22.04** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
+As of Sensu Go 6.7.2, supported packages for the sensuctl command line tool also include **Ubuntu 22.04** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
+
+As of Sensu Go 6.7.3, supported packages for the Sensu backend also include **RHEL/CentOS 9** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
 
 ## Docker images
 

--- a/content/sensu-go/6.7/release-notes.md
+++ b/content/sensu-go/6.7/release-notes.md
@@ -117,6 +117,9 @@ This patch release includes a change in how agents execute check requests to pre
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.7.3.
 
+**IMPROVEMENTS**
+- ([Commercial feature][268]) Added supported packages for the Sensu backend, Sensu agent, and sensuctl for RHEL/CentOS 9.
+
 **FIXES**
 - ([Commercial feature][268]) When using the business service monitoring (BSM) feature, service component metadata is now included in the [`check` scope][291] of events the service component generates.
 Also fixed a bug that could cause BSM service component queries to retrieve events that do not match the specified query expressions.


### PR DESCRIPTION
## Description
Adds RHEL/CentOS 9 to https://docs.sensu.io/sensu-go/latest/platforms/#supported-packages for 6.7.3. Also corrects previous note about Ubuntu 22.04 (released in 6.7.2, not 6.7.3) and adds RHEL/CentOS 9 to 6.7.3 release notes.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3893

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>