### PR TITLE
Document errors due to multiple matching subscriptions

### DIFF
--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/subscriptions.md
@@ -113,10 +113,16 @@ Sensu automatically executes a check when the check definition includes a subscr
 In other words, subscriptions are configured for both checks and agent entities:
 
 - To configure subscriptions for a check, add one or more subscription names in the [check `subscriptions` attribute][15].
-- To configure subscriptions for an agent entity, configure the [`subscriptions`][2] by specifying the subscriptions that include the checks the agent's entities should execute.
+- To configure subscriptions for an agent entity, specify a subscription that matches one subscription in each check the agent's entities should execute.
 
 The Sensu backend [schedules][13] checks once per interval for each agent entity with a matching subscription.
 For example, if you have three entities configured with the `system` subscription, a check configured with the `system` subscription results in three monitoring events per interval: one check execution per entity per interval.
+
+{{% notice warning %}}
+**WARNING**: Make sure that your checks and entities share only one subscription.
+Entities receive a separate check request for each matching subscription, even if the requests are for the same check.
+This can result in check execution errors as well as unexpected results for check `history` and the features that rely on it.
+{{% /notice %}}
 
 In addition to the subscriptions defined in the agent configuration, Sensu agent entities subscribe automatically to subscriptions that match their [entity `name`][10].
 For example, an agent entity with `name: "i-424242"` subscribes to check requests with the subscription `entity:i-424242`.

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/subscriptions.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/subscriptions.md
@@ -113,7 +113,7 @@ Sensu automatically executes a check when the check definition includes a subscr
 In other words, subscriptions are configured for both checks and agent entities:
 
 - To configure subscriptions for a check, add one or more subscription names in the [check `subscriptions` attribute][15].
-- To configure subscriptions for an agent entity, specify a subscription that matches one subscription in each check the agent's entities should execute.
+- To configure subscriptions for an agent entity, specify a subscription that matches one subscription in each check that the agent's entities should execute.
 
 The Sensu backend [schedules][13] checks once per interval for each agent entity with a matching subscription.
 For example, if you have three entities configured with the `system` subscription, a check configured with the `system` subscription results in three monitoring events per interval: one check execution per entity per interval.

--- a/content/sensu-go/6.7/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/troubleshoot.md
@@ -813,6 +813,30 @@ This may result in a crash loop that is difficult to recover from.
 You may observe that the Sensu backend process continues running but is not listening for connections on the agent WebSocket, API, or web UI ports.
 The backend will stop listening on those ports when the etcd database is unavailable.
 
+## Check execution and multiple subscriptions
+
+The following error message indicates that a check and an entity share more than one matching subscription:
+
+{{< code text >}}
+{"component":"agent","error":"check execution still in progress: <CHECK_NAME>","level":"error","msg":"error handling message","time":"2022-07-21T20:08:31Z"}
+{{< /code >}}
+
+The Sensu backend sends check requests to all matching subscriptions.
+If an entity and a check have multiple matching subscriptions, the entity will receive a separate check request for each matching subscription.
+The entity could receive both check requests almost simultaneously.
+
+If the entity is still executing one check request when it receives another for the same check, the Sensu backend will log the `check execution still in progress` error.
+In some cases, entities execute the check requests quickly enough to prevent the `check execution still in progress` error.
+In these cases, check `history` and features that rely on it, like flap detection, may behave in unexpected ways.
+
+To resolve this problem, make sure that your checks and entities share only a single [subscription][31].
+
+{{< code text >}}
+check request has already been received - agent and check may have multiple matching subscriptions
+
+check request is older than a previously received check request
+{{< /code >}}
+
 ## Web UI errors
 
 If the web UI experiences an error, you may see the following message in the web UI:
@@ -888,3 +912,4 @@ Read the documentation for your browser to learn more about the web developer to
 [28]: ../../deploy-sensu/generate-certificates/
 [29]: https://etcd.io/docs/latest/dev-guide/interacting_v3/
 [30]: ../../../observability-pipeline/observe-schedule/backend/
+[31]: ../../../observability-pipeline/observe-schedule/subscriptions/

--- a/content/sensu-go/6.7/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/troubleshoot.md
@@ -813,28 +813,31 @@ This may result in a crash loop that is difficult to recover from.
 You may observe that the Sensu backend process continues running but is not listening for connections on the agent WebSocket, API, or web UI ports.
 The backend will stop listening on those ports when the etcd database is unavailable.
 
-## Check execution and multiple subscriptions
-
-The following error message indicates that a check and an entity share more than one matching subscription:
-
-{{< code text >}}
-{"component":"agent","error":"check execution still in progress: <CHECK_NAME>","level":"error","msg":"error handling message","time":"2022-07-21T20:08:31Z"}
-{{< /code >}}
+## Check execution errors
 
 The Sensu backend sends check requests to all matching subscriptions.
 If an entity and a check have multiple matching subscriptions, the entity will receive a separate check request for each matching subscription.
 The entity could receive both check requests almost simultaneously.
 
-If the entity is still executing one check request when it receives another for the same check, the Sensu backend will log the `check execution still in progress` error.
-In some cases, entities execute the check requests quickly enough to prevent the `check execution still in progress` error.
-In these cases, check `history` and features that rely on it, like flap detection, may behave in unexpected ways.
-
-To resolve this problem, make sure that your checks and entities share only a single [subscription][31].
+As a result, you may see the following error message:
 
 {{< code text >}}
-check request has already been received - agent and check may have multiple matching subscriptions
+{"component":"agent","error":"check execution still in progress: <CHECK_NAME>","level":"error","msg":"error handling message","time":"..."}
+{{< /code >}}
 
-check request is older than a previously received check request
+Entities may execute the duplicate check requests quickly enough to prevent the `check execution still in progress` error.
+In these cases, check `history` and features that rely on it, like flap detection, may behave in unexpected ways.
+
+If you see the `check execution still in progress` error, review the check subscriptions against your entities for multiple matching subscriptions.
+To prevent the problem, make sure that your checks and entities share only a single [subscription][31].
+
+{{% notice note %}}
+**NOTE**: As of Sensu Go 6.7.3, multiple matching check and entity subscriptions may produce the messages listed below in addition to the `check execution still in progress` error.
+{{% /notice %}}
+
+{{< code text >}}
+{"component":"agent","error":"check request is older than a previously received check request","level":"error","msg":"error handling message","time":"..."}
+{"component":"agent","warning":"check request has already been received - agent and check may have multiple matching subscriptions","level":"warn","msg":"error handling message","time":"..."}
 {{< /code >}}
 
 ## Web UI errors

--- a/content/sensu-go/6.7/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/troubleshoot.md
@@ -832,7 +832,7 @@ If you see the `check execution still in progress` error, review the check subsc
 To prevent the problem, make sure that your checks and entities share only a single [subscription][31].
 
 {{% notice note %}}
-**NOTE**: As of Sensu Go 6.7.3, multiple matching check and entity subscriptions may produce the messages listed below in addition to the `check execution still in progress` error.
+**NOTE**: As of Sensu Go 6.7.3, multiple matching check and entity subscriptions may result in the messages listed below in addition to the `check execution still in progress` error.
 {{% /notice %}}
 
 {{< code text >}}


### PR DESCRIPTION
## Description
Documents agent error messages added in https://github.com/sensu/sensu-go/pull/4773 re: entities and checks that share multiple matching subscriptions

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3954

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>