### PR TITLE
Update hugo-cli version in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,6 @@ yarn
 
 This will install Hugo and build the site into the `public` directory.
 
-**NOTE**: If you're using a Mac with an M1 chip, add the following steps. If you're not using an M1 Mac, proceed to step 4.
-
-*Additional steps for M1 Macs only*
-
-a. In your local copy of `sensu-docs`, open `node_modules` > `hugo-cli` > `index.js`.
-
-b. Change line 76 to read `arch_exec = 'arm64';`.
-
-c. Change line 77 to read `arch_dl = '-ARM64';`.
-
-d. Save your changes to `index.js`.
-
-e. Run `yarn` again.
-
 #### 4. Run the site locally
 
 If the site builds successfully, run:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "grunt-env": "^1.0.1",
-    "hugo-cli": "^0.11.0"
+    "hugo-cli": "^0.11.1"
   },
   "engines": {
     "node": ">= 12 <= 18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,10 +1688,10 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-hugo-cli@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/hugo-cli/-/hugo-cli-0.11.0.tgz#ae10973b7b9b0ffd7ba47d8c8ca5a50250726aea"
-  integrity sha512-Gu2s535ASZuV4HOi1hJ1HmNG4zN4Jb30UHcMPzYgTa1Bx2v/urG+vb6c4J0DeYfj4YzpopjFW8w9c0iy51DwPQ==
+hugo-cli@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/hugo-cli/-/hugo-cli-0.11.1.tgz#07e9025b9b765c780139e7229998f694895efcab"
+  integrity sha512-UaZnuQjuog31ElAtll2yLzCNMmp55OWZ3k6IHd3qIswVhYT+zjoWVRXBQ8ZLmAHxT/ToNe2mCXH9FOUqHIxibw==
   dependencies:
     chalk "^2.4.1"
     decompress "^4.0.0"


### PR DESCRIPTION
## Description
Updates the hugo-cli version to 0.11.1 in package.json (resolves the issue with building site locally on M1 macs). Also removes the workaround from sensu-docs readme.

## Motivation and Context
https://github.com/nikku/hugo-cli/issues/35
https://github.com/nikku/hugo-cli/pull/36
