### PR TITLE
Remove incorrect conflation of binaries with OSS

### DIFF
--- a/content/sensu-go/6.5/get-started.md
+++ b/content/sensu-go/6.5/get-started.md
@@ -47,9 +47,8 @@ Sensu offers support packages for Sensu Go as well as commercial licenses design
 
 Sensu Go's core is open source software, freely available under an MIT License.
 
-- Get the Sensu Go [binary distribution][19] for your platform
-- [Visit Sensu Go on GitHub][10]
 - [Compare OSS and commercial features][14]
+- [Visit Sensu Go on GitHub][10]
 - [Build from source][11]
 
 
@@ -70,7 +69,6 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [16]: #build-sensu-from-source-oss
 [17]: #explore-monitoring-at-scale-with-sensu-go
 [18]: ../operations/deploy-sensu/deployment-architecture/#common-sensu-architectures
-[19]: ../platforms/#binary-only-distributions
 [20]: ../platforms/
 [21]: https://sensu.io/learn
 [22]: ../observability-pipeline/

--- a/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
@@ -15,7 +15,7 @@ This installation guide describes how to install the Sensu backend, Sensu agent,
 These instructions explain how to install Sensu for proof-of-concept purposes or testing in a development environment.
 We recommend using a [supported package][14] to follow this guide.
 
-To build from source and install Sensu from a [binary distribution][23], follow the [Sensu Go installation instructions on GitHub][44].
+To build Sensu Go from source (OSS), follow the [Sensu Go installation instructions on GitHub][44].
 
 {{% notice note %}}
 **NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop#overview) instead.
@@ -576,7 +576,6 @@ sensuctl license info
 [20]: ../../../commercial/
 [21]: #install-the-sensu-backend
 [22]: ../cluster-sensu/
-[23]: ../../../platforms/#binary-only-distributions
 [24]: #4-open-the-web-ui
 [25]: ../hardware-requirements/
 [26]: ../../../api/

--- a/content/sensu-go/6.5/platforms.md
+++ b/content/sensu-go/6.5/platforms.md
@@ -356,7 +356,9 @@ You can also use cron to run Sensu checks locally on these systems and forward t
 Sensu Go's core is open source software, freely available under an MIT License.
 Sensu Go instances built from source do not include [commercial features][3] such as the web UI, single sign-on (SSO) authentication, and secrets management.
 Review the [feature comparison matrix][15] to learn more.
+
 To build Sensu Go from source, read the [Sensu Go installation instructions on GitHub][16].
+To download and run the web UI as a separate component, visit the [Sensu Go Web GitHub repository][60].
 
 ## Mirror packages
 

--- a/content/sensu-go/6.6/get-started.md
+++ b/content/sensu-go/6.6/get-started.md
@@ -47,9 +47,8 @@ Sensu offers support packages for Sensu Go as well as commercial licenses design
 
 Sensu Go's core is open source software, freely available under an MIT License.
 
-- Get the Sensu Go [binary distribution][19] for your platform
-- [Visit Sensu Go on GitHub][10]
 - [Compare OSS and commercial features][14]
+- [Visit Sensu Go on GitHub][10]
 - [Build from source][11]
 
 
@@ -70,7 +69,6 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [16]: #build-sensu-from-source-oss
 [17]: #explore-monitoring-at-scale-with-sensu-go
 [18]: ../operations/deploy-sensu/deployment-architecture/#common-sensu-architectures
-[19]: ../platforms/#binary-only-distributions
 [20]: ../platforms/
 [21]: https://sensu.io/learn
 [22]: ../observability-pipeline/

--- a/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
@@ -15,7 +15,7 @@ This installation guide describes how to install the Sensu backend, Sensu agent,
 These instructions explain how to install Sensu for proof-of-concept purposes or testing in a development environment.
 We recommend using a [supported package][14] to follow this guide.
 
-To build from source and install Sensu from a [binary distribution][23], follow the [Sensu Go installation instructions on GitHub][44].
+To build Sensu Go from source (OSS), follow the [Sensu Go installation instructions on GitHub][44].
 
 {{% notice note %}}
 **NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop#overview) instead.
@@ -576,7 +576,6 @@ sensuctl license info
 [20]: ../../../commercial/
 [21]: #install-the-sensu-backend
 [22]: ../cluster-sensu/
-[23]: ../../../platforms/#binary-only-distributions
 [24]: #4-open-the-web-ui
 [25]: ../hardware-requirements/
 [26]: ../../../api/

--- a/content/sensu-go/6.6/platforms.md
+++ b/content/sensu-go/6.6/platforms.md
@@ -356,7 +356,9 @@ You can also use cron to run Sensu checks locally on these systems and forward t
 Sensu Go's core is open source software, freely available under an MIT License.
 Sensu Go instances built from source do not include [commercial features][3] such as the web UI, single sign-on (SSO) authentication, and secrets management.
 Review the [feature comparison matrix][15] to learn more.
+
 To build Sensu Go from source, read the [Sensu Go installation instructions on GitHub][16].
+To download and run the web UI as a separate component, visit the [Sensu Go Web GitHub repository][60].
 
 ## Mirror packages
 

--- a/content/sensu-go/6.7/get-started.md
+++ b/content/sensu-go/6.7/get-started.md
@@ -47,9 +47,8 @@ Sensu offers support packages for Sensu Go as well as commercial licenses design
 
 Sensu Go's core is open source software, freely available under an MIT License.
 
-- Get the Sensu Go [binary distribution][19] for your platform
-- [Visit Sensu Go on GitHub][10]
 - [Compare OSS and commercial features][14]
+- [Visit Sensu Go on GitHub][10]
 - [Build from source][11]
 
 
@@ -70,7 +69,6 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [16]: #build-sensu-from-source-oss
 [17]: #explore-monitoring-at-scale-with-sensu-go
 [18]: ../operations/deploy-sensu/deployment-architecture/#common-sensu-architectures
-[19]: ../platforms/#binary-only-distributions
 [20]: ../platforms/
 [21]: https://sensu.io/learn
 [22]: ../observability-pipeline/

--- a/content/sensu-go/6.7/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/install-sensu.md
@@ -15,7 +15,7 @@ This installation guide describes how to install the Sensu backend, Sensu agent,
 These instructions explain how to install Sensu for proof-of-concept purposes or testing in a development environment.
 We recommend using a [supported package][14] to follow this guide.
 
-To build from source and install Sensu from a [binary distribution][23], follow the [Sensu Go installation instructions on GitHub][44].
+To build Sensu Go from source (OSS), follow the [Sensu Go installation instructions on GitHub][44].
 
 {{% notice note %}}
 **NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop#overview) instead.
@@ -576,7 +576,6 @@ sensuctl license info
 [20]: ../../../commercial/
 [21]: #install-the-sensu-backend
 [22]: ../cluster-sensu/
-[23]: ../../../platforms/#binary-only-distributions
 [24]: #4-open-the-web-ui
 [25]: ../hardware-requirements/
 [26]: ../../../api/

--- a/content/sensu-go/6.7/platforms.md
+++ b/content/sensu-go/6.7/platforms.md
@@ -370,7 +370,9 @@ You can also use cron to run Sensu checks locally on these systems and forward t
 Sensu Go's core is open source software, freely available under an MIT License.
 Sensu Go instances built from source do not include [commercial features][3] such as the web UI, single sign-on (SSO) authentication, and secrets management.
 Review the [feature comparison matrix][15] to learn more.
+
 To build Sensu Go from source, read the [Sensu Go installation instructions on GitHub][16].
+To download and run the web UI as a separate component, visit the [Sensu Go Web GitHub repository][60].
 
 ## Mirror packages
 

--- a/content/sensu-go/6.8/get-started.md
+++ b/content/sensu-go/6.8/get-started.md
@@ -47,9 +47,8 @@ Sensu offers support packages for Sensu Go as well as commercial licenses design
 
 Sensu Go's core is open source software, freely available under an MIT License.
 
-- Get the Sensu Go [binary distribution][19] for your platform
-- [Visit Sensu Go on GitHub][10]
 - [Compare OSS and commercial features][14]
+- [Visit Sensu Go on GitHub][10]
 - [Build from source][11]
 
 
@@ -70,7 +69,6 @@ Sensu Go's core is open source software, freely available under an MIT License.
 [16]: #build-sensu-from-source-oss
 [17]: #explore-monitoring-at-scale-with-sensu-go
 [18]: ../operations/deploy-sensu/deployment-architecture/#common-sensu-architectures
-[19]: ../platforms/#binary-only-distributions
 [20]: ../platforms/
 [21]: https://sensu.io/learn
 [22]: ../observability-pipeline/

--- a/content/sensu-go/6.8/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/install-sensu.md
@@ -15,7 +15,7 @@ This installation guide describes how to install the Sensu backend, Sensu agent,
 These instructions explain how to install Sensu for proof-of-concept purposes or testing in a development environment.
 We recommend using a [supported package][14] to follow this guide.
 
-To build from source and install Sensu from a [binary distribution][23], follow the [Sensu Go installation instructions on GitHub][44].
+To build Sensu Go from source (OSS), follow the [Sensu Go installation instructions on GitHub][44].
 
 {{% notice note %}}
 **NOTE**: If you’re trying Sensu for the first time, consider following the the [Sensu Go workshop](https://github.com/sensu/sensu-go-workshop#overview) instead.
@@ -576,7 +576,6 @@ sensuctl license info
 [20]: ../../../commercial/
 [21]: #install-the-sensu-backend
 [22]: ../cluster-sensu/
-[23]: ../../../platforms/#binary-only-distributions
 [24]: #4-open-the-web-ui
 [25]: ../hardware-requirements/
 [26]: ../../../api/

--- a/content/sensu-go/6.8/platforms.md
+++ b/content/sensu-go/6.8/platforms.md
@@ -64,9 +64,6 @@ Docker images that contain the Sensu backend and Sensu agent are available for L
 
 Sensu binary-only distributions are available in `.zip` and `.tar.gz` formats.
 
-The Sensu web UI is a standalone product &mdash; it is not distributed inside the Sensu backend binary.
-Visit the [Sensu Go Web GitHub repository][60] for more information.
-
 | Platform | Architectures |
 |----------|---------------|
 | [Linux][44] | `386` `amd64` `arm64` `armv5` `armv6` `armv7`<br>`MIPS` `MIPS LE` `MIPS 64` `MIPS 64 LE` `ppc64le` `s390x` |
@@ -358,7 +355,9 @@ You can also use cron to run Sensu checks locally on these systems and forward t
 Sensu Go's core is open source software, freely available under an MIT License.
 Sensu Go instances built from source do not include [commercial features][3] such as the web UI, single sign-on (SSO) authentication, and secrets management.
 Review the [feature comparison matrix][15] to learn more.
+
 To build Sensu Go from source, read the [Sensu Go installation instructions on GitHub][16].
+To download and run the web UI as a separate component, visit the [Sensu Go Web GitHub repository][60].
 
 ## Mirror packages
 
@@ -422,7 +421,7 @@ The [sensu/stable][8] packagecloud repository hosts packages for every Sensu Go 
 [57]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.8.2/sensu-go_6.8.2_linux_armv6.tar.gz
 [58]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.8.2/cgo/sensu-go-cgo_6.8.2_darwin_amd64.tar.gz
 [59]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.8.2/cgo/sensu-go-cgo_6.8.2_darwin_amd64.zip
-[60]: https://github.com/sensu/web
+[60]: https://github.com/sensu/web#roadmap
 [61]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.8.2/sensu-go_6.8.2_darwin_arm64.tar.gz
 [62]: https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.8.2/sensu-go_6.8.2_darwin_arm64.zip
 [63]: https://packagecloud.io/sensu/stable/mirror#yum


### PR DESCRIPTION
## Description
The docs incorrectly conflated binaries with Sensu Go OSS -- in fact the binaries include our commercial distribution.

## Motivation and Context
https://sensucommunity.slack.com/archives/C6ARWHC2W/p1665755904196029
https://sumologic.slack.com/archives/C024XK35Z3Q/p1665756628987299