### PR TITLE
Fix errors from ahrefs site audit and linkchecker scan

### DIFF
--- a/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.4/operations/manage-secrets/secrets-management.md
@@ -46,7 +46,7 @@ Here's how to find your Integration Key in PagerDuty so you can set it up as you
 4. Click the **Integrations** tab.
 The Integration Key is listed in the second column.
 
-{{< figure src="/images/go/secrets-management/old_pagerduty_integration_key.png" alt="PagerDuty Integration Key location" link="/images/go/secrets-management/old_pagerduty_integration_key.png" target="_blank" >}}
+{{< figure src="/images/go/secrets_management/old_pagerduty_integration_key.png" alt="PagerDuty Integration Key location" link="/images/go/secrets_management/old_pagerduty_integration_key.png" target="_blank" >}}
 
 Make a note of your Integration Key &mdash; you'll need it to create your [backend environment variable][28] or [HashiCorp Vault secret][29].
 

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
@@ -46,7 +46,7 @@ Here's how to find your Integration Key in PagerDuty so you can set it up as you
 4. Click the **Integrations** tab.
 The Integration Key is listed in the second column.
 
-{{< figure src="/images/go/secrets-management/old_pagerduty_integration_key.png" alt="PagerDuty Integration Key location" link="/images/go/secrets-management/old_pagerduty_integration_key.png" target="_blank" >}}
+{{< figure src="/images/go/secrets_management/old_pagerduty_integration_key.png" alt="PagerDuty Integration Key location" link="/images/go/secrets_management/old_pagerduty_integration_key.png" target="_blank" >}}
 
 Make a note of your Integration Key &mdash; you'll need it to create your [backend environment variable][28] or [HashiCorp Vault secret][29].
 

--- a/content/sensu-go/6.7/release-notes.md
+++ b/content/sensu-go/6.7/release-notes.md
@@ -2432,8 +2432,8 @@ To get started with Sensu Go:
 [284]: /sensu-go/6.7/observability-pipeline/observe-filter/sensu-query-expressions/#sensucheckdependencies-custom-function
 [285]: /sensu-go/6.7/observability-pipeline/observe-schedule/metrics/#metric-threshold-evaluation
 [286]: /sensu-go/6.7/web-ui/view-manage-resources/#view-resource-data-in-the-web-ui
-[287]: /sensu-go/6.7/web-ui/view-manage-resources/webconfig-reference/#serialization_format
-[288]: /sensu-go/6.7/web-ui/view-manage-resources/webconfig-reference/#sign-in-message
+[287]: /sensu-go/6.7/web-ui/webconfig-reference/#serialization_format
+[288]: /sensu-go/6.7/web-ui/webconfig-reference/#sign-in-message
 [289]: /sensu-go/6.7/web-ui/sensu-catalog/#duplicate-integrations-and-existing-resources
 [290]: /sensu-go/6.7/web-ui/sensu-catalog/
 [291]: /sensu-go/6.7/observability-pipeline/observe-events/events/#check-scope


### PR DESCRIPTION
## Description
Fixes incorrect links from release notes to the webconfig reference and an incorrect image path. Errors found with Ahrefs site audit and linkchecker scan.