### PR TITLE
Add missing line in metadata yaml example in webconfig ref

### DIFF
--- a/content/sensu-go/6.5/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.5/web-ui/webconfig-reference.md
@@ -158,6 +158,7 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
   name: custom-web-ui
+  created_by: admin
 {{< /code >}}
 {{< code json >}}
 {

--- a/content/sensu-go/6.6/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.6/web-ui/webconfig-reference.md
@@ -158,6 +158,7 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
   name: custom-web-ui
+  created_by: admin
 {{< /code >}}
 {{< code json >}}
 {

--- a/content/sensu-go/6.7/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.7/web-ui/webconfig-reference.md
@@ -164,6 +164,7 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
   name: custom-web-ui
+  created_by: admin
 {{< /code >}}
 {{< code json >}}
 {

--- a/content/sensu-go/6.8/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.8/web-ui/webconfig-reference.md
@@ -164,6 +164,7 @@ example      | {{< language-toggle >}}
 {{< code yml >}}
 metadata:
   name: custom-web-ui
+  created_by: admin
 {{< /code >}}
 {{< code json >}}
 {


### PR DESCRIPTION
## Description
In the webconfig reference, in the spec tables, adds missing `created_by` line in the metadata yaml example.