### PR TITLE
Add link to FIPS config info in Platforms page

### DIFF
--- a/content/sensu-go/6.5/platforms.md
+++ b/content/sensu-go/6.5/platforms.md
@@ -175,10 +175,12 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.5.5/sensu-go_6.5
 
 Builds that support the Federal Information Processing Standard (FIPS) for Federal Risk and Authorization Management Program (FedRAMP) compliance are available for Linux `amd64`.
 
-Sensu FIPS builds with [FIPS-mode configuration options][51] are linked with the FIPS 140-2 validated cryptographic library.
+Sensu FIPS builds with FIPS-mode configuration options are linked with the FIPS 140-2 validated cryptographic library.
 You can run Red Hat Enterprise Linux (RHEL) with the FIPS-mode kernel option to enforce FIPS systemwide &mdash; Sensu FIPS builds comply with this mode.
 
 [Contact Sensu][50] to request builds with FIPS support.
+
+Read [Configure Sensu for FIPS compliance][65] to learn more about Sensu's FIPS build, including configuration examples.
 
 ### Windows
 

--- a/content/sensu-go/6.6/platforms.md
+++ b/content/sensu-go/6.6/platforms.md
@@ -175,10 +175,12 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.6.6/sensu-go_6.6
 
 Builds that support the Federal Information Processing Standard (FIPS) for Federal Risk and Authorization Management Program (FedRAMP) compliance are available for Linux `amd64`.
 
-Sensu FIPS builds with [FIPS-mode configuration options][51] are linked with the FIPS 140-2 validated cryptographic library.
+Sensu FIPS builds with FIPS-mode configuration options are linked with the FIPS 140-2 validated cryptographic library.
 You can run Red Hat Enterprise Linux (RHEL) with the FIPS-mode kernel option to enforce FIPS systemwide &mdash; Sensu FIPS builds comply with this mode.
 
 [Contact Sensu][50] to request builds with FIPS support.
+
+Read [Configure Sensu for FIPS compliance][65] to learn more about Sensu's FIPS build, including configuration examples.
 
 ### Windows
 

--- a/content/sensu-go/6.7/platforms.md
+++ b/content/sensu-go/6.7/platforms.md
@@ -189,10 +189,12 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.7.5/sensu-go_6.7
 
 Builds that support the Federal Information Processing Standard (FIPS) for Federal Risk and Authorization Management Program (FedRAMP) compliance are available for Linux `amd64`.
 
-Sensu FIPS builds with [FIPS-mode configuration options][51] are linked with the FIPS 140-2 validated cryptographic library.
+Sensu FIPS builds with FIPS-mode configuration options are linked with the FIPS 140-2 validated cryptographic library.
 You can run Red Hat Enterprise Linux (RHEL) with the FIPS-mode kernel option to enforce FIPS systemwide &mdash; Sensu FIPS builds comply with this mode.
 
 [Contact Sensu][50] to request builds with FIPS support.
+
+Read [Configure Sensu for FIPS compliance][65] to learn more about Sensu's FIPS build, including configuration examples.
 
 ### Windows
 

--- a/content/sensu-go/6.8/platforms.md
+++ b/content/sensu-go/6.8/platforms.md
@@ -177,10 +177,12 @@ curl -LO https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.8.2/sensu-go_6.8
 
 Builds that support the Federal Information Processing Standard (FIPS) for Federal Risk and Authorization Management Program (FedRAMP) compliance are available for Linux `amd64`.
 
-Sensu FIPS builds with [FIPS-mode configuration options][51] are linked with the FIPS 140-2 validated cryptographic library.
+Sensu FIPS builds with FIPS-mode configuration options are linked with the FIPS 140-2 validated cryptographic library.
 You can run Red Hat Enterprise Linux (RHEL) with the FIPS-mode kernel option to enforce FIPS systemwide &mdash; Sensu FIPS builds comply with this mode.
 
 [Contact Sensu][50] to request builds with FIPS support.
+
+Read [Configure Sensu for FIPS compliance][65] to learn more about Sensu's FIPS build, including configuration examples.
 
 ### Windows
 
@@ -425,3 +427,4 @@ The [sensu/stable][8] packagecloud repository hosts packages for every Sensu Go 
 [62]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.8.2/sensu-go_6.8.2_darwin_arm64.zip
 [63]: https://packagecloud.io/sensu/stable/mirror#yum
 [64]: https://packagecloud.io/sensu/stable/mirror#apt
+[65]: ../operations/deploy-sensu/secure-sensu/#optional-configure-sensu-for-fips-compliance


### PR DESCRIPTION
## Description
Adds a link in the Platforms page to the FIPS config info and examples in the Secure Sensu doc

## Motivation and Context
Help interested users find the config info; the new config info has not been indexed by search engines yet