### PR TITLE
Fix code example labels in read-only user and limited service acct docs

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -131,7 +131,7 @@ sensuctl handler update slack
 
 Follow the prompts to add the `hourly` and `is_incident` event filters to the `slack handler`:
 
-{{< code shell >}}
+{{< code text >}}
 ? Environment variables: SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX
 ? Filters: hourly,is_incident
 ? Mutator: 
@@ -143,7 +143,7 @@ Follow the prompts to add the `hourly` and `is_incident` event filters to the `s
 
 You will receive a confirmation message:
 
-{{< code shell >}}
+{{< code text >}}
 Updated
 {{< /code >}}
 
@@ -165,7 +165,7 @@ The updated handler definition will be similar to this example:
 
 {{< language-toggle >}}
 
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: Handler
 api_version: core/v2
@@ -186,7 +186,7 @@ spec:
   type: pipe
 {{< /code >}}
 
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Handler",
   "api_version": "core/v2",
@@ -411,7 +411,7 @@ sensuctl handler update slack
 
 Follow the prompts to add the `fatigue_check` and `is_incident` event filters to the `slack handler`:
 
-{{< code shell >}}
+{{< code text >}}
 ? Environment variables: SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0000/B000/XXXXXXXX
 ? Filters: fatigue_check,is_incident
 ? Mutator: 
@@ -423,7 +423,7 @@ Follow the prompts to add the `fatigue_check` and `is_incident` event filters to
 
 You will receive a confirmation message:
 
-{{< code shell >}}
+{{< code text >}}
 Updated
 {{< /code >}}
 
@@ -445,7 +445,7 @@ The updated handler definition will be similar to this example:
 
 {{< language-toggle >}}
 
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: Handler
 api_version: core/v2
@@ -466,7 +466,7 @@ spec:
   type: pipe
 {{< /code >}}
 
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Handler",
   "api_version": "core/v2",

--- a/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.4/operations/control-access/create-limited-service-accounts.md
@@ -48,8 +48,9 @@ sensuctl user create ec2-service --password=$(head -c1M /dev/urandom | sha512sum
 {{< /code >}}
 
    This command creates the following user definition:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: User
 api_version: core/v2
@@ -59,7 +60,7 @@ spec:
   disabled: false
   username: ec2-service
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "User",
   "api_version": "core/v2",
@@ -81,8 +82,9 @@ sensuctl role create ec2-delete --verb get,list,delete --resource entities --nam
 {{< /code >}}
 
    This command creates the role that has the permissions your service account will need:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: Role
 api_version: core/v2
@@ -98,7 +100,7 @@ spec:
     - list
     - delete
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Role",
   "api_version": "core/v2",
@@ -132,7 +134,7 @@ sensuctl role-binding create ec2-service-delete --role ec2-delete --user ec2-ser
 
    This command creates the role binding that ties the correct permissions (via the `ec2-delete` role) with your service account (via the user `ec2-service`):
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: RoleBinding
 api_version: core/v2
@@ -146,7 +148,7 @@ spec:
   - name: ec2-service
     type: User
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "RoleBinding",
   "api_version": "core/v2",

--- a/content/sensu-go/6.4/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.4/operations/control-access/create-read-only-user.md
@@ -33,13 +33,13 @@ sensuctl user create alice --password='password' --groups=ops
 
    This command creates the following user:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 username: alice
 groups:
 - ops
 disabled: false
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "username": "alice",
   "groups": [
@@ -57,7 +57,7 @@ sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 
    This command creates the following role resource definition:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: Role
 api_version: core/v2
@@ -72,7 +72,7 @@ spec:
     - get
     - list
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Role",
   "api_version": "core/v2",
@@ -103,8 +103,9 @@ sensuctl role-binding create ops-read-only --role=read-only --group=ops
 {{< /code >}}
 
    This command creates the following role binding resource definition:
+
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: RoleBinding
 api_version: core/v2
@@ -118,7 +119,7 @@ spec:
   - name: ops
     type: Group
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "RoleBinding",
   "api_version": "core/v2",
@@ -158,13 +159,13 @@ sensuctl user create bob --password='password' --groups=ops
 
    This command creates the following user:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 username: bob
 groups:
 - ops
 disabled: false
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "username": "bob",
   "groups": [
@@ -181,8 +182,9 @@ sensuctl cluster-role create global-event-reader --verb=get,list --resource=even
 {{< /code >}}
 
    This command creates the following cluster role resource definition:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: ClusterRole
 api_version: core/v2
@@ -197,7 +199,7 @@ spec:
     - get
     - list
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "ClusterRole",
   "api_version": "core/v2",
@@ -228,8 +230,9 @@ sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-even
 {{< /code >}}
 
    This command creates the following cluster role binding resource definition:
+
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: ClusterRoleBinding
 api_version: core/v2
@@ -243,7 +246,7 @@ spec:
   - name: ops
     type: Group
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -133,16 +133,18 @@ If you want to share and reuse this event filter like code, you can [save it to 
 
 ### Add the event filter to a pipeline
 
-Now that you've created the `hourly` event filter, you can add it to a pipeline along with the `slack` handler created in [Send Slack alerts with handlers][3].
-You'll also add the built-in `is_incident` filter so that only failing events are handled, which will further reduce the number of Slack messages Sensu sends.
+Now that you've created the `hourly` event filter, you can include it in a new pipeline, along with the `slack` handler created in [Send Slack alerts with handlers][3].
+You'll also include the built-in `is_incident` filter so that only failing events are handled, which will further reduce the number of Slack messages Sensu sends.
 
 {{% notice note %}}
 **NOTE**: If you haven't already created the `slack` handler, follow [Send Slack alerts with handlers](../../observe-process/send-slack-alerts/) before continuing with this step.
 {{% /notice %}}
 
+To create a new pipeline that includes the `hourly` and `is_incident` event filters as well as the `slack` handler, run:
+
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -164,7 +166,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",

--- a/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.5/operations/control-access/create-limited-service-accounts.md
@@ -48,8 +48,9 @@ sensuctl user create ec2-service --password=$(head -c1M /dev/urandom | sha512sum
 {{< /code >}}
 
    This command creates the following user definition:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: User
 api_version: core/v2
@@ -59,7 +60,7 @@ spec:
   disabled: false
   username: ec2-service
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "User",
   "api_version": "core/v2",
@@ -81,8 +82,9 @@ sensuctl role create ec2-delete --verb get,list,delete --resource entities --nam
 {{< /code >}}
 
    This command creates the role that has the permissions your service account will need:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: Role
 api_version: core/v2
@@ -98,7 +100,7 @@ spec:
     - list
     - delete
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Role",
   "api_version": "core/v2",
@@ -132,7 +134,7 @@ sensuctl role-binding create ec2-service-delete --role ec2-delete --user ec2-ser
 
    This command creates the role binding that ties the correct permissions (via the `ec2-delete` role) with your service account (via the user `ec2-service`):
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: RoleBinding
 api_version: core/v2
@@ -146,7 +148,7 @@ spec:
   - name: ec2-service
     type: User
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "RoleBinding",
   "api_version": "core/v2",

--- a/content/sensu-go/6.5/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.5/operations/control-access/create-read-only-user.md
@@ -33,13 +33,13 @@ sensuctl user create alice --password='password' --groups=ops
 
    This command creates the following user:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 username: alice
 groups:
 - ops
 disabled: false
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "username": "alice",
   "groups": [
@@ -56,8 +56,9 @@ sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /code >}}
 
    This command creates the following role resource definition:
+
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: Role
 api_version: core/v2
@@ -72,7 +73,7 @@ spec:
     - get
     - list
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Role",
   "api_version": "core/v2",
@@ -103,8 +104,9 @@ sensuctl role-binding create ops-read-only --role=read-only --group=ops
 {{< /code >}}
 
    This command creates the following role binding resource definition:
+
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: RoleBinding
 api_version: core/v2
@@ -118,7 +120,7 @@ spec:
   - name: ops
     type: Group
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "RoleBinding",
   "api_version": "core/v2",
@@ -158,13 +160,13 @@ sensuctl user create bob --password='password' --groups=ops
 
    This command creates the following user:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 username: bob
 groups:
 - ops
 disabled: false
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "username": "bob",
   "groups": [
@@ -181,8 +183,9 @@ sensuctl cluster-role create global-event-reader --verb=get,list --resource=even
 {{< /code >}}
 
    This command creates the following cluster role resource definition:
+
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: ClusterRole
 api_version: core/v2
@@ -197,7 +200,7 @@ spec:
     - get
     - list
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "ClusterRole",
   "api_version": "core/v2",
@@ -228,8 +231,9 @@ sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-even
 {{< /code >}}
 
    This command creates the following cluster role binding resource definition:
+
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: ClusterRoleBinding
 api_version: core/v2
@@ -243,7 +247,7 @@ spec:
   - name: ops
     type: Group
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -133,16 +133,18 @@ If you want to share and reuse this event filter like code, you can [save it to 
 
 ### Add the event filter to a pipeline
 
-Now that you've created the `hourly` event filter, you can add it to a pipeline along with the `slack` handler created in [Send Slack alerts with handlers][3].
-You'll also add the built-in `is_incident` filter so that only failing events are handled, which will further reduce the number of Slack messages Sensu sends.
+Now that you've created the `hourly` event filter, you can include it in a new pipeline, along with the `slack` handler created in [Send Slack alerts with handlers][3].
+You'll also include the built-in `is_incident` filter so that only failing events are handled, which will further reduce the number of Slack messages Sensu sends.
 
 {{% notice note %}}
 **NOTE**: If you haven't already created the `slack` handler, follow [Send Slack alerts with handlers](../../observe-process/send-slack-alerts/) before continuing with this step.
 {{% /notice %}}
 
+To create a new pipeline that includes the `hourly` and `is_incident` event filters as well as the `slack` handler, run:
+
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -164,7 +166,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",

--- a/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.6/operations/control-access/create-limited-service-accounts.md
@@ -48,8 +48,9 @@ sensuctl user create ec2-service --password=$(head -c1M /dev/urandom | sha512sum
 {{< /code >}}
 
    This command creates the following user definition:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: User
 api_version: core/v2
@@ -59,7 +60,7 @@ spec:
   disabled: false
   username: ec2-service
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "User",
   "api_version": "core/v2",
@@ -81,8 +82,9 @@ sensuctl role create ec2-delete --verb get,list,delete --resource entities --nam
 {{< /code >}}
 
    This command creates the role that has the permissions your service account will need:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: Role
 api_version: core/v2
@@ -98,7 +100,7 @@ spec:
     - list
     - delete
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Role",
   "api_version": "core/v2",
@@ -132,7 +134,7 @@ sensuctl role-binding create ec2-service-delete --role ec2-delete --user ec2-ser
 
    This command creates the role binding that ties the correct permissions (via the `ec2-delete` role) with your service account (via the user `ec2-service`):
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: RoleBinding
 api_version: core/v2
@@ -146,7 +148,7 @@ spec:
   - name: ec2-service
     type: User
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "RoleBinding",
   "api_version": "core/v2",

--- a/content/sensu-go/6.6/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.6/operations/control-access/create-read-only-user.md
@@ -33,13 +33,13 @@ sensuctl user create alice --password='password' --groups=ops
 
    This command creates the following user:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 username: alice
 groups:
 - ops
 disabled: false
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "username": "alice",
   "groups": [
@@ -158,13 +158,13 @@ sensuctl user create bob --password='password' --groups=ops
 
    This command creates the following user:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 username: bob
 groups:
 - ops
 disabled: false
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "username": "bob",
   "groups": [

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -133,16 +133,18 @@ If you want to share and reuse this event filter like code, you can [save it to 
 
 ### Add the event filter to a pipeline
 
-Now that you've created the `hourly` event filter, you can add it to a pipeline along with the `slack` handler created in [Send Slack alerts with handlers][3].
-You'll also add the built-in `is_incident` filter so that only failing events are handled, which will further reduce the number of Slack messages Sensu sends.
+Now that you've created the `hourly` event filter, you can include it in a new pipeline, along with the `slack` handler created in [Send Slack alerts with handlers][3].
+You'll also include the built-in `is_incident` filter so that only failing events are handled, which will further reduce the number of Slack messages Sensu sends.
 
 {{% notice note %}}
 **NOTE**: If you haven't already created the `slack` handler, follow [Send Slack alerts with handlers](../../observe-process/send-slack-alerts/) before continuing with this step.
 {{% /notice %}}
 
+To create a new pipeline that includes the `hourly` and `is_incident` event filters as well as the `slack` handler, run:
+
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -164,7 +166,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",

--- a/content/sensu-go/6.7/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.7/operations/control-access/create-limited-service-accounts.md
@@ -48,8 +48,9 @@ sensuctl user create ec2-service --password=$(head -c1M /dev/urandom | sha512sum
 {{< /code >}}
 
    This command creates the following user definition:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: User
 api_version: core/v2
@@ -59,7 +60,7 @@ spec:
   disabled: false
   username: ec2-service
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "User",
   "api_version": "core/v2",
@@ -81,8 +82,9 @@ sensuctl role create ec2-delete --verb get,list,delete --resource entities --nam
 {{< /code >}}
 
    This command creates the role that has the permissions your service account will need:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: Role
 api_version: core/v2
@@ -98,7 +100,7 @@ spec:
     - list
     - delete
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Role",
   "api_version": "core/v2",
@@ -132,7 +134,7 @@ sensuctl role-binding create ec2-service-delete --role ec2-delete --user ec2-ser
 
    This command creates the role binding that ties the correct permissions (via the `ec2-delete` role) with your service account (via the user `ec2-service`):
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: RoleBinding
 api_version: core/v2
@@ -146,7 +148,7 @@ spec:
   - name: ec2-service
     type: User
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "RoleBinding",
   "api_version": "core/v2",

--- a/content/sensu-go/6.7/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.7/operations/control-access/create-read-only-user.md
@@ -33,13 +33,13 @@ sensuctl user create alice --password='password' --groups=ops
 
    This command creates the following user:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 username: alice
 groups:
 - ops
 disabled: false
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "username": "alice",
   "groups": [
@@ -56,8 +56,9 @@ sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /code >}}
 
    This command creates the following role resource definition:
+
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: Role
 api_version: core/v2
@@ -72,7 +73,7 @@ spec:
     - get
     - list
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Role",
   "api_version": "core/v2",
@@ -104,7 +105,7 @@ sensuctl role-binding create ops-read-only --role=read-only --group=ops
 
    This command creates the following role binding resource definition:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: RoleBinding
 api_version: core/v2
@@ -118,7 +119,7 @@ spec:
   - name: ops
     type: Group
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "RoleBinding",
   "api_version": "core/v2",
@@ -158,13 +159,13 @@ sensuctl user create bob --password='password' --groups=ops
 
    This command creates the following user:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 username: bob
 groups:
 - ops
 disabled: false
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "username": "bob",
   "groups": [
@@ -181,8 +182,9 @@ sensuctl cluster-role create global-event-reader --verb=get,list --resource=even
 {{< /code >}}
 
    This command creates the following cluster role resource definition:
+
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: ClusterRole
 api_version: core/v2
@@ -197,7 +199,7 @@ spec:
     - get
     - list
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "ClusterRole",
   "api_version": "core/v2",
@@ -228,8 +230,9 @@ sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-even
 {{< /code >}}
 
    This command creates the following cluster role binding resource definition:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: ClusterRoleBinding
 api_version: core/v2
@@ -243,7 +246,7 @@ spec:
   - name: ops
     type: Group
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",

--- a/content/sensu-go/6.8/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -133,16 +133,18 @@ If you want to share and reuse this event filter like code, you can [save it to 
 
 ### Add the event filter to a pipeline
 
-Now that you've created the `hourly` event filter, you can add it to a pipeline along with the `slack` handler created in [Send Slack alerts with handlers][3].
-You'll also add the built-in `is_incident` filter so that only failing events are handled, which will further reduce the number of Slack messages Sensu sends.
+Now that you've created the `hourly` event filter, you can include it in a new pipeline, along with the `slack` handler created in [Send Slack alerts with handlers][3].
+You'll also include the built-in `is_incident` filter so that only failing events are handled, which will further reduce the number of Slack messages Sensu sends.
 
 {{% notice note %}}
 **NOTE**: If you haven't already created the `slack` handler, follow [Send Slack alerts with handlers](../../observe-process/send-slack-alerts/) before continuing with this step.
 {{% /notice %}}
 
+To create a new pipeline that includes the `hourly` and `is_incident` event filters as well as the `slack` handler, run:
+
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -164,7 +166,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",

--- a/content/sensu-go/6.8/operations/control-access/create-limited-service-accounts.md
+++ b/content/sensu-go/6.8/operations/control-access/create-limited-service-accounts.md
@@ -48,8 +48,9 @@ sensuctl user create ec2-service --password=$(head -c1M /dev/urandom | sha512sum
 {{< /code >}}
 
    This command creates the following user definition:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: User
 api_version: core/v2
@@ -59,7 +60,7 @@ spec:
   disabled: false
   username: ec2-service
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "User",
   "api_version": "core/v2",
@@ -81,8 +82,9 @@ sensuctl role create ec2-delete --verb get,list,delete --resource entities --nam
 {{< /code >}}
 
    This command creates the role that has the permissions your service account will need:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: Role
 api_version: core/v2
@@ -98,7 +100,7 @@ spec:
     - list
     - delete
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Role",
   "api_version": "core/v2",
@@ -132,7 +134,7 @@ sensuctl role-binding create ec2-service-delete --role ec2-delete --user ec2-ser
 
    This command creates the role binding that ties the correct permissions (via the `ec2-delete` role) with your service account (via the user `ec2-service`):
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YML" >}}
 ---
 type: RoleBinding
 api_version: core/v2
@@ -146,7 +148,7 @@ spec:
   - name: ec2-service
     type: User
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "RoleBinding",
   "api_version": "core/v2",

--- a/content/sensu-go/6.8/operations/control-access/create-read-only-user.md
+++ b/content/sensu-go/6.8/operations/control-access/create-read-only-user.md
@@ -33,13 +33,13 @@ sensuctl user create alice --password='password' --groups=ops
 
    This command creates the following user:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 username: alice
 groups:
 - ops
 disabled: false
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "username": "alice",
   "groups": [
@@ -56,8 +56,9 @@ sensuctl role create read-only --verb=get,list --resource=* --namespace=default
 {{< /code >}}
 
    This command creates the following role resource definition:
+
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: Role
 api_version: core/v2
@@ -72,7 +73,7 @@ spec:
     - get
     - list
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "Role",
   "api_version": "core/v2",
@@ -104,7 +105,7 @@ sensuctl role-binding create ops-read-only --role=read-only --group=ops
 
    This command creates the following role binding resource definition:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: RoleBinding
 api_version: core/v2
@@ -118,7 +119,7 @@ spec:
   - name: ops
     type: Group
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "RoleBinding",
   "api_version": "core/v2",
@@ -158,13 +159,13 @@ sensuctl user create bob --password='password' --groups=ops
 
    This command creates the following user:
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 username: bob
 groups:
 - ops
 disabled: false
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "username": "bob",
   "groups": [
@@ -181,8 +182,9 @@ sensuctl cluster-role create global-event-reader --verb=get,list --resource=even
 {{< /code >}}
 
    This command creates the following cluster role resource definition:
+
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: ClusterRole
 api_version: core/v2
@@ -197,7 +199,7 @@ spec:
     - get
     - list
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "ClusterRole",
   "api_version": "core/v2",
@@ -228,8 +230,9 @@ sensuctl cluster-role-binding create ops-event-reader --cluster-role=global-even
 {{< /code >}}
 
    This command creates the following cluster role binding resource definition:
+   
    {{< language-toggle >}}
-{{< code yml >}}
+{{< code text "YAML" >}}
 ---
 type: ClusterRoleBinding
 api_version: core/v2
@@ -243,7 +246,7 @@ spec:
   - name: ops
     type: Group
 {{< /code >}}
-{{< code json >}}
+{{< code text "JSON" >}}
 {
   "type": "ClusterRoleBinding",
   "api_version": "core/v2",


### PR DESCRIPTION
## Description
Removes copy functions from responses in:
- https://docs.sensu.io/sensu-go/latest/operations/control-access/create-read-only-user/
- https://docs.sensu.io/sensu-go/latest/operations/control-access/create-limited-service-accounts/

## Motivation and Context
Found when working on something else

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>