### PR TITLE
Fix copy buttons and other code formatting in filtering guides

### DIFF
--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -500,9 +500,13 @@ spec:
 Verify the proper behavior of these event filters with `sensu-backend` logs.
 The default location of these logs varies based on the platform used (read [Troubleshoot Sensu][2] for details).
 
-Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by
-a second log entry with the message `"msg":"pipelined executed event pipe
-handler","output":"","status":0`.
+Whenever an event is being handled, two log entries are added:
+
+{{< code text >}}
+"handler":"slack","level":"debug","msg":"sending event to handler"
+"msg":"pipelined executed event pipe handler","output":"","status":0
+{{< /code >}}
+
 However, if the event is being discarded by the event filter, a log entry with the message `event filtered` will appear instead.
 
 ## Next steps

--- a/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.4/observability-pipeline/observe-filter/route-alerts.md
@@ -114,7 +114,7 @@ Use sensuctl to create the three event filters:
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: EventFilter
 api_version: core/v2
@@ -150,7 +150,7 @@ spec:
     - no_contacts(event)' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "EventFilter",
   "api_version": "core/v2",
@@ -262,7 +262,7 @@ After you update the code to use your preferred Slack channels and webhook URL, 
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -603,7 +603,7 @@ You'll also add the built-in `is_incident` filter so that only failing events ar
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -625,7 +625,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",
@@ -667,9 +667,13 @@ Instead of waiting to receive a Slack alert, you can verify the proper behavior 
 The default location of these logs varies based on your platform.
 Read [Troubleshoot Sensu][2] for details about the log location.
 
-Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by
-a second log entry with the message `"msg":"pipelined executed event pipe
-handler","output":"","status":0`.
+Whenever an event is being handled, two log entries are added:
+
+{{< code text >}}
+"handler":"slack","level":"debug","msg":"sending event to handler"
+"msg":"pipelined executed event pipe handler","output":"","status":0
+{{< /code >}}
+
 However, if the event is being discarded by the event filter, a log entry with the message `event filtered` will appear instead.
 
 ## Next steps

--- a/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-filter/route-alerts.md
@@ -147,7 +147,7 @@ Use sensuctl to create the three event filters:
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: EventFilter
 api_version: core/v2
@@ -183,7 +183,7 @@ spec:
     - no_contacts(event)' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "EventFilter",
   "api_version": "core/v2",
@@ -274,7 +274,7 @@ After you update the code to use your preferred Slack channels and webhook URL, 
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -322,7 +322,7 @@ spec:
   type: pipe' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Handler",
   "api_version": "core/v2",
@@ -414,7 +414,7 @@ All of the workflows also include the built-in [is_incident event filter][20] to
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -460,7 +460,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -603,7 +603,7 @@ You'll also add the built-in `is_incident` filter so that only failing events ar
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -625,7 +625,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",
@@ -667,9 +667,13 @@ Instead of waiting to receive a Slack alert, you can verify the proper behavior 
 The default location of these logs varies based on your platform.
 Read [Troubleshoot Sensu][2] for details about the log location.
 
-Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by
-a second log entry with the message `"msg":"pipelined executed event pipe
-handler","output":"","status":0`.
+Whenever an event is being handled, two log entries are added:
+
+{{< code text >}}
+"handler":"slack","level":"debug","msg":"sending event to handler"
+"msg":"pipelined executed event pipe handler","output":"","status":0
+{{< /code >}}
+
 However, if the event is being discarded by the event filter, a log entry with the message `event filtered` will appear instead.
 
 ## Next steps

--- a/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-filter/route-alerts.md
@@ -147,7 +147,7 @@ Use sensuctl to create the three event filters:
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: EventFilter
 api_version: core/v2
@@ -183,7 +183,7 @@ spec:
     - no_contacts(event)' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "EventFilter",
   "api_version": "core/v2",
@@ -274,7 +274,7 @@ After you update the code to use your preferred Slack channels and webhook URL, 
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -322,7 +322,7 @@ spec:
   type: pipe' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Handler",
   "api_version": "core/v2",
@@ -414,7 +414,7 @@ All of the workflows also include the built-in [is_incident event filter][20] to
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -460,7 +460,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -603,7 +603,7 @@ You'll also add the built-in `is_incident` filter so that only failing events ar
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -625,7 +625,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",
@@ -667,9 +667,13 @@ Instead of waiting to receive a Slack alert, you can verify the proper behavior 
 The default location of these logs varies based on your platform.
 Read [Troubleshoot Sensu][2] for details about the log location.
 
-Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by
-a second log entry with the message `"msg":"pipelined executed event pipe
-handler","output":"","status":0`.
+Whenever an event is being handled, two log entries are added:
+
+{{< code text >}}
+"handler":"slack","level":"debug","msg":"sending event to handler"
+"msg":"pipelined executed event pipe handler","output":"","status":0
+{{< /code >}}
+
 However, if the event is being discarded by the event filter, a log entry with the message `event filtered` will appear instead.
 
 ## Next steps

--- a/content/sensu-go/6.7/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-filter/route-alerts.md
@@ -147,7 +147,7 @@ Use sensuctl to create the three event filters:
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: EventFilter
 api_version: core/v2
@@ -183,7 +183,7 @@ spec:
     - no_contacts(event)' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "EventFilter",
   "api_version": "core/v2",
@@ -274,7 +274,7 @@ After you update the code to use your preferred Slack channels and webhook URL, 
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -322,7 +322,7 @@ spec:
   type: pipe' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Handler",
   "api_version": "core/v2",
@@ -414,7 +414,7 @@ All of the workflows also include the built-in [is_incident event filter][20] to
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -460,7 +460,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",

--- a/content/sensu-go/6.8/observability-pipeline/observe-filter/reduce-alert-fatigue.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-filter/reduce-alert-fatigue.md
@@ -603,7 +603,7 @@ You'll also add the built-in `is_incident` filter so that only failing events ar
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -625,7 +625,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",
@@ -667,9 +667,13 @@ Instead of waiting to receive a Slack alert, you can verify the proper behavior 
 The default location of these logs varies based on your platform.
 Read [Troubleshoot Sensu][2] for details about the log location.
 
-Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by
-a second log entry with the message `"msg":"pipelined executed event pipe
-handler","output":"","status":0`.
+Whenever an event is being handled, two log entries are added:
+
+{{< code text >}}
+"handler":"slack","level":"debug","msg":"sending event to handler"
+"msg":"pipelined executed event pipe handler","output":"","status":0
+{{< /code >}}
+
 However, if the event is being discarded by the event filter, a log entry with the message `event filtered` will appear instead.
 
 ## Next steps

--- a/content/sensu-go/6.8/observability-pipeline/observe-filter/route-alerts.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-filter/route-alerts.md
@@ -147,7 +147,7 @@ Use sensuctl to create the three event filters:
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: EventFilter
 api_version: core/v2
@@ -183,7 +183,7 @@ spec:
     - no_contacts(event)' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "EventFilter",
   "api_version": "core/v2",
@@ -274,7 +274,7 @@ After you update the code to use your preferred Slack channels and webhook URL, 
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Handler
 api_version: core/v2
@@ -322,7 +322,7 @@ spec:
   type: pipe' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Handler",
   "api_version": "core/v2",
@@ -414,7 +414,7 @@ All of the workflows also include the built-in [is_incident event filter][20] to
 
 {{< language-toggle >}}
 
-{{< code text "YML" >}}
+{{< code shell "YML" >}}
 echo '---
 type: Pipeline
 api_version: core/v2
@@ -460,7 +460,7 @@ spec:
       api_version: core/v2' | sensuctl create
 {{< /code >}}
 
-{{< code text "JSON" >}}
+{{< code shell "JSON" >}}
 echo '{
   "type": "Pipeline",
   "api_version": "core/v2",


### PR DESCRIPTION
## Description
Fixes copy button formatting and other code formatting in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-filter/reduce-alert-fatigue/ and https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-filter/route-alerts/

## Motivation and Context
Found when working on other docs

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>
