### PR TITLE
Fix minor typo

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -246,7 +246,7 @@ The Sensu agent uses WebSocket to communicate with the Sensu backend, sending ev
 As your checks run, the Sensu agent captures check standard output (stdout) or standard error (stderr).
 This data will be included in the JSON payload the agent sends to your Sensu backend as the event data.
 
-It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
+It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to the Sensu backend.
 Use sensuctl to view the event data and confirm that Sensu is monitoring CPU usage:
 
 {{< code shell >}}
@@ -460,7 +460,7 @@ As with the `check_cpu` check, you can share, reuse, and maintain this check [ju
 
 ### Validate the webserver check
 
-It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
+It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to the Sensu backend.
 Use sensuctl to view event data and confirm that Sensu is monitoring the NGINX webserver status:
 
 {{< code shell >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -246,7 +246,7 @@ The Sensu agent uses WebSocket to communicate with the Sensu backend, sending ev
 As your checks run, the Sensu agent captures check standard output (stdout) or standard error (stderr).
 This data will be included in the JSON payload the agent sends to your Sensu backend as the event data.
 
-It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
+It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to the Sensu backend.
 Use sensuctl to view the event data and confirm that Sensu is monitoring CPU usage:
 
 {{< code shell >}}
@@ -460,7 +460,7 @@ As with the `check_cpu` check, you can share, reuse, and maintain this check [ju
 
 ### Validate the webserver check
 
-It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
+It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to the Sensu backend.
 Use sensuctl to view event data and confirm that Sensu is monitoring the NGINX webserver status:
 
 {{< code shell >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -246,7 +246,7 @@ The Sensu agent uses WebSocket to communicate with the Sensu backend, sending ev
 As your checks run, the Sensu agent captures check standard output (stdout) or standard error (stderr).
 This data will be included in the JSON payload the agent sends to your Sensu backend as the event data.
 
-It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
+It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to the Sensu backend.
 Use sensuctl to view the event data and confirm that Sensu is monitoring CPU usage:
 
 {{< code shell >}}
@@ -460,7 +460,7 @@ As with the `check_cpu` check, you can share, reuse, and maintain this check [ju
 
 ### Validate the webserver check
 
-It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
+It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to the Sensu backend.
 Use sensuctl to view event data and confirm that Sensu is monitoring the NGINX webserver status:
 
 {{< code shell >}}

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -246,7 +246,7 @@ The Sensu agent uses WebSocket to communicate with the Sensu backend, sending ev
 As your checks run, the Sensu agent captures check standard output (stdout) or standard error (stderr).
 This data will be included in the JSON payload the agent sends to your Sensu backend as the event data.
 
-It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
+It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to the Sensu backend.
 Use sensuctl to view the event data and confirm that Sensu is monitoring CPU usage:
 
 {{< code shell >}}
@@ -460,7 +460,7 @@ As with the `check_cpu` check, you can share, reuse, and maintain this check [ju
 
 ### Validate the webserver check
 
-It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to Sensu backend.
+It might take a few moments after you create the check for the check to be scheduled on the entity and the event to return to the Sensu backend.
 Use sensuctl to view event data and confirm that Sensu is monitoring the NGINX webserver status:
 
 {{< code shell >}}


### PR DESCRIPTION
## Description
Fixes a minor typo in two places in https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/monitor-server-resources/#validate-the-cpu-check (`...to return to Sensu backend.` is missing "the")

## Motivation and Context
Found when working on something else.
