### PR TITLE
Clarify config changes require restart

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/agent.md
@@ -1649,6 +1649,11 @@ The default agent configuration file path for Windows is `C:\ProgramData\sensu\c
 To use the `agent.yml` file to configure the agent, list the desired configuration attributes and values.
 Review the [example Sensu agent configuration file][5] for a complete example.
 
+{{% notice note %}}
+**NOTE**: The agent loads configuration upon startup.
+If you make changes in the `agent.yml` configuration file after startup, you must restart the agent for the changes to take effect.
+{{% /notice %}}
+
 Configuration via command line flags or environment variables overrides any configuration specified in the agent configuration file.
 Read [Create overrides][68] to learn more.
 

--- a/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-schedule/backend.md
@@ -1375,9 +1375,15 @@ pipelined-workers: 100{{< /code >}}
 ### Backend configuration file
 
 You can customize the backend configuration in a `.yml` configuration file.
+The default backend configuration file path for Linux is `/etc/sensu/backend.yml`.
 
 To use the `backend.yml` file to configure the backend, list the desired configuration attributes and values.
 Review the [example Sensu backend configuration file][17] for a complete example.
+
+{{% notice note %}}
+**NOTE**: The backend loads configuration upon startup.
+If you make changes in the `backend.yml` configuration file after startup, you must restart the backend for the changes to take effect.
+{{% /notice %}}
 
 Configuration via command line flags or environment variables overrides any configuration specified in the backend configuration file.
 Read [Create overrides][74] to learn more.

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -1518,6 +1518,11 @@ The default agent configuration file path for Windows is `C:\ProgramData\sensu\c
 To use the `agent.yml` file to configure the agent, list the desired configuration attributes and values.
 Review the [example Sensu agent configuration file][5] for a complete example.
 
+{{% notice note %}}
+**NOTE**: The agent loads configuration upon startup.
+If you make changes in the `agent.yml` configuration file after startup, you must restart the agent for the changes to take effect.
+{{% /notice %}}
+
 Configuration via command line flags or environment variables overrides any configuration specified in the agent configuration file.
 Read [Create overrides][68] to learn more.
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -1391,9 +1391,15 @@ pipelined-workers: 100{{< /code >}}
 ### Backend configuration file
 
 You can customize the backend configuration in a `.yml` configuration file.
+The default backend configuration file path for Linux is `/etc/sensu/backend.yml`.
 
 To use the `backend.yml` file to configure the backend, list the desired configuration attributes and values.
 Review the [example Sensu backend configuration file][17] for a complete example.
+
+{{% notice note %}}
+**NOTE**: The backend loads configuration upon startup.
+If you make changes in the `backend.yml` configuration file after startup, you must restart the backend for the changes to take effect.
+{{% /notice %}}
 
 Configuration via command line flags or environment variables overrides any configuration specified in the backend configuration file.
 Read [Create overrides][74] to learn more.

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -1517,6 +1517,11 @@ The default agent configuration file path for Windows is `C:\ProgramData\sensu\c
 To use the `agent.yml` file to configure the agent, list the desired configuration attributes and values.
 Review the [example Sensu agent configuration file][5] for a complete example.
 
+{{% notice note %}}
+**NOTE**: The agent loads configuration upon startup.
+If you make changes in the `agent.yml` configuration file after startup, you must restart the agent for the changes to take effect.
+{{% /notice %}}
+
 Configuration via command line flags or environment variables overrides any configuration specified in the agent configuration file.
 Read [Create overrides][68] to learn more.
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
@@ -1402,9 +1402,15 @@ pipelined-workers: 100{{< /code >}}
 ### Backend configuration file
 
 You can customize the backend configuration in a `.yml` configuration file.
+The default backend configuration file path for Linux is `/etc/sensu/backend.yml`.
 
 To use the `backend.yml` file to configure the backend, list the desired configuration attributes and values.
 Review the [example Sensu backend configuration file][17] for a complete example.
+
+{{% notice note %}}
+**NOTE**: The backend loads configuration upon startup.
+If you make changes in the `backend.yml` configuration file after startup, you must restart the backend for the changes to take effect.
+{{% /notice %}}
 
 Configuration via command line flags or environment variables overrides any configuration specified in the backend configuration file.
 Read [Create overrides][74] to learn more.

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -1576,6 +1576,11 @@ The default agent configuration file path for Windows is `C:\ProgramData\sensu\c
 To use the `agent.yml` file to configure the agent, list the desired configuration attributes and values.
 Review the [example Sensu agent configuration file][5] for a complete example.
 
+{{% notice note %}}
+**NOTE**: The agent loads configuration upon startup.
+If you make changes in the `agent.yml` configuration file after startup, you must restart the agent for the changes to take effect.
+{{% /notice %}}
+
 Configuration via command line flags or environment variables overrides any configuration specified in the agent configuration file.
 Read [Create overrides][68] to learn more.
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
@@ -1428,9 +1428,15 @@ pipelined-workers: 100{{< /code >}}
 ### Backend configuration file
 
 You can customize the backend configuration in a `.yml` configuration file.
+The default backend configuration file path for Linux is `/etc/sensu/backend.yml`.
 
 To use the `backend.yml` file to configure the backend, list the desired configuration attributes and values.
 Review the [example Sensu backend configuration file][17] for a complete example.
+
+{{% notice note %}}
+**NOTE**: The backend loads configuration upon startup.
+If you make changes in the `backend.yml` configuration file after startup, you must restart the backend for the changes to take effect.
+{{% /notice %}}
 
 Configuration via command line flags or environment variables overrides any configuration specified in the backend configuration file.
 Read [Create overrides][74] to learn more.

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/agent.md
@@ -1576,6 +1576,11 @@ The default agent configuration file path for Windows is `C:\ProgramData\sensu\c
 To use the `agent.yml` file to configure the agent, list the desired configuration attributes and values.
 Review the [example Sensu agent configuration file][5] for a complete example.
 
+{{% notice note %}}
+**NOTE**: The agent loads configuration upon startup.
+If you make changes in the `agent.yml` configuration file after startup, you must restart the agent for the changes to take effect.
+{{% /notice %}}
+
 Configuration via command line flags or environment variables overrides any configuration specified in the agent configuration file.
 Read [Create overrides][68] to learn more.
 

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/backend.md
@@ -1425,9 +1425,15 @@ pipelined-workers: 100{{< /code >}}
 ### Backend configuration file
 
 You can customize the backend configuration in a `.yml` configuration file.
+The default backend configuration file path for Linux is `/etc/sensu/backend.yml`.
 
 To use the `backend.yml` file to configure the backend, list the desired configuration attributes and values.
 Review the [example Sensu backend configuration file][17] for a complete example.
+
+{{% notice note %}}
+**NOTE**: The backend loads configuration upon startup.
+If you make changes in the `backend.yml` configuration file after startup, you must restart the backend for the changes to take effect.
+{{% /notice %}}
 
 Configuration via command line flags or environment variables overrides any configuration specified in the backend configuration file.
 Read [Create overrides][74] to learn more.


### PR DESCRIPTION
## Description
When I reworked the configuration options and methods sections in the agent and backend references, I did not include a note with the config file method to explain that agent/backend restart is required for changes to take effect. This PR remedies the omission.

## Motivation and Context
Noticed when working on something else

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>