### PR TITLE
Minor fixes in sensuctl and web UI docs

### DIFF
--- a/content/sensu-go/6.4/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.4/sensuctl/create-manage-resources.md
@@ -612,7 +612,7 @@ Combine the resource command with a [subcommand][23] to complete operations like
 - [`sensuctl namespace`][21]
 - [`sensuctl role`][35]
 - [`sensuctl role-binding`][44]
-- [`sensuctl secrets`][28]
+- [`sensuctl secret`][28]
 - [`sensuctl silenced`][20]
 - [`sensuctl tessen`][27]
 - [`sensuctl user`][22]

--- a/content/sensu-go/6.5/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.5/sensuctl/create-manage-resources.md
@@ -613,7 +613,7 @@ Combine the resource command with a [subcommand][23] to complete operations like
 - [`sensuctl pipeline`][9]
 - [`sensuctl role`][35]
 - [`sensuctl role-binding`][44]
-- [`sensuctl secrets`][28]
+- [`sensuctl secret`][28]
 - [`sensuctl silenced`][20]
 - [`sensuctl tessen`][27]
 - [`sensuctl user`][22]

--- a/content/sensu-go/6.6/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.6/sensuctl/create-manage-resources.md
@@ -613,7 +613,7 @@ Combine the resource command with a [subcommand][23] to complete operations like
 - [`sensuctl pipeline`][9]
 - [`sensuctl role`][35]
 - [`sensuctl role-binding`][44]
-- [`sensuctl secrets`][28]
+- [`sensuctl secret`][28]
 - [`sensuctl silenced`][20]
 - [`sensuctl tessen`][27]
 - [`sensuctl user`][22]

--- a/content/sensu-go/6.7/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.7/sensuctl/create-manage-resources.md
@@ -618,7 +618,7 @@ Combine the resource command with a [subcommand][23] to complete operations like
 - [`sensuctl pipeline`][9]
 - [`sensuctl role`][35]
 - [`sensuctl role-binding`][44]
-- [`sensuctl secrets`][28]
+- [`sensuctl secret`][28]
 - [`sensuctl silenced`][20]
 - [`sensuctl tessen`][27]
 - [`sensuctl user`][22]

--- a/content/sensu-go/6.7/web-ui/_index.md
+++ b/content/sensu-go/6.7/web-ui/_index.md
@@ -57,7 +57,7 @@ A banner appears at the top of the web UI screen when your organization's licens
 The banner is only visible to [users][6] who have read access to your organization's license.
 
 By default, the banner starts appearing when the license expiration is 30 days away.
-To adjust the number of days before license expiration to begin displaying the banner, use the [license_expiry_reminder][9] web configuration attribute.
+To adjust the number of days before license expiration to begin displaying the banner, use the [license_expiry_reminder][9] web UI configuration attribute.
 
 ## Use the implicit OR operator
 

--- a/content/sensu-go/6.8/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.8/sensuctl/create-manage-resources.md
@@ -618,7 +618,7 @@ Combine the resource command with a [subcommand][23] to complete operations like
 - [`sensuctl pipeline`][9]
 - [`sensuctl role`][35]
 - [`sensuctl role-binding`][44]
-- [`sensuctl secrets`][28]
+- [`sensuctl secret`][28]
 - [`sensuctl silenced`][20]
 - [`sensuctl tessen`][27]
 - [`sensuctl user`][22]

--- a/content/sensu-go/6.8/web-ui/_index.md
+++ b/content/sensu-go/6.8/web-ui/_index.md
@@ -57,7 +57,7 @@ A banner appears at the top of the web UI screen when your organization's licens
 The banner is only visible to [users][6] who have read access to your organization's license.
 
 By default, the banner starts appearing when the license expiration is 30 days away.
-To adjust the number of days before license expiration to begin displaying the banner, use the [license_expiry_reminder][9] web configuration attribute.
+To adjust the number of days before license expiration to begin displaying the banner, use the [license_expiry_reminder][9] web UI configuration attribute.
 
 ## Use the implicit OR operator
 


### PR DESCRIPTION
## Description
- Fixes `sensuctl secrets` (should be singular `secret`) in https://docs.sensu.io/sensu-go/latest/sensuctl/create-manage-resources/#manage-resources
- Fixes `web configuration attribute` (should be `web UI configuration attribute`) in https://docs.sensu.io/sensu-go/latest/web-ui/#license-expiration-banner

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>