### PR TITLE
6.9.0: Remove 6.8.x patch notations

### DIFF
--- a/content/sensu-go/6.9/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-schedule/agent.md
@@ -1938,7 +1938,7 @@ Restart the agent with a service manager:
 sc.exe start SensuAgent
 {{< /code >}}
 
-As of Sensu Go 6.8.2, the Sensu Agent service on Windows platforms will automatically restart after failures.
+On Windows platforms, the Sensu Agent service will automatically restart after failures.
 You'll still need to use a service manager restart Windows agents to implement configuration updates.
 
 {{< platformBlockClose >}}

--- a/content/sensu-go/6.9/observability-pipeline/observe-schedule/checks.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-schedule/checks.md
@@ -1783,7 +1783,7 @@ ttl: 100
 
 |max_output_size  | |
 -------------|-------
-description  | Maximum size of stored check outputs. In bytes. When set to a non-zero value, the Sensu backend truncates check outputs larger than this value before storing to etcd. `max_output_size` does not affect data sent to Sensu filters, mutators, and handlers.<br><br>As of Sensu Go 6.8.2, when check output is truncated due to the `max_output_size` configuration, the events the check produces will include a `sensu.io/output_truncated_bytes` label.
+description  | Maximum size of stored check outputs. In bytes. When set to a non-zero value, the Sensu backend truncates check outputs larger than this value before storing to etcd. `max_output_size` does not affect data sent to Sensu filters, mutators, and handlers.<br><br>When check output is truncated due to the `max_output_size` configuration, the events the check produces will include the label `sensu.io/output_truncated_bytes`.
 required     | false
 type         | Integer
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.9/web-ui/_index.md
+++ b/content/sensu-go/6.9/web-ui/_index.md
@@ -45,8 +45,7 @@ Read the [RBAC reference][3] for [default user credentials][4] and instructions 
 
 ### Backend log messages for web UI sign-in
 
-As of Sensu Go 6.8.2, Sensu logs an INFO message in the backend log upon successful login, with details about the
-user and provider.
+Upon successful login, Sensu logs an INFO message in the backend log with details about the user and provider.
 For unsuccessful login attempts, Sensu logs an ERROR message upon authentication failure, along with the username that was tried.
 
 Read [Service logging][10] for more information about the backend log and log levels.


### PR DESCRIPTION
## Description
In the 6.9 docset, removes 6.8.x patch notations.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/4060