### PR TITLE
Update default preferences heading and links

### DIFF
--- a/content/sensu-go/6.5/commercial.md
+++ b/content/sensu-go/6.5/commercial.md
@@ -125,7 +125,7 @@ These resources will help you use commercial features in Sensu Go:
 [23]: ../observability-pipeline/observe-schedule/business-service-monitoring/
 [24]: ../plugins/featured-integrations/
 [25]: #commercial-features-in-sensu-go
-[26]: ../web-ui/webconfig-reference/#default_preferences-attributes
+[26]: ../web-ui/webconfig-reference/#default-preferences-attributes
 [27]: ../web-ui/webconfig-reference/#page-preferences-attributes
 [28]: ../web-ui/webconfig-reference/#sign-in-message
 [29]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -2114,7 +2114,7 @@ To get started with Sensu Go:
 [220]: /sensu-go/6.4/web-ui/webconfig-reference/#sign-in-message
 [221]: /sensu-go/6.4/web-ui/webconfig-reference/#page-preferences-attributes
 [222]: /sensu-go/6.4/operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-640-from-any-previous-version
-[223]: /sensu-go/6.3/web-ui/webconfig-reference/#default_preferences-attributes
+[223]: /sensu-go/6.3/web-ui/webconfig-reference/#default-preferences-attributes
 [224]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#metrics-refresh-interval
 [225]: /sensu-go/6.4/observability-pipeline/observe-schedule/agent/#log-level
 [226]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-log-parallel-encoders

--- a/content/sensu-go/6.5/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.5/web-ui/webconfig-reference.md
@@ -425,7 +425,7 @@ signin_message: with your LDAP or system credentials
 {{< /code >}}
 {{< /language-toggle >}}
 
-#### default_preferences attributes
+#### Default preferences attributes
 
 poll_interval | 
 -------------|------ 
@@ -602,7 +602,7 @@ urls:
 {{< /language-toggle >}}
 
 
-[1]: #default_preferences-attributes
+[1]: #default-preferences-attributes
 [2]: ../../api/enterprise/webconfig/
 [3]: ../
 [4]: #spec-attributes

--- a/content/sensu-go/6.6/commercial.md
+++ b/content/sensu-go/6.6/commercial.md
@@ -125,7 +125,7 @@ These resources will help you use commercial features in Sensu Go:
 [23]: ../observability-pipeline/observe-schedule/business-service-monitoring/
 [24]: ../plugins/featured-integrations/
 [25]: #commercial-features-in-sensu-go
-[26]: ../web-ui/webconfig-reference/#default_preferences-attributes
+[26]: ../web-ui/webconfig-reference/#default-preferences-attributes
 [27]: ../web-ui/webconfig-reference/#page-preferences-attributes
 [28]: ../web-ui/webconfig-reference/#sign-in-message
 [29]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source

--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -2262,7 +2262,7 @@ To get started with Sensu Go:
 [220]: /sensu-go/6.4/web-ui/webconfig-reference/#sign-in-message
 [221]: /sensu-go/6.4/web-ui/webconfig-reference/#page-preferences-attributes
 [222]: /sensu-go/6.4/operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-640-from-any-previous-version
-[223]: /sensu-go/6.3/web-ui/webconfig-reference/#default_preferences-attributes
+[223]: /sensu-go/6.3/web-ui/webconfig-reference/#default-preferences-attributes
 [224]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#metrics-refresh-interval
 [225]: /sensu-go/6.4/observability-pipeline/observe-schedule/agent/#log-level
 [226]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-log-parallel-encoders

--- a/content/sensu-go/6.6/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.6/web-ui/webconfig-reference.md
@@ -425,7 +425,7 @@ signin_message: with your LDAP or system credentials
 {{< /code >}}
 {{< /language-toggle >}}
 
-#### default_preferences attributes
+#### Default preferences attributes
 
 page_size | 
 -------------|------ 
@@ -602,7 +602,7 @@ urls:
 {{< /language-toggle >}}
 
 
-[1]: #default_preferences-attributes
+[1]: #default-preferences-attributes
 [2]: ../../api/enterprise/webconfig/
 [3]: ../
 [4]: #spec-attributes

--- a/content/sensu-go/6.7/commercial.md
+++ b/content/sensu-go/6.7/commercial.md
@@ -126,7 +126,7 @@ These resources will help you use commercial features in Sensu Go:
 [23]: ../observability-pipeline/observe-schedule/business-service-monitoring/
 [24]: ../plugins/featured-integrations/
 [25]: #commercial-features-in-sensu-go
-[26]: ../web-ui/webconfig-reference/#default_preferences-attributes
+[26]: ../web-ui/webconfig-reference/#default-preferences-attributes
 [27]: ../web-ui/webconfig-reference/#page-preferences-attributes
 [28]: ../web-ui/webconfig-reference/#sign-in-message
 [29]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source

--- a/content/sensu-go/6.7/release-notes.md
+++ b/content/sensu-go/6.7/release-notes.md
@@ -2392,7 +2392,7 @@ To get started with Sensu Go:
 [220]: /sensu-go/6.4/web-ui/webconfig-reference/#sign-in-message
 [221]: /sensu-go/6.4/web-ui/webconfig-reference/#page-preferences-attributes
 [222]: /sensu-go/6.4/operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-640-from-any-previous-version
-[223]: /sensu-go/6.3/web-ui/webconfig-reference/#default_preferences-attributes
+[223]: /sensu-go/6.3/web-ui/webconfig-reference/#default-preferences-attributes
 [224]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#metrics-refresh-interval
 [225]: /sensu-go/6.4/observability-pipeline/observe-schedule/agent/#log-level
 [226]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-log-parallel-encoders

--- a/content/sensu-go/6.7/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.7/web-ui/webconfig-reference.md
@@ -455,7 +455,7 @@ signin_message: with your *LDAP or system credentials*
 {{< /code >}}
 {{< /language-toggle >}}
 
-#### default_preferences attributes
+#### Default preferences attributes
 
 page_size | 
 -------------|------ 
@@ -652,7 +652,7 @@ urls:
 {{< /language-toggle >}}
 
 
-[1]: #default_preferences-attributes
+[1]: #default-preferences-attributes
 [2]: ../../api/enterprise/webconfig/
 [3]: ../
 [4]: #spec-attributes

--- a/content/sensu-go/6.8/commercial.md
+++ b/content/sensu-go/6.8/commercial.md
@@ -126,7 +126,7 @@ These resources will help you use commercial features in Sensu Go:
 [23]: ../observability-pipeline/observe-schedule/business-service-monitoring/
 [24]: ../plugins/featured-integrations/
 [25]: #commercial-features-in-sensu-go
-[26]: ../web-ui/webconfig-reference/#default_preferences-attributes
+[26]: ../web-ui/webconfig-reference/#default-preferences-attributes
 [27]: ../web-ui/webconfig-reference/#page-preferences-attributes
 [28]: ../web-ui/webconfig-reference/#sign-in-message
 [29]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source

--- a/content/sensu-go/6.8/release-notes.md
+++ b/content/sensu-go/6.8/release-notes.md
@@ -2435,7 +2435,7 @@ To get started with Sensu Go:
 [220]: /sensu-go/6.4/web-ui/webconfig-reference/#sign-in-message
 [221]: /sensu-go/6.4/web-ui/webconfig-reference/#page-preferences-attributes
 [222]: /sensu-go/6.4/operations/maintain-sensu/upgrade/#upgrade-to-sensu-go-640-from-any-previous-version
-[223]: /sensu-go/6.3/web-ui/webconfig-reference/#default_preferences-attributes
+[223]: /sensu-go/6.3/web-ui/webconfig-reference/#default-preferences-attributes
 [224]: /sensu-go/5.20/observability-pipeline/observe-schedule/backend/#metrics-refresh-interval
 [225]: /sensu-go/6.4/observability-pipeline/observe-schedule/agent/#log-level
 [226]: /sensu-go/6.4/observability-pipeline/observe-schedule/backend/#event-log-parallel-encoders

--- a/content/sensu-go/6.8/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.8/web-ui/webconfig-reference.md
@@ -455,7 +455,7 @@ signin_message: with your *LDAP or system credentials*
 {{< /code >}}
 {{< /language-toggle >}}
 
-#### default_preferences attributes
+#### Default preferences attributes
 
 page_size | 
 -------------|------ 
@@ -652,7 +652,7 @@ urls:
 {{< /language-toggle >}}
 
 
-[1]: #default_preferences-attributes
+[1]: #default-preferences-attributes
 [2]: ../../api/enterprise/webconfig/
 [3]: ../
 [4]: #spec-attributes


### PR DESCRIPTION
## Description
In the WebConfig reference, updates the Default preferences attributes heading to use sentence case. Also updates links to the default preferences attributes throughout the docs.