### PR TITLE
Update Hugo version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Contact [sensu/sensu-docs][9] administrators at [docs@sensu.io][5] if needed.
 Sensu documentation is written in [Goldmark Markdown][16], built with [Hugo][15], and maintained on GitHub in the [sensu/sensu-docs][9] repo.
 
 Goldmark Markdown is largely [GitHub-flavored Markdown][17].
-The Sensu docs project requires Hugo version 0.72.0 or later.
+The Sensu docs project requires Hugo version 0.101.0 or later.
 You'll also need to [install Git][18] to contribute from your command line.
 
 ## Contributing instructions

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
     env : {
       options : {
         add : {
-          HUGO_VERSION : '0.72.0'
+          HUGO_VERSION : '0.101.0'
         }
       },
       dev : {}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This builds the Hugo server so you can view the site in your local web browser a
 
 Here are some things to try if you encounter an issue working with the site:
 
-* Run `yarn hugo-version` to print the running version of Hugo. Version 0.72.0 or newer is required.
+* Run `yarn hugo-version` to print the running version of Hugo. Version 0.101.0 or newer is required.
 * If you're still having trouble viewing the site, [open an issue][issue], and we'll be happy to help!
 
 #### Internet Explorer Users


### PR DESCRIPTION
## Description
Updates the Hugo version to 0.101.0.

The latest version is 0.103.1, but 0.101.0 is the latest version that will build. I think it's something to do with the [changes in 0.102.0](https://github.com/gohugoio/hugo/releases/tag/v0.102.0).