### PR TITLE
Add anchor link for annotations description table in agent ref

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -898,6 +898,8 @@ sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
 agent.yml config file example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
 
+<a id="agent-annotations"></a>
+
 | annotations|      |
 -------------|------
 description  | Non-identifying metadata to include with event data that you can access with [event filters][9] and [tokens][27]. You can use annotations to add data that is meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][25], [sensuctl response filtering][26], or [web UI view filtering][54].{{% notice note %}}

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -726,6 +726,8 @@ sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
 agent.yml config file example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
 
+<a id="agent-annotations"></a>
+
 | annotations|      |
 -------------|------
 description  | Non-identifying metadata to include with event data that you can access with [event filters][9] and [tokens][27]. You can use annotations to add data that is meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][25], [sensuctl response filtering][26], or [web UI view filtering][54].{{% notice note %}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -725,6 +725,8 @@ sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
 agent.yml config file example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
 
+<a id="agent-annotations"></a>
+
 | annotations|      |
 -------------|------
 description  | Non-identifying metadata to include with event data that you can access with [event filters][9] and [tokens][27]. You can use annotations to add data that is meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][25], [sensuctl response filtering][26], or [web UI view filtering][54].{{% notice note %}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -755,6 +755,8 @@ sensu-agent start --allow-list /etc/sensu/check-allow-list.yaml{{< /code >}}
 agent.yml config file example | {{< code shell >}}
 allow-list: /etc/sensu/check-allow-list.yaml{{< /code >}}
 
+<a id="agent-annotations"></a>
+
 | annotations|      |
 -------------|------
 description  | Non-identifying metadata to include with event data that you can access with [event filters][9] and [tokens][27]. You can use annotations to add data that is meaningful to people or external tools that interact with Sensu.<br><br>In contrast to labels, you cannot use annotations in [API response filtering][25], [sensuctl response filtering][26], or [web UI view filtering][54].{{% notice note %}}


### PR DESCRIPTION
## Description
Adds an `agent-annotations` anchor link to the annotations description table in the agent reference.

## Motivation and Context
Needed for catalog integration links

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>