### PR TITLE
Doc single or double quotes for string values in filter expressions

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/filters.md
@@ -92,11 +92,19 @@ Event filters that return a `true` value will continue to be processed via addit
 
 When more complex conditional logic is needed than direct filter expression comparison, Sensu event filters provide support for expression evaluation using [Otto][31].
 Otto is an ECMAScript 5 (JavaScript) virtual machine that evaluates JavaScript expressions provided in an event filter.
+
+In event filter expressions, place string values inside single or double quotes.
+These filter expressions are equivalent in EMCAScript:
+
+{{< code text >}}
+event.check.annotations['service_priority'] == 1
+event.check.annotations["service_priority"] == 1
+{{< /code >}}
+
 There are some caveats to using Otto: not all of the regular expressions (regex) specified in ECMAScript 5 will work.
 Review the [Otto README][32] for more details.
 
 Use [Go regex syntax][3] to create event filter expressions that combine any available [event][46], [check][47], or [entity][48] attributes with `match(<regex>)`.
-
 For example, this event filter allows handling for events whose `event.check.name` ends with `metrics`:
 
 {{< language-toggle >}}
@@ -765,18 +773,20 @@ action: allow
 
 expressions   | 
 -------------|------
-description  | Event filter expressions to be compared with event data. You can reference event metadata without including the `metadata` scope (for example, `event.entity.namespace`).
+description  | Event filter expressions to be compared with event data. You can reference event metadata without including the `metadata` scope (for example, `event.entity.namespace`).<br><br>In event filter expressions, place string values inside single or double quotes.
 required     | true
 type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 expressions:
 - event.check.team == 'ops'
+- event.check.annotations["service_priority"] == 1
 {{< /code >}}
 {{< code json >}}
 {
   "expressions": [
-    "event.check.team == 'ops'"
+    "event.check.team == 'ops'",
+    "event.check.annotations[\"service_priority\"] == 1"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/filters.md
@@ -96,11 +96,19 @@ Event filter expressions are compared directly with their event data counterpart
 
 When more complex conditional logic is needed than direct filter expression comparison, Sensu event filters provide support for expression evaluation using [Otto][31].
 Otto is an ECMAScript 5 (JavaScript) virtual machine that evaluates JavaScript expressions provided in an event filter.
+
+In event filter expressions, place string values inside single or double quotes.
+These filter expressions are equivalent in EMCAScript:
+
+{{< code text >}}
+event.check.annotations['service_priority'] == 1
+event.check.annotations["service_priority"] == 1
+{{< /code >}}
+
 There are some caveats to using Otto: not all of the regular expressions (regex) specified in ECMAScript 5 will work.
 Review the [Otto README][32] for more details.
 
 Use [Go regex syntax][3] to create event filter expressions that combine any available [event][46], [check][47], or [entity][48] attributes with `match(<regex>)`.
-
 For example, this event filter allows handling for events whose `event.check.name` ends with `metrics`:
 
 {{< language-toggle >}}
@@ -792,18 +800,20 @@ action: allow
 
 expressions   | 
 -------------|------
-description  | Event filter expressions to be compared with event data. You can reference event metadata without including the `metadata` scope (for example, `event.entity.namespace`).
+description  | Event filter expressions to be compared with event data. You can reference event metadata without including the `metadata` scope (for example, `event.entity.namespace`).<br><br>In event filter expressions, place string values inside single or double quotes.
 required     | true
 type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 expressions:
 - event.check.team == 'ops'
+- event.check.annotations["service_priority"] == 1
 {{< /code >}}
 {{< code json >}}
 {
   "expressions": [
-    "event.check.team == 'ops'"
+    "event.check.team == 'ops'",
+    "event.check.annotations[\"service_priority\"] == 1"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/filters.md
@@ -96,11 +96,19 @@ Event filter expressions are compared directly with their event data counterpart
 
 When more complex conditional logic is needed than direct filter expression comparison, Sensu event filters provide support for expression evaluation using [Otto][31].
 Otto is an ECMAScript 5 (JavaScript) virtual machine that evaluates JavaScript expressions provided in an event filter.
+
+In event filter expressions, place string values inside single or double quotes.
+These filter expressions are equivalent in EMCAScript:
+
+{{< code text >}}
+event.check.annotations['service_priority'] == 1
+event.check.annotations["service_priority"] == 1
+{{< /code >}}
+
 There are some caveats to using Otto: not all of the regular expressions (regex) specified in ECMAScript 5 will work.
 Review the [Otto README][32] for more details.
 
 Use [Go regex syntax][3] to create event filter expressions that combine any available [event][46], [check][47], or [entity][48] attributes with `match(<regex>)`.
-
 For example, this event filter allows handling for events whose `event.check.name` ends with `metrics`:
 
 {{< language-toggle >}}
@@ -792,18 +800,20 @@ action: allow
 
 expressions   | 
 -------------|------
-description  | Event filter expressions to be compared with event data. You can reference event metadata without including the `metadata` scope (for example, `event.entity.namespace`).
+description  | Event filter expressions to be compared with event data. You can reference event metadata without including the `metadata` scope (for example, `event.entity.namespace`).<br><br>In event filter expressions, place string values inside single or double quotes.
 required     | true
 type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 expressions:
 - event.check.team == 'ops'
+- event.check.annotations["service_priority"] == 1
 {{< /code >}}
 {{< code json >}}
 {
   "expressions": [
-    "event.check.team == 'ops'"
+    "event.check.team == 'ops'",
+    "event.check.annotations[\"service_priority\"] == 1"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/filters.md
@@ -96,11 +96,19 @@ Event filter expressions are compared directly with their event data counterpart
 
 When more complex conditional logic is needed than direct filter expression comparison, Sensu event filters provide support for expression evaluation using [Otto][31].
 Otto is an ECMAScript 5 (JavaScript) virtual machine that evaluates JavaScript expressions provided in an event filter.
+
+In event filter expressions, place string values inside single or double quotes.
+These filter expressions are equivalent in EMCAScript:
+
+{{< code text >}}
+event.check.annotations['service_priority'] == 1
+event.check.annotations["service_priority"] == 1
+{{< /code >}}
+
 There are some caveats to using Otto: not all of the regular expressions (regex) specified in ECMAScript 5 will work.
 Review the [Otto README][32] for more details.
 
 Use [Go regex syntax][3] to create event filter expressions that combine any available [event][46], [check][47], or [entity][48] attributes with `match(<regex>)`.
-
 For example, this event filter allows handling for events whose `event.check.name` ends with `metrics`:
 
 {{< language-toggle >}}
@@ -792,18 +800,20 @@ action: allow
 
 expressions   | 
 -------------|------
-description  | Event filter expressions to be compared with event data. You can reference event metadata without including the `metadata` scope (for example, `event.entity.namespace`).
+description  | Event filter expressions to be compared with event data. You can reference event metadata without including the `metadata` scope (for example, `event.entity.namespace`).<br><br>In filter expressions, place string values inside single or double quotes.
 required     | true
 type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 expressions:
 - event.check.team == 'ops'
+- event.check.annotations["service_priority"] == 1
 {{< /code >}}
 {{< code json >}}
 {
   "expressions": [
-    "event.check.team == 'ops'"
+    "event.check.team == 'ops'",
+    "event.check.annotations[\"service_priority\"] == 1"
   ]
 }
 {{< /code >}}


### PR DESCRIPTION
## Description
In the filter reference, add instruction to place string values in filter expressions in single or double quotes. Also adds a double-quote example in the `expressions` attribute description table.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3958

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>