### PR TITLE
Updates in backend env vars explanation and datastore spec

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -1440,12 +1440,11 @@ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables that control Sensu backend configuration begin with `SENSU_BACKEND_`.
 
-     To rename a configuration option you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
+   * To rename a [configuration option][77] you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
      For example, the environment variable for the configuration option `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
+   * For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file.

--- a/content/sensu-go/6.5/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/datastore.md
@@ -379,7 +379,7 @@ batch_workers: 0
 
 dsn          |      |
 -------------|------
-description  | Data source names. Specified as a URL or [PostgreSQL connection string][15]. The Sensu backend uses the Go pq library, which supports a [subset of the PostgreSQL libpq connection string parameters][4].
+description  | data source name. Specified as a URL or [PostgreSQL connection string][15]. The Sensu backend uses the Go pq library, which supports a [subset of the PostgreSQL libpq connection string parameters][4].
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
@@ -1451,12 +1451,11 @@ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables that control Sensu backend configuration begin with `SENSU_BACKEND_`.
 
-     To rename a configuration option you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
+   * To rename a [configuration option][77] you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
      For example, the environment variable for the configuration option `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
+   * For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file.

--- a/content/sensu-go/6.6/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/datastore.md
@@ -379,7 +379,7 @@ batch_workers: 0
 
 dsn          |      |
 -------------|------
-description  | Data source names. Specified as a URL or [PostgreSQL connection string][15]. The Sensu backend uses the Go pq library, which supports a [subset of the PostgreSQL libpq connection string parameters][4].
+description  | data source name. Specified as a URL or [PostgreSQL connection string][15]. The Sensu backend uses the Go pq library, which supports a [subset of the PostgreSQL libpq connection string parameters][4].
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
@@ -1477,12 +1477,11 @@ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables that control Sensu backend configuration begin with `SENSU_BACKEND_`.
 
-     To rename a configuration option you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
+   * To rename a [configuration option][77] you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
      For example, the environment variable for the configuration option `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
+   * For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file.

--- a/content/sensu-go/6.7/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/datastore.md
@@ -379,7 +379,7 @@ batch_workers: 0
 
 dsn          |      |
 -------------|------
-description  | Data source names. Specified as a URL or [PostgreSQL connection string][15]. The Sensu backend uses the Go pq library, which supports a [subset of the PostgreSQL libpq connection string parameters][4].
+description  | data source name. Specified as a URL or [PostgreSQL connection string][15]. The Sensu backend uses the Go pq library, which supports a [subset of the PostgreSQL libpq connection string parameters][4].
 required     | true
 type         | String
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/backend.md
@@ -1502,12 +1502,11 @@ sudo touch /etc/sysconfig/sensu-backend
      {{< /language-toggle >}}
 
 2. Make sure the environment variable is named correctly.
-All environment variables that control Sensu backend configuration begin with `SENSU_BACKEND_`.
 
-     To rename a configuration option you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
+   * To rename a [configuration option][77] you wish to specify as an environment variable, prepend `SENSU_BACKEND_`, convert dashes to underscores, and capitalize all letters.
      For example, the environment variable for the configuration option `api-listen-address` is `SENSU_BACKEND_API_LISTEN_ADDRESS`.
 
-     For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
+   * For a custom environment variable, you do not have to prepend `SENSU_BACKEND`.
      For example, `TEST_VAR_1` is a valid custom environment variable name.
 
 3. Add the environment variable to the environment file.

--- a/content/sensu-go/6.8/operations/deploy-sensu/datastore.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/datastore.md
@@ -379,7 +379,7 @@ batch_workers: 0
 
 dsn          |      |
 -------------|------
-description  | Data source names. Specified as a URL or [PostgreSQL connection string][15]. The Sensu backend uses the Go pq library, which supports a [subset of the PostgreSQL libpq connection string parameters][4].
+description  | data source name. Specified as a URL or [PostgreSQL connection string][15]. The Sensu backend uses the Go pq library, which supports a [subset of the PostgreSQL libpq connection string parameters][4].
 required     | true
 type         | String
 example      | {{< language-toggle >}}


### PR DESCRIPTION
## Description
Clarifies explanation and adds bullet points in backend env vars explanation. Also removes plural from "data source name" in the datastore spec.