### PR TITLE
Remove 6.4 reference in note about CN deprecation in Go 1.15

### DIFF
--- a/content/sensu-go/6.5/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/deployment-architecture.md
@@ -59,9 +59,8 @@ You can secure communications with etcd using the same certificate and key.
 The certificate's Common Name (CN) or Subject Alternative Name (SAN) must include the network interfaces and DNS names that will point to those systems.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 Read [Run a Sensu cluster][7] and the [etcd documentation][4] for more information about TLS setup and configuration, including a walkthrough for generating TLS certificates for your cluster.

--- a/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
@@ -128,8 +128,7 @@ During initial configuration of a cluster of Sensu backends, you must describe e
 In issuing certificates for cluster members, the IP address or hostname used in these URLs must be represented in either the Common Name (CN) or Subject Alternative Name (SAN) records in the certificate.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
 Follow the instructions in this guide to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/secure-sensu.md
@@ -23,9 +23,8 @@ Before you can secure Sensu, you must [generate the certificates][12] you will n
 After you generate certificates, follow this reference to secure Sensu for production.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 ## Secure etcd peer communication

--- a/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/use-federation.md
@@ -65,9 +65,8 @@ To ensure that cluster members can validate each other, certificates for each cl
 In addition to the certificate's [Common Name (CN)][15], [Subject Alternative Names (SANs)][16] are also honored for validation.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 To continue with this guide, make sure you have the required TLS credentials in place:

--- a/content/sensu-go/6.5/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/troubleshoot.md
@@ -175,7 +175,6 @@ For more information, read the [etcd security documentation][4].
 
 ## CommonName deprecation in Go 1.15
 
-Sensu Go 6.4.0 upgrades the Go version from 1.13.15 to 1.16.5.
 As of [Go 1.15][27], certificates must include their CommonName (CN) as a Subject Alternative Name (SAN) field.
 
 The following logged error indicates that a certificate used to secure Sensu does not include the CN as a SAN field:
@@ -184,7 +183,7 @@ The following logged error indicates that a certificate used to secure Sensu doe
 {"component":"agent","error":"x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0","level":"error","msg":"reconnection attempt failed","time":"2021-06-29T11:07:51+02:00"}
 {{< /code >}}
 
-To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates][28] to make sure your certificates' SAN fields include their CNs.
+If you see this connection error, follow [Generate certificates][28] to make sure your certificates' SAN fields include their CNs.
 
 ## Permission issues
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/deployment-architecture.md
@@ -59,9 +59,8 @@ You can secure communications with etcd using the same certificate and key.
 The certificate's Common Name (CN) or Subject Alternative Name (SAN) must include the network interfaces and DNS names that will point to those systems.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 Read [Run a Sensu cluster][7] and the [etcd documentation][4] for more information about TLS setup and configuration, including a walkthrough for generating TLS certificates for your cluster.

--- a/content/sensu-go/6.6/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/generate-certificates.md
@@ -128,8 +128,7 @@ During initial configuration of a cluster of Sensu backends, you must describe e
 In issuing certificates for cluster members, the IP address or hostname used in these URLs must be represented in either the Common Name (CN) or Subject Alternative Name (SAN) records in the certificate.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
 Follow the instructions in this guide to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
@@ -23,9 +23,8 @@ Before you can secure Sensu, you must [generate the certificates][12] you will n
 After you generate certificates, follow this reference to secure Sensu for production.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 ## Secure etcd peer communication

--- a/content/sensu-go/6.6/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/use-federation.md
@@ -65,9 +65,8 @@ To ensure that cluster members can validate each other, certificates for each cl
 In addition to the certificate's [Common Name (CN)][15], [Subject Alternative Names (SANs)][16] are also honored for validation.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 To continue with this guide, make sure you have the required TLS credentials in place:

--- a/content/sensu-go/6.6/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/troubleshoot.md
@@ -175,7 +175,6 @@ For more information, read the [etcd security documentation][4].
 
 ## CommonName deprecation in Go 1.15
 
-Sensu Go 6.4.0 upgrades the Go version from 1.13.15 to 1.16.5.
 As of [Go 1.15][27], certificates must include their CommonName (CN) as a Subject Alternative Name (SAN) field.
 
 The following logged error indicates that a certificate used to secure Sensu does not include the CN as a SAN field:
@@ -184,7 +183,7 @@ The following logged error indicates that a certificate used to secure Sensu doe
 {"component":"agent","error":"x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0","level":"error","msg":"reconnection attempt failed","time":"2021-06-29T11:07:51+02:00"}
 {{< /code >}}
 
-To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates][28] to make sure your certificates' SAN fields include their CNs.
+If you see this connection error, follow [Generate certificates][28] to make sure your certificates' SAN fields include their CNs.
 
 ## Permission issues
 

--- a/content/sensu-go/6.7/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/deployment-architecture.md
@@ -59,9 +59,8 @@ You can secure communications with etcd using the same certificate and key.
 The certificate's Common Name (CN) or Subject Alternative Name (SAN) must include the network interfaces and DNS names that will point to those systems.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 Read [Run a Sensu cluster][7] and the [etcd documentation][4] for more information about TLS setup and configuration, including a walkthrough for generating TLS certificates for your cluster.

--- a/content/sensu-go/6.7/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/generate-certificates.md
@@ -128,8 +128,7 @@ During initial configuration of a cluster of Sensu backends, you must describe e
 In issuing certificates for cluster members, the IP address or hostname used in these URLs must be represented in either the Common Name (CN) or Subject Alternative Name (SAN) records in the certificate.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
 Follow the instructions in this guide to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 

--- a/content/sensu-go/6.7/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/secure-sensu.md
@@ -23,9 +23,8 @@ Before you can secure Sensu, you must [generate the certificates][12] you will n
 After you generate certificates, follow this reference to secure Sensu for production.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 ## Secure etcd peer communication

--- a/content/sensu-go/6.7/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/use-federation.md
@@ -65,9 +65,8 @@ To ensure that cluster members can validate each other, certificates for each cl
 In addition to the certificate's [Common Name (CN)][15], [Subject Alternative Names (SANs)][16] are also honored for validation.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 To continue with this guide, make sure you have the required TLS credentials in place:

--- a/content/sensu-go/6.7/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/troubleshoot.md
@@ -175,7 +175,6 @@ For more information, read the [etcd security documentation][4].
 
 ## CommonName deprecation in Go 1.15
 
-Sensu Go 6.4.0 upgrades the Go version from 1.13.15 to 1.16.5.
 As of [Go 1.15][27], certificates must include their CommonName (CN) as a Subject Alternative Name (SAN) field.
 
 The following logged error indicates that a certificate used to secure Sensu does not include the CN as a SAN field:
@@ -184,7 +183,7 @@ The following logged error indicates that a certificate used to secure Sensu doe
 {"component":"agent","error":"x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0","level":"error","msg":"reconnection attempt failed","time":"2021-06-29T11:07:51+02:00"}
 {{< /code >}}
 
-To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates][28] to make sure your certificates' SAN fields include their CNs.
+If you see this connection error, follow [Generate certificates][28] to make sure your certificates' SAN fields include their CNs.
 
 ## Permission issues
 

--- a/content/sensu-go/6.8/operations/deploy-sensu/deployment-architecture.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/deployment-architecture.md
@@ -59,9 +59,8 @@ You can secure communications with etcd using the same certificate and key.
 The certificate's Common Name (CN) or Subject Alternative Name (SAN) must include the network interfaces and DNS names that will point to those systems.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 Read [Run a Sensu cluster][7] and the [etcd documentation][4] for more information about TLS setup and configuration, including a walkthrough for generating TLS certificates for your cluster.

--- a/content/sensu-go/6.8/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/generate-certificates.md
@@ -128,8 +128,7 @@ During initial configuration of a cluster of Sensu backends, you must describe e
 In issuing certificates for cluster members, the IP address or hostname used in these URLs must be represented in either the Common Name (CN) or Subject Alternative Name (SAN) records in the certificate.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
 Follow the instructions in this guide to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 

--- a/content/sensu-go/6.8/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/secure-sensu.md
@@ -23,9 +23,8 @@ Before you can secure Sensu, you must [generate the certificates][12] you will n
 After you generate certificates, follow this reference to secure Sensu for production.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their Common Name (CN) as a Subject Alternative Name (SAN) field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 ## Secure etcd peer communication

--- a/content/sensu-go/6.8/operations/deploy-sensu/use-federation.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/use-federation.md
@@ -65,9 +65,8 @@ To ensure that cluster members can validate each other, certificates for each cl
 In addition to the certificate's [Common Name (CN)][15], [Subject Alternative Names (SANs)][16] are also honored for validation.
 
 {{% notice note %}}
-**NOTE**: Sensu Go 6.4.0 upgraded the Go version from 1.13.15 to 1.16.5.
-As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
-To prevent connection errors after upgrading to Sensu Go 6.4.0 or later versions, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
+**NOTE**: As of [Go 1.15](https://golang.google.cn/doc/go1.15#commonname), certificates must include their CN as an SAN field.
+To prevent connection errors, follow [Generate certificates](../generate-certificates/) to make sure your certificates' SAN fields include their CNs.
 {{% /notice %}}
 
 To continue with this guide, make sure you have the required TLS credentials in place:

--- a/content/sensu-go/6.8/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.8/operations/maintain-sensu/troubleshoot.md
@@ -175,7 +175,6 @@ For more information, read the [etcd security documentation][4].
 
 ## CommonName deprecation in Go 1.15
 
-Sensu Go 6.4.0 upgrades the Go version from 1.13.15 to 1.16.5.
 As of [Go 1.15][27], certificates must include their CommonName (CN) as a Subject Alternative Name (SAN) field.
 
 The following logged error indicates that a certificate used to secure Sensu does not include the CN as a SAN field:
@@ -184,7 +183,7 @@ The following logged error indicates that a certificate used to secure Sensu doe
 {"component":"agent","error":"x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0","level":"error","msg":"reconnection attempt failed","time":"2021-06-29T11:07:51+02:00"}
 {{< /code >}}
 
-To prevent connection errors after upgrading to Sensu Go 6.4.0, follow [Generate certificates][28] to make sure your certificates' SAN fields include their CNs.
+If you see this connection error, follow [Generate certificates][28] to make sure your certificates' SAN fields include their CNs.
 
 ## Permission issues
 


### PR DESCRIPTION
## Description
Removes mentions of 6.4 in notes about Common Name deprecation in Go 1.15.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/4008