### PR TITLE
Add notes about Catalog option to guides

### DIFF
--- a/content/sensu-go/6.7/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -13,6 +13,11 @@ menu:
     parent: observe-process
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the InfluxDB Metrics integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to send Sensu event data to InfluxDB instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
 A Sensu event handler is an action the Sensu backend executes when a specific [event][1] occurs.
 In this guide, you'll use a [handler][9] to populate the time-series database [InfluxDB][2] with Sensu observability event data.
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -13,6 +13,11 @@ menu:
     parent: observe-process
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the Sumo Logic Analytics integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to send Sensu event data to Sumo Logic instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
 Follow this guide to create a pipeline that sends data from a Sensu check to Sumo Logic for long-term logs and metrics storage.
 Sensu [checks][2] are commands the Sensu agent executes that generate observability data in a status or metric [event][16].
 Sensu [pipelines][14] define the event filters and actions the Sensu backend executes on the events.

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-email-alerts.md
@@ -13,6 +13,11 @@ menu:
     parent: observe-process
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the Email Alerts integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to send email alerts based on Sensu event data instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
 Pipelines are Sensu resources composed of [observation event][1] processing workflows that include filters, mutators, and handlers.
 You can use pipelines to send email alerts, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -13,9 +13,14 @@ menu:
     parent: observe-process
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the PagerDuty integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to send alerts based on Sensu event data instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
+Follow this guide to create a pipeline that sends incident alerts to PagerDuty.
 Sensu [checks][2] are commands the Sensu agent executes that generate observability data in a status or metric [event][19].
 Sensu [pipelines][20] define the event filters and actions the Sensu backend executes on the events.
-Follow this guide to create a pipeline that sends incident alerts to PagerDuty.
 
 This guide will help you send alerts to PagerDuty by configuring a pipeline and adding it to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][3] to add it.

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
@@ -13,6 +13,11 @@ menu:
     parent: observe-process
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the Slack Alerts integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to send Slack alerts based on Sensu event data instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
 Pipelines are Sensu resources composed of [observation event][1] processing workflows that include filters, mutators, and handlers.
 You can use pipelines to send email alerts, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -13,6 +13,11 @@ menu:
     parent: observe-schedule
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the HTTP Service Monitoring (Local) integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to collect service metrics instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
 Sensu checks are **commands** (or scripts) that the Sensu agent executes that output data and produce an exit code to indicate a state.
 If you are unfamiliar with checks, read the [checks reference][1] for details and examples.
 You can also learn how to configure monitoring checks in [Monitor server resources][2].

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/populate-metrics-influxdb.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/populate-metrics-influxdb.md
@@ -13,6 +13,11 @@ menu:
     parent: observe-process
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the InfluxDB Metrics integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to send Sensu event data to InfluxDB instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
 A Sensu event handler is an action the Sensu backend executes when a specific [event][1] occurs.
 In this guide, you'll use a [handler][9] to populate the time-series database [InfluxDB][2] with Sensu observability event data.
 

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -13,6 +13,11 @@ menu:
     parent: observe-process
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the Sumo Logic Analytics integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to send Sensu event data to Sumo Logic instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
 Follow this guide to create a pipeline that sends data from a Sensu check to Sumo Logic for long-term logs and metrics storage.
 Sensu [checks][2] are commands the Sensu agent executes that generate observability data in a status or metric [event][16].
 Sensu [pipelines][14] define the event filters and actions the Sensu backend executes on the events.

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/send-email-alerts.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/send-email-alerts.md
@@ -13,6 +13,11 @@ menu:
     parent: observe-process
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the Email Alerts integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to send email alerts based on Sensu event data instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
 Pipelines are Sensu resources composed of [observation event][1] processing workflows that include filters, mutators, and handlers.
 You can use pipelines to send email alerts, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -13,9 +13,14 @@ menu:
     parent: observe-process
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the PagerDuty integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to send alerts based on Sensu event data instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
+Follow this guide to create a pipeline that sends incident alerts to PagerDuty.
 Sensu [checks][2] are commands the Sensu agent executes that generate observability data in a status or metric [event][19].
 Sensu [pipelines][20] define the event filters and actions the Sensu backend executes on the events.
-Follow this guide to create a pipeline that sends incident alerts to PagerDuty.
 
 This guide will help you send alerts to PagerDuty by configuring a pipeline and adding it to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][3] to add it.

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/send-slack-alerts.md
@@ -13,6 +13,11 @@ menu:
     parent: observe-process
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the Slack Alerts integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to send Slack alerts based on Sensu event data instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
 Pipelines are Sensu resources composed of [observation event][1] processing workflows that include filters, mutators, and handlers.
 You can use pipelines to send email alerts, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -13,6 +13,11 @@ menu:
     parent: observe-schedule
 ---
 
+{{% notice protip %}}
+**PRO TIP**: You can use the HTTP Service Monitoring (Local) integration in the [Sensu Catalog](../../../web-ui/sensu-catalog/) to collect service metrics instead of following this guide.
+Follow the Catalog prompts to configure the Sensu resources you need and start processing your observability data with a few clicks.
+{{% /notice %}}
+
 Sensu checks are **commands** (or scripts) that the Sensu agent executes that output data and produce an exit code to indicate a state.
 If you are unfamiliar with checks, read the [checks reference][1] for details and examples.
 You can also learn how to configure monitoring checks in [Monitor server resources][2].


### PR DESCRIPTION
## Description
For guides with an analogous config option in the Sensu Catalog, added notes to the top of the guide to let users know a Catalog integration is available.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/4064