### PR TITLE
Fix link format typo in filters reference

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -534,7 +534,7 @@ sensu.FetchEvent("server01", "disk")
 {{< /code >}}
 
 You can only load events from the same namespace as the event being filtered.
-The returned object uses the same format as responses for the [core/v2/events API]][43].
+The returned object uses the same format as responses for the [core/v2/events API][43].
 
 If an event does not exist for the specified entity and check names, Sensu will raise an error.
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -561,7 +561,7 @@ sensu.FetchEvent("server01", "disk")
 {{< /code >}}
 
 You can only load events from the same namespace as the event being filtered.
-The returned object uses the same format as responses for the [core/v2/events API]][43].
+The returned object uses the same format as responses for the [core/v2/events API][43].
 
 If an event does not exist for the specified entity and check names, Sensu will raise an error.
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
@@ -561,7 +561,7 @@ sensu.FetchEvent("server01", "disk")
 {{< /code >}}
 
 You can only load events from the same namespace as the event being filtered.
-The returned object uses the same format as responses for the [core/v2/events API]][43].
+The returned object uses the same format as responses for the [core/v2/events API][43].
 
 If an event does not exist for the specified entity and check names, Sensu will raise an error.
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
@@ -561,7 +561,7 @@ sensu.FetchEvent("server01", "disk")
 {{< /code >}}
 
 You can only load events from the same namespace as the event being filtered.
-The returned object uses the same format as responses for the [core/v2/events API]][43].
+The returned object uses the same format as responses for the [core/v2/events API][43].
 
 If an event does not exist for the specified entity and check names, Sensu will raise an error.
 


### PR DESCRIPTION
## Description
Fixes link typo `[core/v2/events API]][43]` in filters reference

## Motivation and Context
Found when working on something else

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>