### PR TITLE
Propagate Secure Postgres to all versions

### DIFF
--- a/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
@@ -88,7 +88,7 @@ Follow these steps to create a CA with cfssl and cfssljson:
 mkdir -p /etc/sensu/tls
 {{< /code >}}
 
-2. Navigate to the new /etc/sensu/tls directory:
+2. Navigate to the new `/etc/sensu/tls` directory:
 {{< code shell >}}
 cd /etc/sensu/tls
 {{< /code >}}

--- a/content/sensu-go/6.5/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/scale-event-storage.md
@@ -151,6 +151,8 @@ sudo systemctl restart postgresql
 
 With this configuration complete, you can configure Sensu to store events in your Postgres database.
 
+To secure communication between Sensu and the PostgreSQL event store using certificate authentication, read [Secure PostgreSQL][7].
+
 ## Configure Sensu
 
 If your Sensu backend is already licensed, the configuration for routing events to Postgres is relatively straightforward.
@@ -476,3 +478,4 @@ With this configuration complete, your Sensu events will be replicated to the st
 [4]: ../../maintain-sensu/troubleshoot/#log-file-locations
 [5]: https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PASSWORD
 [6]: https://wiki.postgresql.org/wiki/Streaming_Replication
+[7]: ../secure-postgres/

--- a/content/sensu-go/6.5/operations/deploy-sensu/secure-postgres.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/secure-postgres.md
@@ -5,11 +5,11 @@ guide_title: "Secure PostgreSQL"
 type: "guide"
 description: "Learn how to secure communication between Sensu and PostgreSQL with certificate authentication."
 weight: 65
-version: "6.8"
+version: "6.5"
 product: "Sensu Go"
 platformContent: false
 menu:
-  sensu-go-6.8:
+  sensu-go-6.5:
     parent: deploy-sensu
 ---
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/generate-certificates.md
@@ -88,7 +88,7 @@ Follow these steps to create a CA with cfssl and cfssljson:
 mkdir -p /etc/sensu/tls
 {{< /code >}}
 
-2. Navigate to the new /etc/sensu/tls directory:
+2. Navigate to the new `/etc/sensu/tls` directory:
 {{< code shell >}}
 cd /etc/sensu/tls
 {{< /code >}}

--- a/content/sensu-go/6.6/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/scale-event-storage.md
@@ -151,6 +151,8 @@ sudo systemctl restart postgresql
 
 With this configuration complete, you can configure Sensu to store events in your Postgres database.
 
+To secure communication between Sensu and the PostgreSQL event store using certificate authentication, read [Secure PostgreSQL][7].
+
 ## Configure Sensu
 
 If your Sensu backend is already licensed, the configuration for routing events to Postgres is relatively straightforward.
@@ -476,3 +478,4 @@ With this configuration complete, your Sensu events will be replicated to the st
 [4]: ../../maintain-sensu/troubleshoot/#log-file-locations
 [5]: https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PASSWORD
 [6]: https://wiki.postgresql.org/wiki/Streaming_Replication
+[7]: ../secure-postgres/

--- a/content/sensu-go/6.6/operations/deploy-sensu/secure-postgres.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/secure-postgres.md
@@ -5,11 +5,11 @@ guide_title: "Secure PostgreSQL"
 type: "guide"
 description: "Learn how to secure communication between Sensu and PostgreSQL with certificate authentication."
 weight: 65
-version: "6.8"
+version: "6.6"
 product: "Sensu Go"
 platformContent: false
 menu:
-  sensu-go-6.8:
+  sensu-go-6.6:
     parent: deploy-sensu
 ---
 

--- a/content/sensu-go/6.7/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/generate-certificates.md
@@ -88,7 +88,7 @@ Follow these steps to create a CA with cfssl and cfssljson:
 mkdir -p /etc/sensu/tls
 {{< /code >}}
 
-2. Navigate to the new /etc/sensu/tls directory:
+2. Navigate to the new `/etc/sensu/tls` directory:
 {{< code shell >}}
 cd /etc/sensu/tls
 {{< /code >}}

--- a/content/sensu-go/6.7/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/scale-event-storage.md
@@ -151,6 +151,8 @@ sudo systemctl restart postgresql
 
 With this configuration complete, you can configure Sensu to store events in your Postgres database.
 
+To secure communication between Sensu and the PostgreSQL event store using certificate authentication, read [Secure PostgreSQL][7].
+
 ## Configure Sensu
 
 If your Sensu backend is already licensed, the configuration for routing events to Postgres is relatively straightforward.
@@ -476,3 +478,4 @@ With this configuration complete, your Sensu events will be replicated to the st
 [4]: ../../maintain-sensu/troubleshoot/#log-file-locations
 [5]: https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PASSWORD
 [6]: https://wiki.postgresql.org/wiki/Streaming_Replication
+[7]: ../secure-postgres/

--- a/content/sensu-go/6.7/operations/deploy-sensu/secure-postgres.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/secure-postgres.md
@@ -5,11 +5,11 @@ guide_title: "Secure PostgreSQL"
 type: "guide"
 description: "Learn how to secure communication between Sensu and PostgreSQL with certificate authentication."
 weight: 65
-version: "6.8"
+version: "6.7"
 product: "Sensu Go"
 platformContent: false
 menu:
-  sensu-go-6.8:
+  sensu-go-6.7:
     parent: deploy-sensu
 ---
 

--- a/content/sensu-go/6.8/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/generate-certificates.md
@@ -88,7 +88,7 @@ Follow these steps to create a CA with cfssl and cfssljson:
 mkdir -p /etc/sensu/tls
 {{< /code >}}
 
-2. Navigate to the new /etc/sensu/tls directory:
+2. Navigate to the new `/etc/sensu/tls` directory:
 {{< code shell >}}
 cd /etc/sensu/tls
 {{< /code >}}

--- a/content/sensu-go/6.8/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/scale-event-storage.md
@@ -151,6 +151,8 @@ sudo systemctl restart postgresql
 
 With this configuration complete, you can configure Sensu to store events in your Postgres database.
 
+To secure communication between Sensu and the PostgreSQL event store using certificate authentication, read [Secure PostgreSQL][7].
+
 ## Configure Sensu
 
 If your Sensu backend is already licensed, the configuration for routing events to Postgres is relatively straightforward.
@@ -476,3 +478,4 @@ With this configuration complete, your Sensu events will be replicated to the st
 [4]: ../../maintain-sensu/troubleshoot/#log-file-locations
 [5]: https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PASSWORD
 [6]: https://wiki.postgresql.org/wiki/Streaming_Replication
+[7]: ../secure-postgres/


### PR DESCRIPTION
## Description
Propagates the new Secure PostgreSQL doc to all versions. Also adds a link to Secure PostgreSQL in the Scale guide to help discoverability.