### PR TITLE
Remove 6.7 patch notes in 6.8 doc set

### DIFF
--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
@@ -1254,8 +1254,8 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 | etcd-unsafe-no-fsync |      |
 -----------------------|------
 description            | The `etcd-unsafe-no-fsync` configuration option allows you to run sensu-backend with an embedded etcd node for testing and development with less load on the file system. If `true`, disable fsync. Otherwise, `false`.{{% notice note %}}
-**NOTE**: The `etcd-unsafe-no-fsync` configuration option is available in Sensu Go 6.7.2, but it is not available in 6.7.0 or 6.7.1.
-Upgrade to Sensu Go 6.7.2 to use `etcd-unsafe-no-fsync`. 
+**NOTE**: The `etcd-unsafe-no-fsync` configuration option is available as of Sensu Go 6.7.2, but it is not available in 6.7.0 or 6.7.1.
+Upgrade to Sensu Go 6.7.2 or later to use `etcd-unsafe-no-fsync`. 
 {{% /notice %}}
 type                   | Boolean
 default                | `false`

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/backend.md
@@ -1253,10 +1253,7 @@ etcd-trusted-ca-file: "./ca.pem"{{< /code >}}
 
 | etcd-unsafe-no-fsync |      |
 -----------------------|------
-description            | The `etcd-unsafe-no-fsync` configuration option allows you to run sensu-backend with an embedded etcd node for testing and development with less load on the file system. If `true`, disable fsync. Otherwise, `false`.{{% notice note %}}
-**NOTE**: The `etcd-unsafe-no-fsync` configuration option is available in Sensu Go 6.7.2, but it is not available in 6.7.0 or 6.7.1.
-Upgrade to Sensu Go 6.7.2 to use `etcd-unsafe-no-fsync`. 
-{{% /notice %}}
+description            | The `etcd-unsafe-no-fsync` configuration option allows you to run sensu-backend with an embedded etcd node for testing and development with less load on the file system. If `true`, disable fsync. Otherwise, `false`.
 type                   | Boolean
 default                | `false`
 environment variable   | `SENSU_BACKEND_ETCD_UNSAFE_NO_FSYNC`

--- a/content/sensu-go/6.8/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.8/operations/maintain-sensu/troubleshoot.md
@@ -819,26 +819,21 @@ The Sensu backend sends check requests to all matching subscriptions.
 If an entity and a check have multiple matching subscriptions, the entity will receive a separate check request for each matching subscription.
 The entity could receive both check requests almost simultaneously.
 
-As a result, you may see the following error message:
+As a result, you may see one or more of the following error messages:
 
 {{< code text >}}
 {"component":"agent","error":"check execution still in progress: <CHECK_NAME>","level":"error","msg":"error handling message","time":"..."}
-{{< /code >}}
 
-Entities may execute the duplicate check requests quickly enough to prevent the `check execution still in progress` error.
-In these cases, check `history` and features that rely on it, like flap detection, may behave in unexpected ways.
-
-If you see the `check execution still in progress` error, review the check subscriptions against your entities for multiple matching subscriptions.
-To prevent the problem, make sure that your checks and entities share only a single [subscription][31].
-
-{{% notice note %}}
-**NOTE**: As of Sensu Go 6.7.3, multiple matching check and entity subscriptions may result in the messages listed below in addition to the `check execution still in progress` error.
-{{% /notice %}}
-
-{{< code text >}}
 {"component":"agent","error":"check request is older than a previously received check request","level":"error","msg":"error handling message","time":"..."}
+
 {"component":"agent","warning":"check request has already been received - agent and check may have multiple matching subscriptions","level":"warn","msg":"error handling message","time":"..."}
 {{< /code >}}
+
+Entities may execute the duplicate check requests quickly enough to prevent these errors.
+In these cases, check `history` and features that rely on it, like flap detection, may behave in unexpected ways.
+
+If you see any of the check execution errors listed above, review the check subscriptions against your entities for multiple matching subscriptions.
+To prevent the problem, make sure that your checks and entities share only a single [subscription][31].
 
 ## Web UI errors
 

--- a/content/sensu-go/6.8/platforms.md
+++ b/content/sensu-go/6.8/platforms.md
@@ -25,43 +25,31 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensu backend
 
-|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10, 11 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
+|  | RHEL/CentOS<br>6, 7, 8, 9 | Debian 8, 9, 10, 11 | Ubuntu 14.04<br>16.04, 18.04, 18.10<br>19.04, 19.10, 20.04<br>22.04 |
 |----------------------|---------|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} |
 | `arm64` | {{< check >}} | {{< check >}} | {{< check >}} |
 | `ppc64le` | {{< check >}} | {{< check >}} | {{< check >}} |
 
-As of Sensu Go 6.7.2, supported packages for the Sensu backend also include **Ubuntu 22.04** (`amd64`, `arm64`, `ppe64le`).
-
-As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RHEL/CentOS 9** (`amd64`, `arm64`, `ppe64le`).
-
 ### Sensu agent
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL/<br>CentOS<br>6, 7, 8, 9 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04<br>22.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `armv5`<br>`armv6`<br>`armv7` | {{< check >}} | {{< check >}} | {{< check >}} | | |
 | `ppc64le` | {{< check >}} | {{< check >}} | {{< check >}} | | |
 | `s390x` | {{< check >}} | {{< check >}} | {{< check >}} | | |
-
-As of Sensu Go 6.7.2, supported packages for the Sensu agent also include **Ubuntu 22.04** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
-
-As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RHEL/CentOS 9** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
 
 ### Sensuctl command line tool
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL/<br>CentOS<br>6, 7, 8, 9 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04<br>22.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `armv5`<br>`armv6`<br>`armv7` | {{< check >}} | {{< check >}} | {{< check >}} | | |
 | `ppc64le` | {{< check >}} | {{< check >}} | {{< check >}} | | |
 | `s390x` | {{< check >}} | {{< check >}} | {{< check >}} | | |
-
-As of Sensu Go 6.7.2, supported packages for the sensuctl command line tool also include **Ubuntu 22.04** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
-
-As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RHEL/CentOS 9** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
 
 ## Docker images
 


### PR DESCRIPTION
## Description
Removes notes about 6.7.x patch features in the 6.8 doc set.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/3838

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>