### PR TITLE
Add best practices for sensuctl dump

### DIFF
--- a/content/sensu-go/6.5/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.5/sensuctl/back-up-recover.md
@@ -13,7 +13,7 @@ menu:
 
 The sensuctl dump command allows you to export your [resources][6] to standard out (stdout) or to a file.
 You can export all resources or a subset of them based on a list of resource types.
-The `dump` command supports exporting in `wrapped-json` and `yaml`.
+The dump command supports exporting in `wrapped-json` and `yaml`.
 
 For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format:
 
@@ -29,7 +29,7 @@ sensuctl dump all --format wrapped-json --file my-resources.json
 
 {{< /language-toggle >}}
 
-After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
+You can [restore][3] exported resources with [sensuctl create][1].
 
 {{% notice note %}}
 **NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.<br><br>
@@ -37,106 +37,6 @@ In addition, sensuctl create does not restore API keys from a sensuctl dump back
 Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
 Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
 {{% /notice %}}
-
-This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
-
-## Example sensuctl dump commands
-
-To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.CheckConfig --format yaml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.CheckConfig --format wrapped-json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
-For example:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
-Here's an example that uses fully qualified names:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Here's an example that uses short names:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
 
 ## Back up before a Sensu version upgrade
 
@@ -365,6 +265,115 @@ sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+## Example sensuctl dump commands
+
+To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.CheckConfig --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --format wrapped-json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
+For example:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
+Here's an example that uses fully qualified names:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Here's an example that uses short names:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Best practices for sensuctl dump
+
+To reduce the running time for the sensuctl dump command, omit events and export only one namespace at a time.
+
+Omit events from your sensuctl dump command to reduce the size of the exported payload and the system resources required to export.
+The most important part of a backup is capturing the Sensu configuration, and even with regular backups, events are likely to be outdated by the time you restore them.
+If you need access to all events, send them to a database store instead of including events in routine Sensu backups.
+
+It takes longer to export resources from all namespaces at once than the resources from one namespace, especially as the number of resources in each namespace grows.
+To export resources more quickly, export a single namespace at a time.
 
 
 [1]: ../create-manage-resources/#create-resources

--- a/content/sensu-go/6.6/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.6/sensuctl/back-up-recover.md
@@ -13,7 +13,7 @@ menu:
 
 The sensuctl dump command allows you to export your [resources][6] to standard out (stdout) or to a file.
 You can export all resources or a subset of them based on a list of resource types.
-The `dump` command supports exporting in `wrapped-json` and `yaml`.
+The dump command supports exporting in `wrapped-json` and `yaml`.
 
 For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format:
 
@@ -29,7 +29,7 @@ sensuctl dump all --format wrapped-json --file my-resources.json
 
 {{< /language-toggle >}}
 
-After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
+You can [restore][3] exported resources with [sensuctl create][1].
 
 {{% notice note %}}
 **NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.<br><br>
@@ -37,106 +37,6 @@ In addition, sensuctl create does not restore API keys from a sensuctl dump back
 Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
 Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
 {{% /notice %}}
-
-This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
-
-## Example sensuctl dump commands
-
-To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.CheckConfig --format yaml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.CheckConfig --format wrapped-json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
-For example:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
-Here's an example that uses fully qualified names:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Here's an example that uses short names:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
 
 ## Back up before a Sensu version upgrade
 
@@ -365,6 +265,115 @@ sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+## Example sensuctl dump commands
+
+To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.CheckConfig --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --format wrapped-json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
+For example:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
+Here's an example that uses fully qualified names:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Here's an example that uses short names:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Best practices for sensuctl dump
+
+To reduce the running time for the sensuctl dump command, omit events and export only one namespace at a time.
+
+Omit events from your sensuctl dump command to reduce the size of the exported payload and the system resources required to export.
+The most important part of a backup is capturing the Sensu configuration, and even with regular backups, events are likely to be outdated by the time you restore them.
+If you need access to all events, send them to a database store instead of including events in routine Sensu backups.
+
+It takes longer to export resources from all namespaces at once than the resources from one namespace, especially as the number of resources in each namespace grows.
+To export resources more quickly, export a single namespace at a time.
 
 
 [1]: ../create-manage-resources/#create-resources

--- a/content/sensu-go/6.7/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.7/sensuctl/back-up-recover.md
@@ -13,7 +13,7 @@ menu:
 
 The sensuctl dump command allows you to export your [resources][6] to standard out (stdout) or to a file.
 You can export all resources or a subset of them based on a list of resource types.
-The `dump` command supports exporting in `wrapped-json` and `yaml`.
+The dump command supports exporting in `wrapped-json` and `yaml`.
 
 For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format:
 
@@ -29,7 +29,7 @@ sensuctl dump all --format wrapped-json --file my-resources.json
 
 {{< /language-toggle >}}
 
-After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
+You can [restore][3] exported resources with [sensuctl create][1].
 
 {{% notice note %}}
 **NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.<br><br>
@@ -37,106 +37,6 @@ In addition, sensuctl create does not restore API keys from a sensuctl dump back
 Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
 Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
 {{% /notice %}}
-
-This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
-
-## Example sensuctl dump commands
-
-To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.CheckConfig --format yaml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.CheckConfig --format wrapped-json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
-For example:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
-Here's an example that uses fully qualified names:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Here's an example that uses short names:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
 
 ## Back up before a Sensu version upgrade
 
@@ -365,6 +265,115 @@ sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+## Example sensuctl dump commands
+
+To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.CheckConfig --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --format wrapped-json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
+For example:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
+Here's an example that uses fully qualified names:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Here's an example that uses short names:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Best practices for sensuctl dump
+
+To reduce the running time for the sensuctl dump command, omit events and export only one namespace at a time.
+
+Omit events from your sensuctl dump command to reduce the size of the exported payload and the system resources required to export.
+The most important part of a backup is capturing the Sensu configuration, and even with regular backups, events are likely to be outdated by the time you restore them.
+If you need access to all events, send them to a database store instead of including events in routine Sensu backups.
+
+It takes longer to export resources from all namespaces at once than the resources from one namespace, especially as the number of resources in each namespace grows.
+To export resources more quickly, export a single namespace at a time.
 
 
 [1]: ../create-manage-resources/#create-resources

--- a/content/sensu-go/6.8/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.8/sensuctl/back-up-recover.md
@@ -13,7 +13,7 @@ menu:
 
 The sensuctl dump command allows you to export your [resources][6] to standard out (stdout) or to a file.
 You can export all resources or a subset of them based on a list of resource types.
-The `dump` command supports exporting in `wrapped-json` and `yaml`.
+The dump command supports exporting in `wrapped-json` and `yaml`.
 
 For example, to export all resources for the current namespace to a file named `my-resources.yml` or `my-resources.json` in `yaml` or `wrapped-json` format:
 
@@ -29,7 +29,7 @@ sensuctl dump all --format wrapped-json --file my-resources.json
 
 {{< /language-toggle >}}
 
-After you use sensuctl dump to back up your Sensu resources, you can [restore][3] them later with [sensuctl create][1].
+You can [restore][3] exported resources with [sensuctl create][1].
 
 {{% notice note %}}
 **NOTE**: The sensuctl dump command does not export user passwords &mdash; you must add the [`password_hash`](../#generate-a-password-hash) or `password` attribute to any exported users resources before restoring them with sensuctl create.<br><br>
@@ -37,106 +37,6 @@ In addition, sensuctl create does not restore API keys from a sensuctl dump back
 Because users and API keys require these additional steps to restore with sensuctl create, you might prefer to use the [etcd snapshot and restore process](https://etcd.io/docs/latest/op-guide/recovery/) as your primary backup and restore method.
 Take regular etcd snapshots and make regular sensuctl dump backups for extra reassurance.
 {{% /notice %}}
-
-This page explains how to back up your resources for two common use cases: before a Sensu version upgrade and to populate new namespaces with existing resources.
-
-## Example sensuctl dump commands
-
-To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.CheckConfig --format yaml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.CheckConfig --format wrapped-json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
-For example:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
-Here's an example that uses fully qualified names:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
-
-Here's an example that uses short names:
-
-{{< language-toggle >}}
-
-{{< code shell "YML" >}}
-sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
-{{< /code >}}
-
-{{< code shell "Wrapped JSON" >}}
-sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
-{{< /code >}}
-
-{{< /language-toggle >}}
 
 ## Back up before a Sensu version upgrade
 
@@ -362,6 +262,115 @@ sensuctl describe-type core/v2.CheckConfig --format yaml
 
 {{< code shell "Wrapped JSON">}}
 sensuctl describe-type core/v2.CheckConfig --format wrapped-json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+## Best practices for sensuctl dump
+
+To reduce the running time for the sensuctl dump command, omit events and export only one namespace at a time.
+
+Omit events from your sensuctl dump command to reduce the size of the exported payload and the system resources required to export.
+The most important part of a backup is capturing the Sensu configuration, and even with regular backups, events are likely to be outdated by the time you restore them.
+If you need access to all events, send them to a database store instead of including events in routine Sensu backups.
+
+It takes longer to export resources from all namespaces at once than the resources from one namespace, especially as the number of resources in each namespace grows.
+To export resources more quickly, export a single namespace at a time.
+
+## Example sensuctl dump commands
+
+To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.CheckConfig --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --format wrapped-json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To export only handlers and filters for only the current namespace to a file named `my-handlers-and-filters` in YAML or wrapped JSON format:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+To export resources for **all namespaces**, add the `--all-namespaces` flag to any sensuctl dump command.
+For example:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump all --all-namespaces --format yaml --file my-resources.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump all --all-namespaces --format wrapped-json --file my-resources.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format yaml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.CheckConfig --all-namespaces --format wrapped-json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --all-namespaces --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+You can use [fully qualified names or short names][6] to specify resources in sensuctl dump commands.
+Here's an example that uses fully qualified names:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump core/v2.Handler,core/v2.EventFilter --format wrapped-json --file my-handlers-and-filters.json
+{{< /code >}}
+
+{{< /language-toggle >}}
+
+Here's an example that uses short names:
+
+{{< language-toggle >}}
+
+{{< code shell "YML" >}}
+sensuctl dump handlers,filters --format yaml --file my-handlers-and-filters.yml
+{{< /code >}}
+
+{{< code shell "Wrapped JSON" >}}
+sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filters.json
 {{< /code >}}
 
 {{< /language-toggle >}}

--- a/content/sensu-go/6.8/sensuctl/back-up-recover.md
+++ b/content/sensu-go/6.8/sensuctl/back-up-recover.md
@@ -266,17 +266,6 @@ sensuctl describe-type core/v2.CheckConfig --format wrapped-json
 
 {{< /language-toggle >}}
 
-## Best practices for sensuctl dump
-
-To reduce the running time for the sensuctl dump command, omit events and export only one namespace at a time.
-
-Omit events from your sensuctl dump command to reduce the size of the exported payload and the system resources required to export.
-The most important part of a backup is capturing the Sensu configuration, and even with regular backups, events are likely to be outdated by the time you restore them.
-If you need access to all events, send them to a database store instead of including events in routine Sensu backups.
-
-It takes longer to export resources from all namespaces at once than the resources from one namespace, especially as the number of resources in each namespace grows.
-To export resources more quickly, export a single namespace at a time.
-
 ## Example sensuctl dump commands
 
 To export only checks for only the current namespace to stdout in YAML or wrapped JSON format:
@@ -374,6 +363,17 @@ sensuctl dump handlers,filters --format wrapped-json --file my-handlers-and-filt
 {{< /code >}}
 
 {{< /language-toggle >}}
+
+## Best practices for sensuctl dump
+
+To reduce the running time for the sensuctl dump command, omit events and export only one namespace at a time.
+
+Omit events from your sensuctl dump command to reduce the size of the exported payload and the system resources required to export.
+The most important part of a backup is capturing the Sensu configuration, and even with regular backups, events are likely to be outdated by the time you restore them.
+If you need access to all events, send them to a database store instead of including events in routine Sensu backups.
+
+It takes longer to export resources from all namespaces at once than the resources from one namespace, especially as the number of resources in each namespace grows.
+To export resources more quickly, export a single namespace at a time.
 
 
 [1]: ../create-manage-resources/#create-resources


### PR DESCRIPTION
## Description
In the Back up and recover doc, adds recommendations for running sensuctl dump without events and one namespace at a time.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/4071