### PR TITLE
Update sensuctl backup commands

### DIFF
--- a/content/sensu-go/6.4/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.4/sensuctl/back-up-recover.md
@@ -15,7 +15,7 @@ The sensuctl dump command allows you to export your [resources][6] to standard o
 You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format:
 
 {{< language-toggle >}}
 
@@ -25,10 +25,6 @@ sensuctl dump all --format yaml --file my-resources.yml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump all --format wrapped-json --file my-resources.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump all --format json --file my-resources.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -46,7 +42,7 @@ This page explains how to back up your resources for two common use cases: befor
 
 ## Example sensuctl dump commands
 
-To export only checks for only the current namespace to stdout in YAML or JSON format:
+To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
 
 {{< language-toggle >}}
 
@@ -58,13 +54,9 @@ sensuctl dump core/v2.CheckConfig --format yaml
 sensuctl dump core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.CheckConfig --format json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or JSON format:
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
 
 {{< language-toggle >}}
 
@@ -74,10 +66,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handle
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -95,10 +83,6 @@ sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump all --all-namespaces --format json --file my-resources.json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 {{< language-toggle >}}
@@ -111,10 +95,6 @@ sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 {{< language-toggle >}}
@@ -125,10 +105,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -146,10 +122,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handle
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 Here's an example that uses short names:
@@ -162,10 +134,6 @@ sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -186,19 +154,15 @@ mkdir backup
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format yaml > backup/config.yml
+--format yaml \
+--file backup/config.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format wrapped-json > backup/config.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump all \
---all-namespaces \
---omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format json > backup/config.json
+--format wrapped-json \
+--file backup/config.json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -207,17 +171,14 @@ sensuctl dump all \
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format yaml > backup/rbac.yml
+--format yaml \
+--file backup/rbac.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format wrapped-json > backup/rbac.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---all-namespaces \
---format json > backup/rbac.json
+--format wrapped-json \
+--file backup/rbac.json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -226,17 +187,14 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 {{< code shell "YML" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format yaml > backup/cannotrestore.yml
+--format yaml \
+--file backup/cannotrestore.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format wrapped-json > backup/cannotrestore.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.APIKey,core/v2.User \
---all-namespaces \
---format json > backup/cannotrestore.json
+--format wrapped-json \
+--file backup/cannotrestore.json
 {{< /code >}}
 {{< /language-toggle >}}
 {{% notice note %}}
@@ -250,17 +208,14 @@ Because users require this additional configuration and API keys cannot be resto
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format yaml > backup/inventory.yml
+--format yaml \
+--file backup/inventory.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format wrapped-json > backup/inventory.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Entity \
---all-namespaces \
---format json > backup/inventory.json
+--format wrapped-json \
+--file backup/inventory.json
 {{< /code >}}
 {{< /language-toggle >}}
 {{% notice note %}}
@@ -291,11 +246,6 @@ sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.Event
 --all-namespaces \
 --format wrapped-json | grep -v "^\s*namespace:" > backup/pipelines.json
 {{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
---all-namespaces \
---format json | grep -v "^\s*namespace:" > backup/pipelines.json
-{{< /code >}}
 {{< /language-toggle >}}
 
 ## Restore resources from backup
@@ -316,7 +266,7 @@ To restore a subset of your exported resources (in this example, your RBAC resou
 sensuctl create -f backup/rbac.yml
 {{< /code >}}
 
-{{< code shell "JSON" >}}
+{{< code shell "Wrapped JSON" >}}
 sensuctl create -f backup/rbac.json
 {{< /code >}}
 

--- a/content/sensu-go/6.5/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.5/sensuctl/back-up-recover.md
@@ -15,7 +15,7 @@ The sensuctl dump command allows you to export your [resources][6] to standard o
 You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format:
 
 {{< language-toggle >}}
 
@@ -25,10 +25,6 @@ sensuctl dump all --format yaml --file my-resources.yml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump all --format wrapped-json --file my-resources.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump all --format json --file my-resources.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -46,7 +42,7 @@ This page explains how to back up your resources for two common use cases: befor
 
 ## Example sensuctl dump commands
 
-To export only checks for only the current namespace to stdout in YAML or JSON format:
+To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
 
 {{< language-toggle >}}
 
@@ -58,13 +54,9 @@ sensuctl dump core/v2.CheckConfig --format yaml
 sensuctl dump core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.CheckConfig --format json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or JSON format:
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
 
 {{< language-toggle >}}
 
@@ -74,10 +66,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handle
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -95,10 +83,6 @@ sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump all --all-namespaces --format json --file my-resources.json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 {{< language-toggle >}}
@@ -111,10 +95,6 @@ sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 {{< language-toggle >}}
@@ -125,10 +105,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -146,10 +122,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handle
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 Here's an example that uses short names:
@@ -162,10 +134,6 @@ sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -186,19 +154,15 @@ mkdir backup
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format yaml > backup/config.yml
+--format yaml \
+--file backup/config.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format wrapped-json > backup/config.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump all \
---all-namespaces \
---omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format json > backup/config.json
+--format wrapped-json \
+--file backup/config.json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -207,17 +171,14 @@ sensuctl dump all \
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format yaml > backup/rbac.yml
+--format yaml \
+--file backup/rbac.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format wrapped-json > backup/rbac.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---all-namespaces \
---format json > backup/rbac.json
+--format wrapped-json \
+--file backup/rbac.json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -226,17 +187,14 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 {{< code shell "YML" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format yaml > backup/cannotrestore.yml
+--format yaml \
+--file backup/cannotrestore.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format wrapped-json > backup/cannotrestore.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.APIKey,core/v2.User \
---all-namespaces \
---format json > backup/cannotrestore.json
+--format wrapped-json \
+--file backup/cannotrestore.json
 {{< /code >}}
 {{< /language-toggle >}}
 {{% notice note %}}
@@ -250,17 +208,14 @@ Because users require this additional configuration and API keys cannot be resto
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format yaml > backup/inventory.yml
+--format yaml \
+--file backup/inventory.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format wrapped-json > backup/inventory.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Entity \
---all-namespaces \
---format json > backup/inventory.json
+--format wrapped-json \
+--file backup/inventory.json
 {{< /code >}}
 {{< /language-toggle >}}
 {{% notice note %}}
@@ -291,11 +246,6 @@ sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.Event
 --all-namespaces \
 --format wrapped-json | grep -v "^\s*namespace:" > backup/pipelines.json
 {{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
---all-namespaces \
---format json | grep -v "^\s*namespace:" > backup/pipelines.json
-{{< /code >}}
 {{< /language-toggle >}}
 
 ## Restore resources from backup
@@ -316,7 +266,7 @@ To restore a subset of your exported resources (in this example, your RBAC resou
 sensuctl create -f backup/rbac.yml
 {{< /code >}}
 
-{{< code shell "JSON" >}}
+{{< code shell "Wrapped JSON" >}}
 sensuctl create -f backup/rbac.json
 {{< /code >}}
 

--- a/content/sensu-go/6.6/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.6/sensuctl/back-up-recover.md
@@ -15,7 +15,7 @@ The sensuctl dump command allows you to export your [resources][6] to standard o
 You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format:
 
 {{< language-toggle >}}
 
@@ -25,10 +25,6 @@ sensuctl dump all --format yaml --file my-resources.yml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump all --format wrapped-json --file my-resources.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump all --format json --file my-resources.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -46,7 +42,7 @@ This page explains how to back up your resources for two common use cases: befor
 
 ## Example sensuctl dump commands
 
-To export only checks for only the current namespace to stdout in YAML or JSON format:
+To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
 
 {{< language-toggle >}}
 
@@ -58,13 +54,9 @@ sensuctl dump core/v2.CheckConfig --format yaml
 sensuctl dump core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.CheckConfig --format json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or JSON format:
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
 
 {{< language-toggle >}}
 
@@ -74,10 +66,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handle
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -95,10 +83,6 @@ sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump all --all-namespaces --format json --file my-resources.json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 {{< language-toggle >}}
@@ -111,10 +95,6 @@ sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 {{< language-toggle >}}
@@ -125,10 +105,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -146,10 +122,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handle
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 Here's an example that uses short names:
@@ -162,10 +134,6 @@ sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -186,19 +154,15 @@ mkdir backup
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format yaml > backup/config.yml
+--format yaml \
+--file backup/config.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format wrapped-json > backup/config.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump all \
---all-namespaces \
---omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format json > backup/config.json
+--format wrapped-json \
+--file backup/config.json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -207,17 +171,14 @@ sensuctl dump all \
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format yaml > backup/rbac.yml
+--format yaml \
+--file backup/rbac.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format wrapped-json > backup/rbac.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---all-namespaces \
---format json > backup/rbac.json
+--format wrapped-json \
+--file backup/rbac.json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -226,17 +187,14 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 {{< code shell "YML" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format yaml > backup/cannotrestore.yml
+--format yaml \
+--file backup/cannotrestore.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format wrapped-json > backup/cannotrestore.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.APIKey,core/v2.User \
---all-namespaces \
---format json > backup/cannotrestore.json
+--format wrapped-json \
+--file backup/cannotrestore.json
 {{< /code >}}
 {{< /language-toggle >}}
 {{% notice note %}}
@@ -250,17 +208,14 @@ Because users require this additional configuration and API keys cannot be resto
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format yaml > backup/inventory.yml
+--format yaml \
+--file backup/inventory.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format wrapped-json > backup/inventory.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Entity \
---all-namespaces \
---format json > backup/inventory.json
+--format wrapped-json \
+--file backup/inventory.json
 {{< /code >}}
 {{< /language-toggle >}}
 {{% notice note %}}
@@ -291,11 +246,6 @@ sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.Event
 --all-namespaces \
 --format wrapped-json | grep -v "^\s*namespace:" > backup/pipelines.json
 {{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
---all-namespaces \
---format json | grep -v "^\s*namespace:" > backup/pipelines.json
-{{< /code >}}
 {{< /language-toggle >}}
 
 ## Restore resources from backup
@@ -316,7 +266,7 @@ To restore a subset of your exported resources (in this example, your RBAC resou
 sensuctl create -f backup/rbac.yml
 {{< /code >}}
 
-{{< code shell "JSON" >}}
+{{< code shell "Wrapped JSON" >}}
 sensuctl create -f backup/rbac.json
 {{< /code >}}
 

--- a/content/sensu-go/6.7/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.7/sensuctl/back-up-recover.md
@@ -15,7 +15,7 @@ The sensuctl dump command allows you to export your [resources][6] to standard o
 You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format:
 
 {{< language-toggle >}}
 
@@ -25,10 +25,6 @@ sensuctl dump all --format yaml --file my-resources.yml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump all --format wrapped-json --file my-resources.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump all --format json --file my-resources.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -46,7 +42,7 @@ This page explains how to back up your resources for two common use cases: befor
 
 ## Example sensuctl dump commands
 
-To export only checks for only the current namespace to stdout in YAML or JSON format:
+To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
 
 {{< language-toggle >}}
 
@@ -58,13 +54,9 @@ sensuctl dump core/v2.CheckConfig --format yaml
 sensuctl dump core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.CheckConfig --format json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or JSON format:
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
 
 {{< language-toggle >}}
 
@@ -74,10 +66,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handle
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -95,10 +83,6 @@ sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump all --all-namespaces --format json --file my-resources.json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 {{< language-toggle >}}
@@ -111,10 +95,6 @@ sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 {{< language-toggle >}}
@@ -125,10 +105,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -146,10 +122,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handle
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 Here's an example that uses short names:
@@ -162,10 +134,6 @@ sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -186,19 +154,15 @@ mkdir backup
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format yaml > backup/config.yml
+--format yaml \
+--file backup/config.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format wrapped-json > backup/config.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump all \
---all-namespaces \
---omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format json > backup/config.json
+--format wrapped-json \
+--file backup/config.json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -207,17 +171,14 @@ sensuctl dump all \
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format yaml > backup/rbac.yml
+--format yaml \
+--file backup/rbac.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format wrapped-json > backup/rbac.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---all-namespaces \
---format json > backup/rbac.json
+--format wrapped-json \
+--file backup/rbac.json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -226,17 +187,14 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 {{< code shell "YML" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format yaml > backup/cannotrestore.yml
+--format yaml \
+--file backup/cannotrestore.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format wrapped-json > backup/cannotrestore.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.APIKey,core/v2.User \
---all-namespaces \
---format json > backup/cannotrestore.json
+--format wrapped-json \
+--file backup/cannotrestore.json
 {{< /code >}}
 {{< /language-toggle >}}
 {{% notice note %}}
@@ -250,17 +208,14 @@ Because users require this additional configuration and API keys cannot be resto
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format yaml > backup/inventory.yml
+--format yaml \
+--file backup/inventory.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format wrapped-json > backup/inventory.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Entity \
---all-namespaces \
---format json > backup/inventory.json
+--format wrapped-json \
+--file backup/inventory.json
 {{< /code >}}
 {{< /language-toggle >}}
 {{% notice note %}}
@@ -291,11 +246,6 @@ sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.Event
 --all-namespaces \
 --format wrapped-json | grep -v "^\s*namespace:" > backup/pipelines.json
 {{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
---all-namespaces \
---format json | grep -v "^\s*namespace:" > backup/pipelines.json
-{{< /code >}}
 {{< /language-toggle >}}
 
 ## Restore resources from backup
@@ -316,7 +266,7 @@ To restore a subset of your exported resources (in this example, your RBAC resou
 sensuctl create -f backup/rbac.yml
 {{< /code >}}
 
-{{< code shell "JSON" >}}
+{{< code shell "Wrapped JSON" >}}
 sensuctl create -f backup/rbac.json
 {{< /code >}}
 

--- a/content/sensu-go/6.8/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.8/sensuctl/back-up-recover.md
@@ -15,7 +15,7 @@ The sensuctl dump command allows you to export your [resources][6] to standard o
 You can export all resources or a subset of them based on a list of resource types.
 The `dump` command supports exporting in `wrapped-json` and `yaml`.
 
-For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format for use with sensuctl or `json` format for use with the Sensu API:
+For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format:
 
 {{< language-toggle >}}
 
@@ -25,10 +25,6 @@ sensuctl dump all --format yaml --file my-resources.yml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump all --format wrapped-json --file my-resources.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump all --format json --file my-resources.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -46,7 +42,7 @@ This page explains how to back up your resources for two common use cases: befor
 
 ## Example sensuctl dump commands
 
-To export only checks for only the current namespace to stdout in YAML or JSON format:
+To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
 
 {{< language-toggle >}}
 
@@ -58,13 +54,9 @@ sensuctl dump core/v2.CheckConfig --format yaml
 sensuctl dump core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.CheckConfig --format json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or JSON format:
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
 
 {{< language-toggle >}}
 
@@ -74,10 +66,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handle
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -95,10 +83,6 @@ sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
 sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump all --all-namespaces --format json --file my-resources.json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 {{< language-toggle >}}
@@ -111,10 +95,6 @@ sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
 sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 {{< language-toggle >}}
@@ -125,10 +105,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -146,10 +122,6 @@ sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handle
 sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format json --file my-handlers-and-filters.json
-{{< /code >}}
-
 {{< /language-toggle >}}
 
 Here's an example that uses short names:
@@ -162,10 +134,6 @@ sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
 
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< code shell "JSON" >}}
-sensuctl dump handlers,filters --format json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}
@@ -186,19 +154,15 @@ mkdir backup
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format yaml > backup/config.yml
+--format yaml \
+--file backup/config.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump all \
 --all-namespaces \
 --omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format wrapped-json > backup/config.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump all \
---all-namespaces \
---omit core/v2.Entity,core/v2.Event,core/v2.APIKey,core/v2.User,core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---format json > backup/config.json
+--format wrapped-json \
+--file backup/config.json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -207,17 +171,14 @@ sensuctl dump all \
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format yaml > backup/rbac.yml
+--format yaml \
+--file backup/rbac.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
 --all-namespaces \
---format wrapped-json > backup/rbac.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.ClusterRoleBinding \
---all-namespaces \
---format json > backup/rbac.json
+--format wrapped-json \
+--file backup/rbac.json
 {{< /code >}}
 {{< /language-toggle >}}
 
@@ -226,17 +187,14 @@ sensuctl dump core/v2.Role,core/v2.RoleBinding,core/v2.ClusterRole,core/v2.Clust
 {{< code shell "YML" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format yaml > backup/cannotrestore.yml
+--format yaml \
+--file backup/cannotrestore.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.APIKey,core/v2.User \
 --all-namespaces \
---format wrapped-json > backup/cannotrestore.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.APIKey,core/v2.User \
---all-namespaces \
---format json > backup/cannotrestore.json
+--format wrapped-json \
+--file backup/cannotrestore.json
 {{< /code >}}
 {{< /language-toggle >}}
 {{% notice note %}}
@@ -250,17 +208,14 @@ Because users require this additional configuration and API keys cannot be resto
 {{< code shell "YML" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format yaml > backup/inventory.yml
+--format yaml \
+--file backup/inventory.yml
 {{< /code >}}
 {{< code shell "Wrapped JSON" >}}
 sensuctl dump core/v2.Entity \
 --all-namespaces \
---format wrapped-json > backup/inventory.json
-{{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Entity \
---all-namespaces \
---format json > backup/inventory.json
+--format wrapped-json \
+--file backup/inventory.json
 {{< /code >}}
 {{< /language-toggle >}}
 {{% notice note %}}
@@ -291,11 +246,6 @@ sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.Event
 --all-namespaces \
 --format wrapped-json | grep -v "^\s*namespace:" > backup/pipelines.json
 {{< /code >}}
-{{< code shell "JSON" >}}
-sensuctl dump core/v2.Asset,core/v2.CheckConfig,core/v2.HookConfig,core/v2.EventFilter,core/v2.Mutator,core/v2.Handler,core/v2.Silenced,secrets/v1.Secret,secrets/v1.Provider \
---all-namespaces \
---format json | grep -v "^\s*namespace:" > backup/pipelines.json
-{{< /code >}}
 {{< /language-toggle >}}
 
 ## Restore resources from backup
@@ -316,7 +266,7 @@ To restore a subset of your exported resources (in this example, your RBAC resou
 sensuctl create -f backup/rbac.yml
 {{< /code >}}
 
-{{< code shell "JSON" >}}
+{{< code shell "Wrapped JSON" >}}
 sensuctl create -f backup/rbac.json
 {{< /code >}}
 


### PR DESCRIPTION
## Description
Removes JSON examples (sensuctl dump supports yaml and wrapped json) and updates dump commands to use the --file flag

## Motivation and Context
Noticed when working on disaster recovery doc

Signed-off-by: Hillary Fraley <hfraley@sumologic.com>