### PR TITLE
Use singular pipeline in sensuctl command examples

### DIFF
--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -588,7 +588,7 @@ Use the `sensuctl edit` command with any of the following resource types:
 [`asset`][12] | [`auth`][39] | [`check`][13] | [`cluster`][7]
 [`cluster-role`][43] | [`cluster-role-binding`][45] | [`entity`][14] | [`event`][15]
 [`filter`][16] | [`handler`][17] | [`hook`][18] | [`mutator`][19]
-[`namespace`][21] | [`pipelines`][9] | [`role`][35] | [`role-binding`][44]
+[`namespace`][21] | [`pipeline`][9] | [`role`][35] | [`role-binding`][44]
 [`silenced`][20] | [`user`][22]
  
 ## Manage resources
@@ -610,7 +610,7 @@ Combine the resource command with a [subcommand][23] to complete operations like
 - [`sensuctl license`][34] (commercial feature)
 - [`sensuctl mutator`][19]
 - [`sensuctl namespace`][21]
-- [`sensuctl pipelines`][9]
+- [`sensuctl pipeline`][9]
 - [`sensuctl role`][35]
 - [`sensuctl role-binding`][44]
 - [`sensuctl secrets`][28]

--- a/content/sensu-go/6.6/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.6/sensuctl/create-manage-resources.md
@@ -588,7 +588,7 @@ Use the `sensuctl edit` command with any of the following resource types:
 [`asset`][12] | [`auth`][39] | [`check`][13] | [`cluster`][7]
 [`cluster-role`][43] | [`cluster-role-binding`][45] | [`entity`][14] | [`event`][15]
 [`filter`][16] | [`handler`][17] | [`hook`][18] | [`mutator`][19]
-[`namespace`][21] | [`pipelines`][9] | [`role`][35] | [`role-binding`][44]
+[`namespace`][21] | [`pipeline`][9] | [`role`][35] | [`role-binding`][44]
 [`silenced`][20] | [`user`][22]
  
 ## Manage resources
@@ -610,7 +610,7 @@ Combine the resource command with a [subcommand][23] to complete operations like
 - [`sensuctl license`][34] (commercial feature)
 - [`sensuctl mutator`][19]
 - [`sensuctl namespace`][21]
-- [`sensuctl pipelines`][9]
+- [`sensuctl pipeline`][9]
 - [`sensuctl role`][35]
 - [`sensuctl role-binding`][44]
 - [`sensuctl secrets`][28]

--- a/content/sensu-go/6.7/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.7/sensuctl/create-manage-resources.md
@@ -593,7 +593,7 @@ Use the `sensuctl edit` command with any of the following resource types:
 [`asset`][12] | [`auth`][39] | [`check`][13] | [`cluster`][7]
 [`cluster-role`][43] | [`cluster-role-binding`][45] | [`entity`][14] | [`event`][15]
 [`filter`][16] | [`handler`][17] | [`hook`][18] | [`mutator`][19]
-[`namespace`][21] | [`pipelines`][9] | [`role`][35] | [`role-binding`][44]
+[`namespace`][21] | [`pipeline`][9] | [`role`][35] | [`role-binding`][44]
 [`silenced`][20] | [`user`][22]
  
 ## Manage resources
@@ -615,7 +615,7 @@ Combine the resource command with a [subcommand][23] to complete operations like
 - [`sensuctl license`][34] (commercial feature)
 - [`sensuctl mutator`][19]
 - [`sensuctl namespace`][21]
-- [`sensuctl pipelines`][9]
+- [`sensuctl pipeline`][9]
 - [`sensuctl role`][35]
 - [`sensuctl role-binding`][44]
 - [`sensuctl secrets`][28]


### PR DESCRIPTION
## Description
The lists at https://docs.sensu.io/sensu-go/latest/sensuctl/create-manage-resources/#sensuctl-edit-resource-types and https://docs.sensu.io/sensu-go/latest/sensuctl/create-manage-resources/#manage-resources use `pipelines` instead of the singular.

`sensuctl edit pipelines` works, but `sensuctl pipelines info` does not. To prevent confusion and to be consistent with the singular form used for other resources, this PR changes the commands in the docs to use `pipeline`.

## Motivation and Context
Found when working on catalog integrations

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>