### PR TITLE
Add notes about ad hoc check execution for round robin checks

### DIFF
--- a/content/sensu-go/6.5/api/core/checks.md
+++ b/content/sensu-go/6.5/api/core/checks.md
@@ -584,7 +584,12 @@ The `/checks/:check/execute` API endpoint provides HTTP POST access to create an
 ### Example {#checkscheckexecute-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/checks/:check/execute` API endpoint to execute the `check_cpu` check.
-The request includes the check name in the request body. 
+The request includes the check name in the request body.
+
+{{% notice protip %}}
+**PRO TIP**: Include the `subscriptions` attribute with the request body to override the subscriptions configured in the check definition.
+This gives you the flexibility to execute a check on any Sensu entity or group of entities on demand.
+{{% /notice %}}
 
 {{< code shell >}}
 curl -X POST \
@@ -605,9 +610,11 @@ The request will return a successful `HTTP/1.1 202 Accepted` response and an `is
 {"issued":1543861798}
 {{< /code >}}
 
-{{% notice protip %}}
-**PRO TIP**: Include the `subscriptions` attribute with the request body to override the subscriptions configured in the check definition.
-This gives you the flexibility to execute a check on any Sensu entity or group of entities on demand.
+{{% notice note %}}
+**NOTE**: If you specify a [round robin check](../../../observability-pipeline/observe-schedule/checks/#round-robin-checks), Sensu will execute the check on *all* agents with a matching subscription.
+After the ad hoc execution, the check will run as scheduled in round robin fashion.<br><br>
+To execute a round robin check on a single agent, include the agent's entity name subscription in the request body.
+For example, if the entity is named `webserver1`, use the subscription `entity:webserver1`.
 {{% /notice %}}
 
 ### API Specification {#checkscheckexecute-post-specification}

--- a/content/sensu-go/6.6/api/core/checks.md
+++ b/content/sensu-go/6.6/api/core/checks.md
@@ -584,7 +584,12 @@ The `/checks/:check/execute` API endpoint provides HTTP POST access to create an
 ### Example {#checkscheckexecute-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/checks/:check/execute` API endpoint to execute the `check_cpu` check.
-The request includes the check name in the request body. 
+The request includes the check name in the request body.
+
+{{% notice protip %}}
+**PRO TIP**: Include the `subscriptions` attribute with the request body to override the subscriptions configured in the check definition.
+This gives you the flexibility to execute a check on any Sensu entity or group of entities on demand.
+{{% /notice %}}
 
 {{< code shell >}}
 curl -X POST \
@@ -605,9 +610,11 @@ The request will return a successful `HTTP/1.1 202 Accepted` response and an `is
 {"issued":1543861798}
 {{< /code >}}
 
-{{% notice protip %}}
-**PRO TIP**: Include the `subscriptions` attribute with the request body to override the subscriptions configured in the check definition.
-This gives you the flexibility to execute a check on any Sensu entity or group of entities on demand.
+{{% notice note %}}
+**NOTE**: If you specify a [round robin check](../../../observability-pipeline/observe-schedule/checks/#round-robin-checks), Sensu will execute the check on *all* agents with a matching subscription.
+After the ad hoc execution, the check will run as scheduled in round robin fashion.<br><br>
+To execute a round robin check on a single agent, include the agent's entity name subscription in the request body.
+For example, if the entity is named `webserver1`, use the subscription `entity:webserver1`.
 {{% /notice %}}
 
 ### API Specification {#checkscheckexecute-post-specification}

--- a/content/sensu-go/6.7/api/core/checks.md
+++ b/content/sensu-go/6.7/api/core/checks.md
@@ -586,6 +586,11 @@ The `/checks/:check/execute` API endpoint provides HTTP POST access to create an
 In the following example, an HTTP POST request is submitted to the `/checks/:check/execute` API endpoint to execute the `check_cpu` check.
 The request includes the check name in the request body. 
 
+{{% notice protip %}}
+**PRO TIP**: Include the `subscriptions` attribute with the request body to override the subscriptions configured in the check definition.
+This gives you the flexibility to execute a check on any Sensu entity or group of entities on demand.
+{{% /notice %}}
+
 {{< code shell >}}
 curl -X POST \
 -H "Authorization: Key $SENSU_API_KEY" \
@@ -605,9 +610,11 @@ The request will return a successful `HTTP/1.1 202 Accepted` response and an `is
 {"issued":1543861798}
 {{< /code >}}
 
-{{% notice protip %}}
-**PRO TIP**: Include the `subscriptions` attribute with the request body to override the subscriptions configured in the check definition.
-This gives you the flexibility to execute a check on any Sensu entity or group of entities on demand.
+{{% notice note %}}
+**NOTE**: If you specify a [round robin check](../../../observability-pipeline/observe-schedule/checks/#round-robin-checks), Sensu will execute the check on *all* agents with a matching subscription.
+After the ad hoc execution, the check will run as scheduled in round robin fashion.<br><br>
+To execute a round robin check on a single agent, include the agent's entity name subscription in the request body.
+For example, if the entity is named `webserver1`, use the subscription `entity:webserver1`.
 {{% /notice %}}
 
 ### API Specification {#checkscheckexecute-post-specification}

--- a/content/sensu-go/6.7/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.7/web-ui/view-manage-resources.md
@@ -118,6 +118,13 @@ In the Execute Check dialog window, you can execute the check according to its e
 
 {{< figure src="/images/go/view_manage_resources/execute_check_dialog_670.png" alt="Execute Check dialog window for executing a check on demand from the web UI" link="/images/go/view_manage_resources/execute_check_dialog_670.png" target="_blank" >}}
 
+{{% notice note %}}
+**NOTE**: If you manually execute a [round robin check](../../observability-pipeline/observe-schedule/checks/#round-robin-checks) in the web UI, Sensu will execute the check on *all* subscribed agents.
+After the manual execution, the check will run as scheduled in round robin fashion.<br><br>
+To manually execute a round robin check on a single agent, specify the agent's entity name subscription in the Execute Check dialog.
+For example, if the entity is named `webserver1`, use the subscription `entity:webserver1`.
+{{% /notice %}}
+
 ## View resource data in the web UI
 
 You can view and copy the YAML or JSON definition for any event, entity, or configuration resource directly in the web UI.

--- a/content/sensu-go/6.8/api/core/checks.md
+++ b/content/sensu-go/6.8/api/core/checks.md
@@ -584,7 +584,12 @@ The `/checks/:check/execute` API endpoint provides HTTP POST access to create an
 ### Example {#checkscheckexecute-post-example}
 
 In the following example, an HTTP POST request is submitted to the `/checks/:check/execute` API endpoint to execute the `check_cpu` check.
-The request includes the check name in the request body. 
+The request includes the check name in the request body.
+
+{{% notice protip %}}
+**PRO TIP**: Include the `subscriptions` attribute with the request body to override the subscriptions configured in the check definition.
+This gives you the flexibility to execute a check on any Sensu entity or group of entities on demand.
+{{% /notice %}}
 
 {{< code shell >}}
 curl -X POST \
@@ -605,9 +610,11 @@ The request will return a successful `HTTP/1.1 202 Accepted` response and an `is
 {"issued":1543861798}
 {{< /code >}}
 
-{{% notice protip %}}
-**PRO TIP**: Include the `subscriptions` attribute with the request body to override the subscriptions configured in the check definition.
-This gives you the flexibility to execute a check on any Sensu entity or group of entities on demand.
+{{% notice note %}}
+**NOTE**: If you specify a [round robin check](../../../observability-pipeline/observe-schedule/checks/#round-robin-checks), Sensu will execute the check on *all* agents with a matching subscription.
+After the ad hoc execution, the check will run as scheduled in round robin fashion.<br><br>
+To execute a round robin check on a single agent, include the agent's entity name subscription in the request body.
+For example, if the entity is named `webserver1`, use the subscription `entity:webserver1`.
 {{% /notice %}}
 
 ### API Specification {#checkscheckexecute-post-specification}

--- a/content/sensu-go/6.8/web-ui/view-manage-resources.md
+++ b/content/sensu-go/6.8/web-ui/view-manage-resources.md
@@ -118,6 +118,13 @@ In the Execute Check dialog window, you can execute the check according to its e
 
 {{< figure src="/images/go/view_manage_resources/execute_check_dialog_670.png" alt="Execute Check dialog window for executing a check on demand from the web UI" link="/images/go/view_manage_resources/execute_check_dialog_670.png" target="_blank" >}}
 
+{{% notice note %}}
+**NOTE**: If you manually execute a [round robin check](../../observability-pipeline/observe-schedule/checks/#round-robin-checks) in the web UI, Sensu will execute the check on *all* subscribed agents.
+After the manual execution, the check will run as scheduled in round robin fashion.<br><br>
+To manually execute a round robin check on a single agent, specify the agent's entity name subscription in the Execute Check dialog.
+For example, if the entity is named `webserver1`, use the subscription `entity:webserver1`.
+{{% /notice %}}
+
 ## View resource data in the web UI
 
 You can view and copy the YAML or JSON definition for any event, entity, or configuration resource directly in the web UI.


### PR DESCRIPTION
## Description
In the check API and web UI view and manage resources docs, adds notes about how manual/ad hoc check execution works for round robin checks, as well as how to limit execution to a single entity.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/4067