### PR TITLE
Document workaround for running local preview on M1 macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ yarn
 
 This will install Hugo and build the site into the `public` directory.
 
+    **NOTE**: If you're using a Mac with an M1 chip, add the following steps. If you're not using an M1 Mac, proceed to step 4.
+
+    a. In your local copy of `sensu-docs`, open `node_modules` > `hugo-cli` > `index.js`.
+    b. Change line 76 to read `arch_exec = 'arm64';`.
+    c. Change line 77 to read `arch_dl = '-ARM64';`.
+    d. Save your changes to `index.js`.
+    e. Run `yarn` again.
+
 #### 4. Run the site locally
 
 If the site builds successfully, run:
@@ -82,10 +90,6 @@ Here are some things to try if you encounter an issue working with the site:
 The docs site displays incorrectly in Internet Explorer.
 If you cannot use a different browser, you can access a PDF copy of the Sensu documentation on our [supported versions][supp-vers] page.
 
-### Theme
-
-This project uses a [fork](themes/hugo-material-docs/) of the wonderful [hugo-material-docs](https://github.com/digitalcraftsman/hugo-material-docs) theme.
-
 ### Developing Offline Docs
 
 Offline documentation uses a set of layouts located in the `offline` directory. To preview them:
@@ -94,7 +98,7 @@ Offline documentation uses a set of layouts located in the `offline` directory. 
 yarn run server --layoutDir=offline
 ```
 
-To exclude content from the offline documentation, the following can be added to a markdown file's front matter:
+To exclude content from the offline documentation, add this line to a markdown file's front matter:
 
 ```
 offline: false

--- a/README.md
+++ b/README.md
@@ -63,10 +63,15 @@ This will install Hugo and build the site into the `public` directory.
 **NOTE**: If you're using a Mac with an M1 chip, add the following steps. If you're not using an M1 Mac, proceed to step 4.
 
 *Additional steps for M1 Macs only*
+
 a. In your local copy of `sensu-docs`, open `node_modules` > `hugo-cli` > `index.js`.
+
 b. Change line 76 to read `arch_exec = 'arm64';`.
+
 c. Change line 77 to read `arch_dl = '-ARM64';`.
+
 d. Save your changes to `index.js`.
+
 e. Run `yarn` again.
 
 #### 4. Run the site locally

--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ yarn
 
 This will install Hugo and build the site into the `public` directory.
 
-    **NOTE**: If you're using a Mac with an M1 chip, add the following steps. If you're not using an M1 Mac, proceed to step 4.
+**NOTE**: If you're using a Mac with an M1 chip, add the following steps. If you're not using an M1 Mac, proceed to step 4.
 
-    a. In your local copy of `sensu-docs`, open `node_modules` > `hugo-cli` > `index.js`.
-    b. Change line 76 to read `arch_exec = 'arm64';`.
-    c. Change line 77 to read `arch_dl = '-ARM64';`.
-    d. Save your changes to `index.js`.
-    e. Run `yarn` again.
+*Additional steps for M1 Macs only*
+a. In your local copy of `sensu-docs`, open `node_modules` > `hugo-cli` > `index.js`.
+b. Change line 76 to read `arch_exec = 'arm64';`.
+c. Change line 77 to read `arch_dl = '-ARM64';`.
+d. Save your changes to `index.js`.
+e. Run `yarn` again.
 
 #### 4. Run the site locally
 


### PR DESCRIPTION
## Description
Document workaround for M1 macs so that the yarn commands will work to build and run the site locally.

Also removes mention of the hugo-material-docs theme, which is discussed in https://github.com/sensu/sensu-docs/issues/2443.