### PR TITLE
Update secrets docs to fix links and other minor issues

### DIFF
--- a/content/sensu-go/6.5/api/enterprise/secrets.md
+++ b/content/sensu-go/6.5/api/enterprise/secrets.md
@@ -66,7 +66,7 @@ The request results in a successful `HTTP/1.1 200 OK` response and a JSON array 
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/_index.md
@@ -21,8 +21,8 @@ Your Sensu backend will be able to execute the handler with any check.
 
 ## Secrets
 
-Secrets are configured via secrets resources.
-A secret resource definition refers to the secrets provider (`Env` or `VaultProvider`) and an ID (the named secret to fetch from the secrets provider).
+Secrets are configured with Sensu's `Secret` resources.
+A secret resource definition refers to the secrets provider and an ID (the named secret to fetch from the secrets provider).
 
 The [secrets reference][3] includes the specification, sensuctl configuration subcommands, and examples for secrets resources.
 

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
@@ -52,7 +52,7 @@ Make a note of your Integration Key &mdash; you'll need it to create your [backe
 
 ## Use Env for secrets management
 
-The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][41] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 ### Create your backend environment variable
@@ -536,7 +536,7 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [15]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
-[21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[21]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [22]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [23]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [24]: ../../../observability-pipeline/observe-schedule/checks/#pipelines-attribute
@@ -550,3 +550,4 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [34]: ../../../observability-pipeline/observe-filter/filters/#built-in-filter-is_incident
 [35]: ../../../observability-pipeline/observe-process/pipelines/#workflows
 [36]: ../../../observability-pipeline/observe-process/send-pagerduty-alerts/#assign-the-pipeline-to-a-check
+[41]: ../../../commercial/

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-providers.md
@@ -21,7 +21,7 @@ Sensu's secrets management eliminates the need to expose secrets like usernames,
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].
 
 {{% notice note %}}
-**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-with-secret), [handlers](../../../observability-pipeline/observe-process/handlers/#handler-with-secret), and [mutators](../../../observability-pipeline/observe-transform/mutators/#mutator-with-secret).
+**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-example-that-uses-secrets-management), [handlers](../../../observability-pipeline/observe-process/handlers/#use-secrets-management-in-a-handler), and [mutators](../../../observability-pipeline/observe-transform/mutators/#use-secrets-management-in-a-mutator).
 {{% /notice %}}
 
 Only Sensu backends have access to request [secrets][9] from a secrets provider.
@@ -335,7 +335,7 @@ address: https://vaultserver.example.com:8200
 
 max_retries  | 
 -------------|------ 
-description  | Number of times to retry connecting to the vault provider.
+description  | Number of times to retry connecting to the Vault provider.
 required     | true
 type         | Integer
 default      | 2
@@ -392,7 +392,7 @@ timeout: 20s
 
 tls          | 
 -------------|------ 
-description  | TLS object. Vault only works with TLS configured. You may need to set up a CA cert if it is not already stored in your operating system's trust store. To do this, set the TLS object and provide the `ca_cert` path. You may also need to set up `client_cert`, `client_key`, or [`cname`][15].
+description  | TLS object. Vault only works with TLS configured. You may need to set up a Certificate Authority (CA) certificate if it is not already stored in your operating system's trust store. To do this, set the TLS object and provide the `ca_cert` path. You may also need to set up `client_cert`, `client_key`, or [`cname`][15].
 required     | false
 type         | Map of key-value pairs
 example      | {{< language-toggle >}}
@@ -486,7 +486,7 @@ limit: 10.0
 [1]: ../../../commercial/
 [2]: ../../../api/enterprise/secrets/
 [3]: ../../../sensuctl/
-[4]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[4]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [5]: https://www.vaultproject.io/docs/what-is-vault/
 [6]: ../../control-access/rbac#default-users
 [7]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets.md
@@ -21,7 +21,7 @@ Sensu's secrets management eliminates the need to expose secrets in your Sensu c
 When a Sensu resource definition requires a secret (for example, a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
 
 {{% notice note %}}
-**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-with-secret), [handlers](../../../observability-pipeline/observe-process/handlers/#handler-with-secret), and [mutators](../../../observability-pipeline/observe-transform/mutators/#mutator-with-secret).
+**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-example-that-uses-secrets-management), [handlers](../../../observability-pipeline/observe-process/handlers/#use-secrets-management-in-a-handler), and [mutators](../../../observability-pipeline/observe-transform/mutators/#use-secrets-management-in-a-mutator).
 {{% /notice %}}
 
 Only Sensu backends have access to request secrets from a [secrets provider][7].
@@ -267,7 +267,7 @@ namespace: default
 
 id           | 
 -------------|------ 
-description  | Identifying key for the provider to retrieve the secret. For the `Env` secrets provider, the `id` is the environment variable. For the `Vault` secrets provider, the `id` specifies the secrets engine path, the path to the secret within that secrets engine, and the field to retrieve within the secret.
+description  | Identifying key for the provider to use to retrieve the secret. For the `Env` secrets provider, the `id` is the environment variable. For the `VaultProvider` secrets provider, the `id` specifies the secrets engine path, the path to the secret within that secrets engine, and the field to retrieve within the secret.
 required     | true
 type         | String
 example for Vault KV Secrets Engine v1 | {{< language-toggle >}}
@@ -311,7 +311,7 @@ provider: vault
 [2]: ../../../api/enterprise/secrets/
 [3]: ../../../sensuctl/
 [4]: ../../../sensuctl/create-manage-resources/#subcommands
-[5]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[5]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [6]: ../../control-access/rbac#default-users
 [7]: ../secrets-providers/
 [8]: #spec-attributes

--- a/content/sensu-go/6.6/api/enterprise/secrets.md
+++ b/content/sensu-go/6.6/api/enterprise/secrets.md
@@ -66,7 +66,7 @@ The request results in a successful `HTTP/1.1 200 OK` response and a JSON array 
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/_index.md
@@ -21,8 +21,8 @@ Your Sensu backend will be able to execute the handler with any check.
 
 ## Secrets
 
-Secrets are configured via secrets resources.
-A secret resource definition refers to the secrets provider (`Env` or `VaultProvider`) and an ID (the named secret to fetch from the secrets provider).
+Secrets are configured with Sensu's `Secret` resources.
+A secret resource definition refers to the secrets provider and an ID (the named secret to fetch from the secrets provider).
 
 The [secrets reference][3] includes the specification, sensuctl configuration subcommands, and examples for secrets resources.
 

--- a/content/sensu-go/6.6/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/secrets-management.md
@@ -54,7 +54,7 @@ Make a note of your Integration Key &mdash; you'll need it to create your [backe
 
 ## Use Env for secrets management
 
-The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][41] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 ### Create your backend environment variable
@@ -538,7 +538,7 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [15]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
-[21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[21]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [22]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [23]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [24]: ../../../observability-pipeline/observe-schedule/checks/#pipelines-attribute
@@ -552,3 +552,4 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [34]: ../../../observability-pipeline/observe-filter/filters/#built-in-filter-is_incident
 [35]: ../../../observability-pipeline/observe-process/pipelines/#workflows
 [36]: ../../../observability-pipeline/observe-process/send-pagerduty-alerts/#assign-the-pipeline-to-a-check
+[41]: ../../../commercial/

--- a/content/sensu-go/6.6/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/secrets-providers.md
@@ -21,7 +21,7 @@ Sensu's secrets management eliminates the need to expose secrets like usernames,
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].
 
 {{% notice note %}}
-**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-with-secret), [handlers](../../../observability-pipeline/observe-process/handlers/#handler-with-secret), and [mutators](../../../observability-pipeline/observe-transform/mutators/#mutator-with-secret).
+**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-example-that-uses-secrets-management), [handlers](../../../observability-pipeline/observe-process/handlers/#use-secrets-management-in-a-handler), and [mutators](../../../observability-pipeline/observe-transform/mutators/#use-secrets-management-in-a-mutator).
 {{% /notice %}}
 
 Only Sensu backends have access to request [secrets][9] from a secrets provider.
@@ -335,7 +335,7 @@ address: https://vaultserver.example.com:8200
 
 max_retries  | 
 -------------|------ 
-description  | Number of times to retry connecting to the vault provider.
+description  | Number of times to retry connecting to the Vault provider.
 required     | true
 type         | Integer
 default      | 2
@@ -392,7 +392,7 @@ timeout: 20s
 
 tls          | 
 -------------|------ 
-description  | TLS object. Vault only works with TLS configured. You may need to set up a CA cert if it is not already stored in your operating system's trust store. To do this, set the TLS object and provide the `ca_cert` path. You may also need to set up `client_cert`, `client_key`, or [`cname`][15].
+description  | TLS object. Vault only works with TLS configured. You may need to set up a Certificate Authority (CA) certificate if it is not already stored in your operating system's trust store. To do this, set the TLS object and provide the `ca_cert` path. You may also need to set up `client_cert`, `client_key`, or [`cname`][15].
 required     | false
 type         | Map of key-value pairs
 example      | {{< language-toggle >}}
@@ -486,7 +486,7 @@ limit: 10.0
 [1]: ../../../commercial/
 [2]: ../../../api/enterprise/secrets/
 [3]: ../../../sensuctl/
-[4]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[4]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [5]: https://www.vaultproject.io/docs/what-is-vault/
 [6]: ../../control-access/rbac#default-users
 [7]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.6/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/secrets.md
@@ -21,7 +21,7 @@ Sensu's secrets management eliminates the need to expose secrets in your Sensu c
 When a Sensu resource definition requires a secret (for example, a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
 
 {{% notice note %}}
-**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-with-secret), [handlers](../../../observability-pipeline/observe-process/handlers/#handler-with-secret), and [mutators](../../../observability-pipeline/observe-transform/mutators/#mutator-with-secret).
+**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-example-that-uses-secrets-management), [handlers](../../../observability-pipeline/observe-process/handlers/#use-secrets-management-in-a-handler), and [mutators](../../../observability-pipeline/observe-transform/mutators/#use-secrets-management-in-a-mutator).
 {{% /notice %}}
 
 Only Sensu backends have access to request secrets from a [secrets provider][7].
@@ -267,7 +267,7 @@ namespace: default
 
 id           | 
 -------------|------ 
-description  | Identifying key for the provider to retrieve the secret. For the `Env` secrets provider, the `id` is the environment variable. For the `Vault` secrets provider, the `id` specifies the secrets engine path, the path to the secret within that secrets engine, and the field to retrieve within the secret.
+description  | Identifying key for the provider to use to retrieve the secret. For the `Env` secrets provider, the `id` is the environment variable. For the `VaultProvider` secrets provider, the `id` specifies the secrets engine path, the path to the secret within that secrets engine, and the field to retrieve within the secret.
 required     | true
 type         | String
 example for Vault KV Secrets Engine v1 | {{< language-toggle >}}
@@ -311,7 +311,7 @@ provider: vault
 [2]: ../../../api/enterprise/secrets/
 [3]: ../../../sensuctl/
 [4]: ../../../sensuctl/create-manage-resources/#subcommands
-[5]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[5]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [6]: ../../control-access/rbac#default-users
 [7]: ../secrets-providers/
 [8]: #spec-attributes

--- a/content/sensu-go/6.7/api/enterprise/secrets.md
+++ b/content/sensu-go/6.7/api/enterprise/secrets.md
@@ -66,7 +66,7 @@ The request results in a successful `HTTP/1.1 200 OK` response and a JSON array 
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.7/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.7/operations/manage-secrets/_index.md
@@ -21,8 +21,8 @@ Your Sensu backend will be able to execute the handler with any check.
 
 ## Secrets
 
-Secrets are configured via secrets resources.
-A secret resource definition refers to the secrets provider (`Env` or `VaultProvider`) and an ID (the named secret to fetch from the secrets provider).
+Secrets are configured with Sensu's `Secret` resources.
+A secret resource definition refers to the secrets provider and an ID (the named secret to fetch from the secrets provider).
 
 The [secrets reference][3] includes the specification, sensuctl configuration subcommands, and examples for secrets resources.
 

--- a/content/sensu-go/6.7/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.7/operations/manage-secrets/secrets-management.md
@@ -54,7 +54,7 @@ Make a note of your Integration Key &mdash; you'll need it to create your [backe
 
 ## Use Env for secrets management
 
-The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][41] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 ### Create your backend environment variable
@@ -538,7 +538,7 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [15]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
-[21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[21]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [22]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [23]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [24]: ../../../observability-pipeline/observe-schedule/checks/#pipelines-attribute
@@ -552,3 +552,4 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [34]: ../../../observability-pipeline/observe-filter/filters/#built-in-filter-is_incident
 [35]: ../../../observability-pipeline/observe-process/pipelines/#workflows
 [36]: ../../../observability-pipeline/observe-process/send-pagerduty-alerts/#assign-the-pipeline-to-a-check
+[41]: ../../../commercial/

--- a/content/sensu-go/6.7/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.7/operations/manage-secrets/secrets-providers.md
@@ -21,7 +21,7 @@ Sensu's secrets management eliminates the need to expose secrets like usernames,
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].
 
 {{% notice note %}}
-**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-with-secret), [handlers](../../../observability-pipeline/observe-process/handlers/#handler-with-secret), and [mutators](../../../observability-pipeline/observe-transform/mutators/#mutator-with-secret).
+**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-example-that-uses-secrets-management), [handlers](../../../observability-pipeline/observe-process/handlers/#use-secrets-management-in-a-handler), and [mutators](../../../observability-pipeline/observe-transform/mutators/#use-secrets-management-in-a-mutator).
 {{% /notice %}}
 
 Only Sensu backends have access to request [secrets][9] from a secrets provider.
@@ -335,7 +335,7 @@ address: https://vaultserver.example.com:8200
 
 max_retries  | 
 -------------|------ 
-description  | Number of times to retry connecting to the vault provider.
+description  | Number of times to retry connecting to the Vault provider.
 required     | true
 type         | Integer
 default      | 2
@@ -392,7 +392,7 @@ timeout: 20s
 
 tls          | 
 -------------|------ 
-description  | TLS object. Vault only works with TLS configured. You may need to set up a CA cert if it is not already stored in your operating system's trust store. To do this, set the TLS object and provide the `ca_cert` path. You may also need to set up `client_cert`, `client_key`, or [`cname`][15].
+description  | TLS object. Vault only works with TLS configured. You may need to set up a Certificate Authority (CA) certificate if it is not already stored in your operating system's trust store. To do this, set the TLS object and provide the `ca_cert` path. You may also need to set up `client_cert`, `client_key`, or [`cname`][15].
 required     | false
 type         | Map of key-value pairs
 example      | {{< language-toggle >}}
@@ -486,7 +486,7 @@ limit: 10.0
 [1]: ../../../commercial/
 [2]: ../../../api/enterprise/secrets/
 [3]: ../../../sensuctl/
-[4]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[4]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [5]: https://www.vaultproject.io/docs/what-is-vault/
 [6]: ../../control-access/rbac#default-users
 [7]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.7/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.7/operations/manage-secrets/secrets.md
@@ -21,7 +21,7 @@ Sensu's secrets management eliminates the need to expose secrets in your Sensu c
 When a Sensu resource definition requires a secret (for example, a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
 
 {{% notice note %}}
-**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-with-secret), [handlers](../../../observability-pipeline/observe-process/handlers/#handler-with-secret), and [mutators](../../../observability-pipeline/observe-transform/mutators/#mutator-with-secret).
+**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-example-that-uses-secrets-management), [handlers](../../../observability-pipeline/observe-process/handlers/#use-secrets-management-in-a-handler), and [mutators](../../../observability-pipeline/observe-transform/mutators/#use-secrets-management-in-a-mutator).
 {{% /notice %}}
 
 Only Sensu backends have access to request secrets from a [secrets provider][7].
@@ -267,7 +267,7 @@ namespace: default
 
 id           | 
 -------------|------ 
-description  | Identifying key for the provider to retrieve the secret. For the `Env` secrets provider, the `id` is the environment variable. For the `Vault` secrets provider, the `id` specifies the secrets engine path, the path to the secret within that secrets engine, and the field to retrieve within the secret.
+description  | Identifying key for the provider to use to retrieve the secret. For the `Env` secrets provider, the `id` is the environment variable. For the `VaultProvider` secrets provider, the `id` specifies the secrets engine path, the path to the secret within that secrets engine, and the field to retrieve within the secret.
 required     | true
 type         | String
 example for Vault KV Secrets Engine v1 | {{< language-toggle >}}
@@ -311,7 +311,7 @@ provider: vault
 [2]: ../../../api/enterprise/secrets/
 [3]: ../../../sensuctl/
 [4]: ../../../sensuctl/create-manage-resources/#subcommands
-[5]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[5]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [6]: ../../control-access/rbac#default-users
 [7]: ../secrets-providers/
 [8]: #spec-attributes

--- a/content/sensu-go/6.8/api/enterprise/secrets.md
+++ b/content/sensu-go/6.8/api/enterprise/secrets.md
@@ -66,7 +66,7 @@ The request results in a successful `HTTP/1.1 200 OK` response and a JSON array 
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.8/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.8/operations/manage-secrets/_index.md
@@ -21,8 +21,8 @@ Your Sensu backend will be able to execute the handler with any check.
 
 ## Secrets
 
-Secrets are configured via secrets resources.
-A secret resource definition refers to the secrets provider (`Env` or `VaultProvider`) and an ID (the named secret to fetch from the secrets provider).
+Secrets are configured with Sensu's `Secret` resources.
+A secret resource definition refers to the secrets provider and an ID (the named secret to fetch from the secrets provider).
 
 The [secrets reference][3] includes the specification, sensuctl configuration subcommands, and examples for secrets resources.
 

--- a/content/sensu-go/6.8/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.8/operations/manage-secrets/secrets-management.md
@@ -54,7 +54,7 @@ Make a note of your Integration Key &mdash; you'll need it to create your [backe
 
 ## Use Env for secrets management
 
-The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][41] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 ### Create your backend environment variable
@@ -538,7 +538,7 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [15]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
-[21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[21]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [22]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [23]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [24]: ../../../observability-pipeline/observe-schedule/checks/#pipelines-attribute
@@ -552,3 +552,4 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [34]: ../../../observability-pipeline/observe-filter/filters/#built-in-filter-is_incident
 [35]: ../../../observability-pipeline/observe-process/pipelines/#workflows
 [36]: ../../../observability-pipeline/observe-process/send-pagerduty-alerts/#assign-the-pipeline-to-a-check
+[41]: ../../../commercial/

--- a/content/sensu-go/6.8/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.8/operations/manage-secrets/secrets-providers.md
@@ -21,7 +21,7 @@ Sensu's secrets management eliminates the need to expose secrets like usernames,
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].
 
 {{% notice note %}}
-**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-with-secret), [handlers](../../../observability-pipeline/observe-process/handlers/#handler-with-secret), and [mutators](../../../observability-pipeline/observe-transform/mutators/#mutator-with-secret).
+**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-example-that-uses-secrets-management), [handlers](../../../observability-pipeline/observe-process/handlers/#use-secrets-management-in-a-handler), and [mutators](../../../observability-pipeline/observe-transform/mutators/#use-secrets-management-in-a-mutator).
 {{% /notice %}}
 
 Only Sensu backends have access to request [secrets][9] from a secrets provider.
@@ -335,7 +335,7 @@ address: https://vaultserver.example.com:8200
 
 max_retries  | 
 -------------|------ 
-description  | Number of times to retry connecting to the vault provider.
+description  | Number of times to retry connecting to the Vault provider.
 required     | true
 type         | Integer
 default      | 2
@@ -392,7 +392,7 @@ timeout: 20s
 
 tls          | 
 -------------|------ 
-description  | TLS object. Vault only works with TLS configured. You may need to set up a CA cert if it is not already stored in your operating system's trust store. To do this, set the TLS object and provide the `ca_cert` path. You may also need to set up `client_cert`, `client_key`, or [`cname`][15].
+description  | TLS object. Vault only works with TLS configured. You may need to set up a Certificate Authority (CA) certificate if it is not already stored in your operating system's trust store. To do this, set the TLS object and provide the `ca_cert` path. You may also need to set up `client_cert`, `client_key`, or [`cname`][15].
 required     | false
 type         | Map of key-value pairs
 example      | {{< language-toggle >}}
@@ -486,7 +486,7 @@ limit: 10.0
 [1]: ../../../commercial/
 [2]: ../../../api/enterprise/secrets/
 [3]: ../../../sensuctl/
-[4]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[4]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [5]: https://www.vaultproject.io/docs/what-is-vault/
 [6]: ../../control-access/rbac#default-users
 [7]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.8/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.8/operations/manage-secrets/secrets.md
@@ -21,7 +21,7 @@ Sensu's secrets management eliminates the need to expose secrets in your Sensu c
 When a Sensu resource definition requires a secret (for example, a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
 
 {{% notice note %}}
-**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-with-secret), [handlers](../../../observability-pipeline/observe-process/handlers/#handler-with-secret), and [mutators](../../../observability-pipeline/observe-transform/mutators/#mutator-with-secret).
+**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-example-that-uses-secrets-management), [handlers](../../../observability-pipeline/observe-process/handlers/#use-secrets-management-in-a-handler), and [mutators](../../../observability-pipeline/observe-transform/mutators/#use-secrets-management-in-a-mutator).
 {{% /notice %}}
 
 Only Sensu backends have access to request secrets from a [secrets provider][7].
@@ -267,7 +267,7 @@ namespace: default
 
 id           | 
 -------------|------ 
-description  | Identifying key for the provider to retrieve the secret. For the `Env` secrets provider, the `id` is the environment variable. For the `Vault` secrets provider, the `id` specifies the secrets engine path, the path to the secret within that secrets engine, and the field to retrieve within the secret.
+description  | Identifying key for the provider to use to retrieve the secret. For the `Env` secrets provider, the `id` is the environment variable. For the `VaultProvider` secrets provider, the `id` specifies the secrets engine path, the path to the secret within that secrets engine, and the field to retrieve within the secret.
 required     | true
 type         | String
 example for Vault KV Secrets Engine v1 | {{< language-toggle >}}
@@ -311,7 +311,7 @@ provider: vault
 [2]: ../../../api/enterprise/secrets/
 [3]: ../../../sensuctl/
 [4]: ../../../sensuctl/create-manage-resources/#subcommands
-[5]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[5]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [6]: ../../control-access/rbac#default-users
 [7]: ../secrets-providers/
 [8]: #spec-attributes

--- a/content/sensu-go/6.9/api/enterprise/secrets.md
+++ b/content/sensu-go/6.9/api/enterprise/secrets.md
@@ -66,7 +66,7 @@ The request results in a successful `HTTP/1.1 200 OK` response and a JSON array 
 {{< /code >}}
 
 {{% notice note %}}
-**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables) as secrets.
+**NOTE**: In addition to the `VaultProvider` type, enterprise/secrets/v1 API also includes the `Env` secrets provider type that can retrieve backend [environment variables](../../../observability-pipeline/observe-schedule/backend/#environment-variables) as secrets.
 Learn more in the [secrets providers reference](../../../operations/manage-secrets/secrets-providers/).
 {{% /notice %}}
 

--- a/content/sensu-go/6.9/operations/manage-secrets/_index.md
+++ b/content/sensu-go/6.9/operations/manage-secrets/_index.md
@@ -21,8 +21,8 @@ Your Sensu backend will be able to execute the handler with any check.
 
 ## Secrets
 
-Secrets are configured via secrets resources.
-A secret resource definition refers to the secrets provider (`Env` or `VaultProvider`) and an ID (the named secret to fetch from the secrets provider).
+Secrets are configured with Sensu's `Secret` resources.
+A secret resource definition refers to the secrets provider and an ID (the named secret to fetch from the secrets provider).
 
 The [secrets reference][3] includes the specification, sensuctl configuration subcommands, and examples for secrets resources.
 

--- a/content/sensu-go/6.9/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.9/operations/manage-secrets/secrets-management.md
@@ -54,7 +54,7 @@ Make a note of your Integration Key &mdash; you'll need it to create your [backe
 
 ## Use Env for secrets management
 
-The [Sensu Go commercial distribution][1] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
+The [Sensu Go commercial distribution][41] includes a secrets provider, `Env`, that exposes secrets from [environment variables][21] on your Sensu backend nodes.
 The `Env` secrets provider is automatically created with an empty `spec` when you start your Sensu backend.
 
 ### Create your backend environment variable
@@ -538,7 +538,7 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [15]: ../../deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication
 [17]: ../../../operations/manage-secrets/secrets-providers#tls-vault
 [19]: #add-a-handler
-[21]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[21]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [22]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
 [23]: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
 [24]: ../../../observability-pipeline/observe-schedule/checks/#pipelines-attribute
@@ -552,3 +552,4 @@ Read the [secrets][9] or [secrets providers][2] reference for in-depth secrets m
 [34]: ../../../observability-pipeline/observe-filter/filters/#built-in-filter-is_incident
 [35]: ../../../observability-pipeline/observe-process/pipelines/#workflows
 [36]: ../../../observability-pipeline/observe-process/send-pagerduty-alerts/#assign-the-pipeline-to-a-check
+[41]: ../../../commercial/

--- a/content/sensu-go/6.9/operations/manage-secrets/secrets-providers.md
+++ b/content/sensu-go/6.9/operations/manage-secrets/secrets-providers.md
@@ -21,7 +21,7 @@ Sensu's secrets management eliminates the need to expose secrets like usernames,
 With Sensu's secrets management, you can obtain secrets from one or more external secrets providers, refer to external secrets, and consume secrets via [backend environment variables][4].
 
 {{% notice note %}}
-**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-with-secret), [handlers](../../../observability-pipeline/observe-process/handlers/#handler-with-secret), and [mutators](../../../observability-pipeline/observe-transform/mutators/#mutator-with-secret).
+**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-example-that-uses-secrets-management), [handlers](../../../observability-pipeline/observe-process/handlers/#use-secrets-management-in-a-handler), and [mutators](../../../observability-pipeline/observe-transform/mutators/#use-secrets-management-in-a-mutator).
 {{% /notice %}}
 
 Only Sensu backends have access to request [secrets][9] from a secrets provider.
@@ -335,7 +335,7 @@ address: https://vaultserver.example.com:8200
 
 max_retries  | 
 -------------|------ 
-description  | Number of times to retry connecting to the vault provider.
+description  | Number of times to retry connecting to the Vault provider.
 required     | true
 type         | Integer
 default      | 2
@@ -392,7 +392,7 @@ timeout: 20s
 
 tls          | 
 -------------|------ 
-description  | TLS object. Vault only works with TLS configured. You may need to set up a CA cert if it is not already stored in your operating system's trust store. To do this, set the TLS object and provide the `ca_cert` path. You may also need to set up `client_cert`, `client_key`, or [`cname`][15].
+description  | TLS object. Vault only works with TLS configured. You may need to set up a Certificate Authority (CA) certificate if it is not already stored in your operating system's trust store. To do this, set the TLS object and provide the `ca_cert` path. You may also need to set up `client_cert`, `client_key`, or [`cname`][15].
 required     | false
 type         | Map of key-value pairs
 example      | {{< language-toggle >}}
@@ -486,7 +486,7 @@ limit: 10.0
 [1]: ../../../commercial/
 [2]: ../../../api/enterprise/secrets/
 [3]: ../../../sensuctl/
-[4]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[4]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [5]: https://www.vaultproject.io/docs/what-is-vault/
 [6]: ../../control-access/rbac#default-users
 [7]: ../../../sensuctl/create-manage-resources/#create-resources

--- a/content/sensu-go/6.9/operations/manage-secrets/secrets.md
+++ b/content/sensu-go/6.9/operations/manage-secrets/secrets.md
@@ -21,7 +21,7 @@ Sensu's secrets management eliminates the need to expose secrets in your Sensu c
 When a Sensu resource definition requires a secret (for example, a username or password), Sensu allows you to obtain secrets from one or more external secrets providers, so you can both refer to external secrets and consume secrets via [backend environment variables][5].
 
 {{% notice note %}}
-**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-with-secret), [handlers](../../../observability-pipeline/observe-process/handlers/#handler-with-secret), and [mutators](../../../observability-pipeline/observe-transform/mutators/#mutator-with-secret).
+**NOTE**: Secrets management is implemented for [checks](../../../observability-pipeline/observe-schedule/checks/#check-example-that-uses-secrets-management), [handlers](../../../observability-pipeline/observe-process/handlers/#use-secrets-management-in-a-handler), and [mutators](../../../observability-pipeline/observe-transform/mutators/#use-secrets-management-in-a-mutator).
 {{% /notice %}}
 
 Only Sensu backends have access to request secrets from a [secrets provider][7].
@@ -267,7 +267,7 @@ namespace: default
 
 id           | 
 -------------|------ 
-description  | Identifying key for the provider to retrieve the secret. For the `Env` secrets provider, the `id` is the environment variable. For the `Vault` secrets provider, the `id` specifies the secrets engine path, the path to the secret within that secrets engine, and the field to retrieve within the secret.
+description  | Identifying key for the provider to use to retrieve the secret. For the `Env` secrets provider, the `id` is the environment variable. For the `VaultProvider` secrets provider, the `id` specifies the secrets engine path, the path to the secret within that secrets engine, and the field to retrieve within the secret.
 required     | true
 type         | String
 example for Vault KV Secrets Engine v1 | {{< language-toggle >}}
@@ -311,7 +311,7 @@ provider: vault
 [2]: ../../../api/enterprise/secrets/
 [3]: ../../../sensuctl/
 [4]: ../../../sensuctl/create-manage-resources/#subcommands
-[5]: ../../../observability-pipeline/observe-schedule/backend/#configuration-via-environment-variables
+[5]: ../../../observability-pipeline/observe-schedule/backend/#environment-variables
 [6]: ../../control-access/rbac#default-users
 [7]: ../secrets-providers/
 [8]: #spec-attributes


### PR DESCRIPTION
## Description
Fixes links and some awkward and potentially confusing wording throughout secrets-related docs

## Motivation and Context
Found when working on CyberArk docs for 6.9
