### PR TITLE
Use workshop video 1 on get started page

### DIFF
--- a/content/sensu-go/6.5/get-started.md
+++ b/content/sensu-go/6.5/get-started.md
@@ -27,7 +27,7 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 
 Watch this video for an 8-minute Sensu Go overview and demo:
 
-{{< youtube eUZTMdYtCmg >}}
+{{< youtube uyj3qFjq58g >}}
 
 We recommend these resources for learning more about Sensu:
 
@@ -63,7 +63,7 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [9]: ../operations/maintain-sensu/license/
 [10]: https://github.com/sensu/sensu-go/
 [11]: https://www.github.com/sensu/sensu-go/blob/main/README.md#building-from-source
-[12]: https://github.com/sensu/sensu-go-workshop
+[12]: https://github.com/sensu/sensu-go-workshop#overview
 [13]: ../operations/maintain-sensu/migrate/
 [14]: https://sensu.io/features/compare
 [15]: #install-the-commercial-distribution-of-sensu-go

--- a/content/sensu-go/6.5/learn/_index.md
+++ b/content/sensu-go/6.5/learn/_index.md
@@ -21,7 +21,7 @@ To visualize how Sensu concepts work together in the observability pipeline, [ta
 
 ## Sensu Go workshop
 
-The [Sensu Go workshop][2] is a collection of resources designed to help you learn Sensu:
+The [Sensu Go workshop][4] is a collection of resources designed to help you learn Sensu:
 
 - Interactive lessons designed for self-guided learning.
 - Detailed instructions for Linux, macOS, and Windows workstations.
@@ -43,7 +43,6 @@ You’ll also learn to use sensuctl to configure Nagios-style monitoring checks 
 
 
 [1]: concepts-terminology/
-[2]: https://github.com/sensu/sensu-go-workshop
 [3]: demo/
 [4]: https://github.com/sensu/sensu-go-workshop#overview
 [5]: https://github.com/sensu/sensu-k8s-quick-start

--- a/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
@@ -18,7 +18,7 @@ We recommend using a [supported package][14] to follow this guide.
 To build from source and install Sensu from a [binary distribution][23], follow the [Sensu Go installation instructions on GitHub][44].
 
 {{% notice note %}}
-**NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop) instead.
+**NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop#overview) instead.
 The workshop includes a local sandbox environment and a collection of resources designed to help new users learn and test Sensu.<br><br>
 If you will deploy Sensu to your infrastructure, we recommend securing your installation with transport layer security (TLS) in addition to using one of our supported packages, Docker images, or [configuration management integrations](../configuration-management/).
 Read [Generate certificates](../generate-certificates) next to get the certificates you will need for TLS.

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -574,7 +574,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [45]: https://github.com/sensu/sensu-translator
 [46]: https://slack.sensu.io/
 [47]: https://discourse.sensu.io/c/sensu-go/migrating-to-go
-[48]: https://github.com/sensu/sensu-go-workshop
+[48]: https://github.com/sensu/sensu-go-workshop#overview
 [49]: https://sensu.io/support/
 [50]: ../../../plugins/use-assets-to-install-plugins/
 [51]: ../../../plugins/install-plugins/

--- a/content/sensu-go/6.6/get-started.md
+++ b/content/sensu-go/6.6/get-started.md
@@ -27,7 +27,7 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 
 Watch this video for an 8-minute Sensu Go overview and demo:
 
-{{< youtube eUZTMdYtCmg >}}
+{{< youtube uyj3qFjq58g >}}
 
 We recommend these resources for learning more about Sensu:
 
@@ -63,7 +63,7 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [9]: ../operations/maintain-sensu/license/
 [10]: https://github.com/sensu/sensu-go/
 [11]: https://www.github.com/sensu/sensu-go/blob/main/README.md#building-from-source
-[12]: https://github.com/sensu/sensu-go-workshop
+[12]: https://github.com/sensu/sensu-go-workshop#overview
 [13]: ../operations/maintain-sensu/migrate/
 [14]: https://sensu.io/features/compare
 [15]: #install-the-commercial-distribution-of-sensu-go

--- a/content/sensu-go/6.6/learn/_index.md
+++ b/content/sensu-go/6.6/learn/_index.md
@@ -21,7 +21,7 @@ To visualize how Sensu concepts work together in the observability pipeline, [ta
 
 ## Sensu Go workshop
 
-The [Sensu Go workshop][2] is a collection of resources designed to help you learn Sensu:
+The [Sensu Go workshop][4] is a collection of resources designed to help you learn Sensu:
 
 - Interactive lessons designed for self-guided learning.
 - Detailed instructions for Linux, macOS, and Windows workstations.
@@ -43,7 +43,6 @@ You’ll also learn to use sensuctl to configure Nagios-style monitoring checks 
 
 
 [1]: concepts-terminology/
-[2]: https://github.com/sensu/sensu-go-workshop
 [3]: demo/
 [4]: https://github.com/sensu/sensu-go-workshop#overview
 [5]: https://github.com/sensu/sensu-k8s-quick-start

--- a/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
@@ -18,7 +18,7 @@ We recommend using a [supported package][14] to follow this guide.
 To build from source and install Sensu from a [binary distribution][23], follow the [Sensu Go installation instructions on GitHub][44].
 
 {{% notice note %}}
-**NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop) instead.
+**NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop#overview) instead.
 The workshop includes a local sandbox environment and a collection of resources designed to help new users learn and test Sensu.<br><br>
 If you will deploy Sensu to your infrastructure, we recommend securing your installation with transport layer security (TLS) in addition to using one of our supported packages, Docker images, or [configuration management integrations](../configuration-management/).
 Read [Generate certificates](../generate-certificates) next to get the certificates you will need for TLS.

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -574,7 +574,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [45]: https://github.com/sensu/sensu-translator
 [46]: https://slack.sensu.io/
 [47]: https://discourse.sensu.io/c/sensu-go/migrating-to-go
-[48]: https://github.com/sensu/sensu-go-workshop
+[48]: https://github.com/sensu/sensu-go-workshop#overview
 [49]: https://sensu.io/support/
 [50]: ../../../plugins/use-assets-to-install-plugins/
 [51]: ../../../plugins/install-plugins/

--- a/content/sensu-go/6.7/get-started.md
+++ b/content/sensu-go/6.7/get-started.md
@@ -27,7 +27,7 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 
 Watch this video for an 8-minute Sensu Go overview and demo:
 
-{{< youtube eUZTMdYtCmg >}}
+{{< youtube uyj3qFjq58g >}}
 
 We recommend these resources for learning more about Sensu:
 
@@ -63,7 +63,7 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [9]: ../operations/maintain-sensu/license/
 [10]: https://github.com/sensu/sensu-go/
 [11]: https://www.github.com/sensu/sensu-go/blob/main/README.md#building-from-source
-[12]: https://github.com/sensu/sensu-go-workshop
+[12]: https://github.com/sensu/sensu-go-workshop#overview
 [13]: ../operations/maintain-sensu/migrate/
 [14]: https://sensu.io/features/compare
 [15]: #install-the-commercial-distribution-of-sensu-go

--- a/content/sensu-go/6.7/learn/_index.md
+++ b/content/sensu-go/6.7/learn/_index.md
@@ -21,7 +21,7 @@ To visualize how Sensu concepts work together in the observability pipeline, [ta
 
 ## Sensu Go workshop
 
-The [Sensu Go workshop][2] is a collection of resources designed to help you learn Sensu:
+The [Sensu Go workshop][4] is a collection of resources designed to help you learn Sensu:
 
 - Interactive lessons designed for self-guided learning.
 - Detailed instructions for Linux, macOS, and Windows workstations.
@@ -43,7 +43,6 @@ You’ll also learn to use sensuctl to configure Nagios-style monitoring checks 
 
 
 [1]: concepts-terminology/
-[2]: https://github.com/sensu/sensu-go-workshop
 [3]: demo/
 [4]: https://github.com/sensu/sensu-go-workshop#overview
 [5]: https://github.com/sensu/sensu-k8s-quick-start

--- a/content/sensu-go/6.7/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/install-sensu.md
@@ -18,7 +18,7 @@ We recommend using a [supported package][14] to follow this guide.
 To build from source and install Sensu from a [binary distribution][23], follow the [Sensu Go installation instructions on GitHub][44].
 
 {{% notice note %}}
-**NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop) instead.
+**NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop#overview) instead.
 The workshop includes a local sandbox environment and a collection of resources designed to help new users learn and test Sensu.<br><br>
 If you will deploy Sensu to your infrastructure, we recommend securing your installation with transport layer security (TLS) in addition to using one of our supported packages, Docker images, or [configuration management integrations](../configuration-management/).
 Read [Generate certificates](../generate-certificates) next to get the certificates you will need for TLS.

--- a/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
@@ -576,7 +576,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [45]: https://github.com/sensu/sensu-translator
 [46]: https://slack.sensu.io/
 [47]: https://discourse.sensu.io/c/sensu-go/migrating-to-go
-[48]: https://github.com/sensu/sensu-go-workshop
+[48]: https://github.com/sensu/sensu-go-workshop#overview
 [49]: https://sensu.io/support/
 [50]: ../../../plugins/use-assets-to-install-plugins/
 [51]: ../../../plugins/install-plugins/

--- a/content/sensu-go/6.8/get-started.md
+++ b/content/sensu-go/6.8/get-started.md
@@ -25,9 +25,9 @@ Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windo
 
 ## Learn Sensu
 
-Watch this video for an 8-minute Sensu Go overview and demo:
+Watch this video for a 10-minute introduction to Sensu Go:
 
-{{< youtube eUZTMdYtCmg >}}
+{{< youtube uyj3qFjq58g >}}
 
 We recommend these resources for learning more about Sensu:
 
@@ -63,7 +63,7 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [9]: ../operations/maintain-sensu/license/
 [10]: https://github.com/sensu/sensu-go/
 [11]: https://www.github.com/sensu/sensu-go/blob/main/README.md#building-from-source
-[12]: https://github.com/sensu/sensu-go-workshop
+[12]: https://github.com/sensu/sensu-go-workshop#overview
 [13]: ../operations/maintain-sensu/migrate/
 [14]: https://sensu.io/features/compare
 [15]: #install-the-commercial-distribution-of-sensu-go

--- a/content/sensu-go/6.8/learn/_index.md
+++ b/content/sensu-go/6.8/learn/_index.md
@@ -21,7 +21,7 @@ To visualize how Sensu concepts work together in the observability pipeline, [ta
 
 ## Sensu Go workshop
 
-The [Sensu Go workshop][2] is a collection of resources designed to help you learn Sensu:
+The [Sensu Go workshop][4] is a collection of resources designed to help you learn Sensu:
 
 - Interactive lessons designed for self-guided learning.
 - Detailed instructions for Linux, macOS, and Windows workstations.
@@ -43,7 +43,6 @@ You’ll also learn to use sensuctl to configure Nagios-style monitoring checks 
 
 
 [1]: concepts-terminology/
-[2]: https://github.com/sensu/sensu-go-workshop
 [3]: demo/
 [4]: https://github.com/sensu/sensu-go-workshop#overview
 [5]: https://github.com/sensu/sensu-k8s-quick-start

--- a/content/sensu-go/6.8/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/install-sensu.md
@@ -18,7 +18,7 @@ We recommend using a [supported package][14] to follow this guide.
 To build from source and install Sensu from a [binary distribution][23], follow the [Sensu Go installation instructions on GitHub][44].
 
 {{% notice note %}}
-**NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop) instead.
+**NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop#overview) instead.
 The workshop includes a local sandbox environment and a collection of resources designed to help new users learn and test Sensu.<br><br>
 If you will deploy Sensu to your infrastructure, we recommend securing your installation with transport layer security (TLS) in addition to using one of our supported packages, Docker images, or [configuration management integrations](../configuration-management/).
 Read [Generate certificates](../generate-certificates) next to get the certificates you will need for TLS.

--- a/content/sensu-go/6.8/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.8/operations/maintain-sensu/migrate.md
@@ -576,7 +576,7 @@ After you stop the Sensu Core services, follow package removal instructions for 
 [45]: https://github.com/sensu/sensu-translator
 [46]: https://slack.sensu.io/
 [47]: https://discourse.sensu.io/c/sensu-go/migrating-to-go
-[48]: https://github.com/sensu/sensu-go-workshop
+[48]: https://github.com/sensu/sensu-go-workshop#overview
 [49]: https://sensu.io/support/
 [50]: ../../../plugins/use-assets-to-install-plugins/
 [51]: ../../../plugins/install-plugins/


### PR DESCRIPTION
## Description
On the Get Started page, replaces the Sensu Go informational video (https://www.youtube.com/watch?v=eUZTMdYtCmg) with the first workshop video.

Also updates links to workshop to hop to the overview so that users are immediately presented with lessons instead of the GH repo structure.

## Motivation and Context
Workshop video is current and more helpful
