### PR TITLE
Replace RHEL/CentOS and Ubuntu/Debian labels

### DIFF
--- a/content/sensu-go/6.5/get-started.md
+++ b/content/sensu-go/6.5/get-started.md
@@ -15,7 +15,7 @@ You can [install the commercial distribution][15] or [build Sensu from source][1
 
 ## Install the commercial distribution of Sensu Go
 
-Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windows.
+Sensu's [supported platforms][20] include Debian- and RHEL-family distributions and Windows.
 
 - [**Install Sensu Go**][2] with a commercial package and get started for free
 - Learn about Sensu's [commercial features][3] &mdash; all commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -162,11 +162,11 @@ If you have already created this file on your system, skip to step 2.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-backend
 {{< /code >}}
      
@@ -177,11 +177,11 @@ Run:
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SUMOLOGIC_URL=<SumoLogic_HTTPSourceAddress_URL>' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SUMOLOGIC_URL=<SumoLogic_HTTPSourceAddress_URL>' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-process/send-slack-alerts.md
@@ -19,7 +19,7 @@ You can use pipelines to send email alerts, create or resolve incidents (in Page
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a pipeline and adding it to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][2] to add the check.
 
-Before you start, follow the RHEL/CentOS [install instructions][17] to install and configure the Sensu backend, the Sensu agent, and sensuctl.
+Before you start, follow the RHEL family [install instructions][17] to install and configure the Sensu backend, the Sensu agent, and sensuctl.
 
 ## Configure a Sensu entity
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/_index.md
@@ -31,7 +31,7 @@ Agent entities are responsible for creating [status and metrics events][6] to se
 The Sensu backend includes an integrated structure for scheduling checks using subscriptions and an event pipeline that applies [event filters][15], [mutators][16], and [handlers][17], an embedded [etcd][10] datastore for storing configuration and state, and the Sensu [API][4], Sensu [web UI][5], and [sensuctl][19] command line tool.
 
 The Sensu agent is available for Linux, macOS, and Windows.
-The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
+The Sensu backend is available for Debian- and RHEL-family distributions of Linux.
 Learn more in the [agent][11] and [backend][2] references.
 
 Follow the [installation guide][1] to install the agent and backend.

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/agent.md
@@ -815,7 +815,7 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
-default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+default       | `ws://127.0.0.1:8081`(Debian and RHEL families)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_URL`
@@ -1551,11 +1551,11 @@ Here's how.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1584,11 +1584,11 @@ All environment variables that control Sensu agent configuration begin with `SEN
      
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1605,11 +1605,11 @@ SENSU_API_HOST="0.0.0.0"
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo systemctl restart sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo systemctl restart sensu-agent
 {{< /code >}}
 
@@ -1632,11 +1632,11 @@ For example, to create the labels `"region": "us-east-1"` and `"type": "website"
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1646,11 +1646,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1658,7 +1658,7 @@ echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.
 
 ### Use environment variables with the Sensu agent
 
-Any environment variables you create in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS) will be available to check and hook commands executed by the Sensu agent.
+Any environment variables you create in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family) will be available to check and hook commands executed by the Sensu agent.
 This includes your checks and plugins.
 
 For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-agent file, it will be available to use in your check and hook configurations as `$TEST_VARIABLE`.
@@ -1735,7 +1735,7 @@ Depending on your environment and preferences, you may want to create overrides 
 You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-agent start`.
-- Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+- Environment variables in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family).
 - Configuration settings in the agent.yml config file.
 
 {{% notice note %}}
@@ -1746,7 +1746,7 @@ Future package upgrades can overwrite changes in the systemd unit file.
 Sensu applies the following precedence to override settings:
 
 1. Arguments passed to the Sensu agent via command line configuration flags.
-2. Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+2. Environment variables in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family).
 3. Configuration in the agent.yml config file.
 
 For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-agent` or `/etc/sysconfig/sensu-agent` or the agent.yml config file.
@@ -1766,11 +1766,11 @@ To configure an environment variable for the desired agent log level:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 

--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/backend.md
@@ -18,7 +18,7 @@ menu:
 The Sensu backend is a service that manages check requests and observability data.
 Every Sensu backend includes an integrated structure for scheduling checks using [subscriptions][28], an event processing pipeline that applies [event filters][9], [mutators][10], [handlers][11], and [pipelines][70], an embedded [etcd][2] datastore for storing configuration and state, and the Sensu [API][14], Sensu [web UI][6], and [sensuctl][37] command line tool.
 
-The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
+The Sensu backend is available for Debian- and RHEL-family distributions of Linux.
 For these operating systems, the Sensu backend uses the Bourne shell (sh) for the execution environment.
 
 Read the [installation guide][1] to install the backend.
@@ -29,8 +29,8 @@ For a **new** installation, the backend database must be initialized by providin
 Although initialization is required for every new installation, the implementation differs depending on your method of installation:
 
 - If you are using Docker, you can use environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`) during [step 2 of the backend installation process][24].
-- If you are using Ubuntu/Debian or RHEL/CentOS, you must specify admin credentials during [step 3 of the backend installation process][25].
-Sensu does not apply default admin credentials for Ubuntu/Debian or RHEL/CentoOS installations.
+- If you are using a Debian- or RHEL-family distribution, you must specify admin credentials during [step 3 of the backend installation process][25].
+Sensu does not apply default admin credentials for Debian- or RHEL-family installations.
 
 The initialization step bootstraps the first admin user account for your Sensu installation.
 This first account will be granted the cluster admin role.
@@ -82,9 +82,9 @@ volumes:
 
 If you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process][24], we recommend [changing your default admin password][26] as soon as you have installed sensuctl.
 
-### Ubuntu/Debian or RHEL/CentOS initialization
+### Debian or RHEL family initialization
 
-For Ubuntu/Debian or RHEL/CentOS, set administrator credentials with environment variables at [initialization][25] as shown below.
+For Debian- or RHEL-family distributions, set administrator credentials with environment variables at [initialization][25] as shown below.
 
 To initialize with your username and password, replace `<username>` and `<password>` with the username and password you want to use:
 
@@ -145,7 +145,7 @@ volumes:
     driver: local
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian and RHEL/CentOS" >}}
+{{< code shell "Debian and RHEL families" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 export SENSU_BACKEND_CLUSTER_ADMIN_API_KEY=<api_key>
@@ -455,7 +455,7 @@ api-request-limit: 1024000{{< /code >}}
 -------------|------
 description  | URL used to connect to the API.
 type         | String
-default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+default      | `http://localhost:8080` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_API_URL`
@@ -890,7 +890,7 @@ description   | List of this member's client URLs to advertise to the rest of th
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
-default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
+default       | `http://localhost:2379` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
@@ -1023,7 +1023,7 @@ description                        | List of this member's peer URLs to advertis
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
-default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+default                            | `http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
@@ -1044,7 +1044,7 @@ description            | Initial cluster configuration for bootstrapping.{{% not
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
-default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+default                | `default=http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
@@ -1103,7 +1103,7 @@ description               | List of URLs to listen on for client traffic. Sensu'
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                      | List
-default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
+default                   | `http://127.0.0.1:2379` (Debian and RHEL families)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
@@ -1122,7 +1122,7 @@ description             | List of URLs to listen on for peer traffic. Sensu's de
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
-default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
+default                 | `http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
@@ -1429,11 +1429,11 @@ Here's how.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-backend
 {{< /code >}}
      
@@ -1453,11 +1453,11 @@ sudo touch /etc/sysconfig/sensu-backend
      
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1467,11 +1467,11 @@ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/s
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo systemctl restart sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo systemctl restart sensu-backend
 {{< /code >}}
 
@@ -1490,11 +1490,11 @@ For example, to create the labels `"region": "us-east-1"` and `"type": "website"
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1504,11 +1504,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1516,7 +1516,7 @@ echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hook
 
 ### Use environment variables with the Sensu backend
 
-Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
+Any environment variables you create in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family) will be available to handlers executed by the Sensu backend.
 
 For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-backend file, it will be available to use in your handler configurations as `$TEST_VARIABLE`.
 The following handler will print the `TEST_VARIABLE` value set in your sensu-backend file in `/tmp/test.txt`:
@@ -1565,7 +1565,7 @@ Depending on your environment and preferences, you may want to create overrides 
 You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-backend start`.
-- Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+- Environment variables in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family).
 - Configuration settings in the backend.yml config file.
 
 {{% notice note %}}
@@ -1576,7 +1576,7 @@ Future package upgrades can overwrite changes in the systemd unit file.
 Sensu applies the following precedence to override settings:
 
 1. Arguments passed to the Sensu backend via command line configuration flags.
-2. Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+2. Environment variables in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family).
 3. Configuration in the backend.yml config file.
 
 For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` or the backend.yml config file.
@@ -1595,11 +1595,11 @@ To configure an environment variable for the desired backend log level:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/generate-certificates.md
@@ -300,7 +300,7 @@ We recommend installing the CA root certificate in the trust store of both your 
 Installing the CA certificate in the trust store for these systems makes it easier to connect via web UI or sensuctl without being prompted to accept certificates signed by your self-generated CA.
 
 {{< language-toggle >}}
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 chmod 644 /etc/sensu/tls/ca.pem
 chown root /etc/sensu/tls/ca.pem
 sudo apt-get install ca-certificates -y
@@ -308,7 +308,7 @@ sudo ln -sfv /etc/sensu/tls/ca.pem /usr/local/share/ca-certificates/sensu-ca.crt
 sudo update-ca-certificates
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 chmod 644 /etc/sensu/tls/ca.pem
 chown root /etc/sensu/tls/ca.pem
 sudo yum install -y ca-certificates

--- a/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/install-sensu.md
@@ -82,7 +82,7 @@ The agent TCP and UDP sockets are deprecated in favor of the [agent API][27].
 
 ## Install the Sensu backend
 
-The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and Docker.
+The Sensu backend is available for Debian- and RHEL-family distributions and Docker.
 Review [supported platforms][5] for more information.
 
 ### 1. Download
@@ -99,7 +99,7 @@ docker pull sensu/sensu
 docker pull sensu/sensu-rhel
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -107,7 +107,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -166,7 +166,7 @@ volumes:
 
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
@@ -177,7 +177,7 @@ sudo systemctl start sensu-backend
 sudo systemctl status sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
@@ -211,13 +211,13 @@ Replace `<username>` and `<password>` with the username and password you want to
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 sensu-backend init
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 sensu-backend init
@@ -271,7 +271,7 @@ To install sensuctl:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -279,7 +279,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-cli
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -341,7 +341,7 @@ sensuctl user change-password --interactive
 
 ## Install Sensu agents
 
-The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
+The Sensu agent is available for Debian- and RHEL-family distributions, Windows, and Docker.
 Review [supported platforms][5] for more information.
 
 ### 1. Download {#agent-download}
@@ -358,7 +358,7 @@ docker pull sensu/sensu
 docker pull sensu/sensu-rhel
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -366,7 +366,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -429,7 +429,7 @@ volumes:
     driver: local
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
@@ -437,7 +437,7 @@ sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu
 sudo systemctl start sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/scale-event-storage.md
@@ -38,7 +38,7 @@ The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connect
 
 {{% notice warning %}}
 **IMPORTANT**: PostgreSQL configuration file locations differ depending on platform.
-The steps in this guide use common paths for RHEL/CentOS, but the files may be stored elsewhere on your system.
+The steps in this guide use common paths for RHEL-family distributions, but the files may be stored elsewhere on your system.
 Learn more about [PostgreSQL configuration file locations](https://www.postgresql.org/docs/current/runtime-config-file-locations.html).
 {{% /notice %}}
 

--- a/content/sensu-go/6.5/operations/deploy-sensu/secure-postgres.md
+++ b/content/sensu-go/6.5/operations/deploy-sensu/secure-postgres.md
@@ -40,14 +40,14 @@ If not, run the following commands:
 
 {{< language-toggle >}}
 
-{{< code "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo curl -s -L -o /bin/cfssl https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl_1.6.2_linux_amd64
 sudo curl -s -L -o /bin/cfssljson https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssljson_1.6.2_linux_amd64
 sudo curl -s -L -o /bin/cfssl-certinfo https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl-certinfo_1.6.2_linux_amd64
 sudo chmod +x /bin/cfssl*
 {{< /code >}}
 
-{{< code "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 
 # Update apt repos
 sudo apt-get update
@@ -187,7 +187,7 @@ Working from your Sensu backend, follow these steps to configure Sensu to use ce
 
    {{< language-toggle >}}
 
-  {{< code "RHEL/CentOS" >}}
+  {{< code shell "RHEL family" >}}
 echo 'PGUSER=sensu
 PGSSLMODE="verify-full"
 PGSSLCERT="/etc/sensu/tls/sensu.pem"
@@ -195,7 +195,7 @@ PGSSLKEY="/etc/sensu/tls/sensu-key.pem"
 PGSSLROOTCERT="/etc/sensu/tls/ca.pem"' | sudo tee /etc/sysconfig/sensu-backend
 {{< /code >}}
 
-  {{< code "Ubuntu/Debian" >}}
+  {{< code shell "Debian family" >}}
 echo 'PGUSER=sensu
 PGSSLMODE="verify-full"
 PGSSLCERT="/etc/sensu/tls/sensu.pem"
@@ -281,7 +281,7 @@ scp ca.pem postgres.example.com:/home/user
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/CentOS">}}
+   {{< code shell "RHEL family" >}}
 sudo mkdir /var/lib/pgsql/14/data/tls
 cd /var/lib/pgsql/14/data/tls
 cp /home/user/postgres.example.com* /var/lib/pgsql/14/data/tls/
@@ -289,7 +289,7 @@ cp /home/user/ca.pem /var/lib/pgsql/14/data/tls/
 chown -R postgres:postgres /var/lib/pgsql/14/data
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian">}}
+   {{< code shell "Debian family" >}}
 sudo mkdir /etc/postgresql/14/main/tls
 cd /etc/postgresql/14/main/tls
 cp /home/user/postgres.example.com* /etc/postgresql/14/main/tls/
@@ -303,7 +303,7 @@ chown -R postgres:postgres /etc/postgresql/14/main/
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/CentOS">}}
+   {{< code shell "RHEL family" >}}
 # vim /var/lib/pgsql/14/data/postgresql.conf
 
 # - SSL -
@@ -314,7 +314,7 @@ ssl_cert_file = '/var/lib/pgsql/14/data/tls/postgres.example.com.pem'
 ssl_key_file = '/var/lib/pgsql/14/data/tls/postgres.example.com-key.pem'
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 # vim /etc/postgresql/14/main/postgresql.conf
 
 # - SSL -
@@ -333,7 +333,7 @@ ssl_key_file = '/etc/postgresql/14/main/tls/postgres.example.com-key.pem'
 
    {{< language-toggle >}}
 
-   {{< code shell  "RHEL/CentOS" >}}
+   {{< code shell "RHEL family" >}}
 
 # /var/lib/pgsql/14/data/pg_hba.conf (file location)
 
@@ -345,7 +345,7 @@ hostssl all             postgres        0.0.0.0/0               reject
 hostssl sensu_events    sensu           0.0.0.0/0               cert
 {{< /code >}}
 
-   {{< code shell  "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 
 # /etc/postgresql/14/main/pg_hba.conf (file location)
 
@@ -367,11 +367,11 @@ hostssl sensu_events    sensu           0.0.0.0/0               cert
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/Centos" >}}
+   {{< code shell "RHEL family" >}}
 sudo systemctl restart postgresql-14.service
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 sudo systemctl restart postgresql.service
 {{< /code >}}
 

--- a/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/migrate.md
@@ -21,7 +21,7 @@ The step for [translating integrations, contact routing, and LDAP authentication
 Sensu Go includes important changes to all parts of Sensu: architecture, installation, resource definitions, the observation data (event) model, check dependencies, filter evaluation, and more.
 Sensu Go also includes many powerful [commercial features][27] to make monitoring easier to build, scale, and offer as a self-service tool to your internal customers.
 
-Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
+Sensu Go is available for [Debian- and RHEL-family distributions and Docker][43].
 The Sensu Go agent is also available for Windows.
 
 {{% notice warning %}}
@@ -199,7 +199,7 @@ Read the [API overview][17] for more information.
 
 #### 1. Install the Sensu Go backend 
 
-The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and Docker.
+The Sensu backend is available for Debian- and RHEL-family distributions and Docker.
 Read the [installation guide][52] to install, configure, and start the Sensu backend according to your [deployment strategy][38].
 
 #### 2. Log in to the Sensu web UI
@@ -230,7 +230,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 
 #### 5. Install agents
 
-The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
+The Sensu agent is available for Debian- and RHEL-family distributions, Windows, and Docker.
 Read the [installation guide][55] to install, configure, and start Sensu agents.
 
 If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml` or `C:\ProgramData\sensu\config\agent.yml.example`).

--- a/content/sensu-go/6.5/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.5/operations/maintain-sensu/troubleshoot.md
@@ -32,7 +32,7 @@ Replace the `<service>` variable with the name of the desired service (for examp
 
 {{< language-toggle >}}
 
-{{< code shell "RHEL/CentOS >= 7" >}}
+{{< code shell "RHEL/family >= 7" >}}
 journalctl --follow --unit sensu-<service>
 {{< /code >}}
 
@@ -51,7 +51,7 @@ Replace the `<service>` variable with the name of the desired service (for examp
 
 {{< language-toggle >}}
 
-{{< code shell "RHEL/CentOS <= 6" >}}
+{{< code shell "RHEL/family <= 6" >}}
 tail --follow /var/log/sensu/sensu-<service>
 {{< /code >}}
 

--- a/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.5/operations/manage-secrets/secrets-management.md
@@ -65,11 +65,11 @@ Then, run the following code, replacing `INTEGRATION_KEY` with your PagerDuty In
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_PAGERDUTY_KEY=INTEGRATION_KEY' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_PAGERDUTY_KEY=INTEGRATION_KEY' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.5/platforms.md
+++ b/content/sensu-go/6.5/platforms.md
@@ -25,13 +25,13 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensu backend
 
-|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
+|  | RHEL family<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
 |----------------------|---------|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} |
 
 ### Sensu agent
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL<br>family<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -41,7 +41,7 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensuctl command line tool
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL<br>family<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |

--- a/content/sensu-go/6.5/plugins/install-plugins.md
+++ b/content/sensu-go/6.5/plugins/install-plugins.md
@@ -106,11 +106,11 @@ To download and update package information:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo apt-get update
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo yum update
 {{< /code >}}
 
@@ -120,11 +120,11 @@ Depending on the plugin, you may need to install developer tool packages:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo apt-get install build-essential
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo yum groupinstall "Development Tools"
 {{< /code >}}
 

--- a/content/sensu-go/6.5/release-notes.md
+++ b/content/sensu-go/6.5/release-notes.md
@@ -1109,7 +1109,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.16.0.
 
 **IMPORTANT:**
 
-- For Ubuntu/Debian and RHEL/CentOS installations, the backend is no longer seeded with a default admin username and password.
+- For Debian- and RHEL-family installations, the backend is no longer seeded with a default admin username and password.
 Users will need to [run 'sensu-backend init'][102] on every new installation and specify an admin username and password.
 
 **NEW FEATURES:**
@@ -1189,14 +1189,14 @@ Read the [blog announcement][91] for more information about our usage policy.
 ## 5.14.2 release notes
 
 **November 4, 2019** &mdash; The latest release of Sensu Go, version 5.14.2, is now available for download.
-This release includes an etcd upgrade, fixes that improve stability and performance, and a Sensu Go package for CentOS 8.
+This release includes an etcd upgrade, fixes that improve stability and performance, and a Sensu Go package for RHEL 8.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 5.14.2.
 
 **IMPROVEMENTS:**
 
 - Upgraded etcd to 3.3.17.
-- Added build package for CentOS 8 (`el/8`).
+- Added build package for RHEL 8 (`el/8`).
 - Sensu Go now uses serializable event reads, which helps improve performance.
 
 **FIXES:**
@@ -1429,8 +1429,8 @@ For a complete list of supported platforms, visit the [platforms page][73].
 - Multiple nested set handlers are now flagged correctly, fixing an issue in which they were flagged as deeply nested.
 - Round robin proxy checks now execute as expected in the event of updated entities.
 - The Sensu backend now avoids situations of high CPU usage in the event that watchers enter a tight loop.
-- Due to incompatibility with the Go programming language, Sensu is incompatible with CentOS/RHEL 5.
-As a result, CentOS/RHEL 5 has been removed as a [supported platform][73] for all versions of Sensu Go.
+- Due to incompatibility with the Go programming language, Sensu is incompatible with RHEL 5.
+As a result, RHEL 5 has been removed as a [supported platform][73] for all versions of Sensu Go.
 
 ## 5.10.2 release notes
 

--- a/content/sensu-go/6.6/get-started.md
+++ b/content/sensu-go/6.6/get-started.md
@@ -15,7 +15,7 @@ You can [install the commercial distribution][15] or [build Sensu from source][1
 
 ## Install the commercial distribution of Sensu Go
 
-Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windows.
+Sensu's [supported platforms][20] include Debian- and RHEL-family distributions and Windows.
 
 - [**Install Sensu Go**][2] with a commercial package and get started for free
 - Learn about Sensu's [commercial features][3] &mdash; all commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -162,11 +162,11 @@ If you have already created this file on your system, skip to step 2.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-backend
 {{< /code >}}
      
@@ -177,11 +177,11 @@ Run:
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SUMOLOGIC_URL=<SumoLogic_HTTPSourceAddress_URL>' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SUMOLOGIC_URL=<SumoLogic_HTTPSourceAddress_URL>' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
@@ -19,7 +19,7 @@ You can use pipelines to send email alerts, create or resolve incidents (in Page
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a pipeline and adding it to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][2] to add the check.
 
-Before you start, follow the RHEL/CentOS [install instructions][17] to install and configure the Sensu backend, the Sensu agent, and sensuctl.
+Before you start, follow the RHEL family [install instructions][17] to install and configure the Sensu backend, the Sensu agent, and sensuctl.
 
 ## Configure a Sensu entity
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/_index.md
@@ -31,7 +31,7 @@ Agent entities are responsible for creating [status and metrics events][6] to se
 The Sensu backend includes an integrated structure for scheduling checks using subscriptions and an event pipeline that applies [event filters][15], [mutators][16], and [handlers][17], an embedded [etcd][10] datastore for storing configuration and state, and the Sensu [API][4], Sensu [web UI][5], and [sensuctl][19] command line tool.
 
 The Sensu agent is available for Linux, macOS, and Windows.
-The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
+The Sensu backend is available for Debian- and RHEL-family distributions of Linux.
 Learn more in the [agent][11] and [backend][2] references.
 
 Follow the [installation guide][1] to install the agent and backend.

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/agent.md
@@ -814,7 +814,7 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
-default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+default       | `ws://127.0.0.1:8081`(Debian and RHEL families)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_URL`
@@ -1550,11 +1550,11 @@ Here's how.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1583,11 +1583,11 @@ All environment variables that control Sensu agent configuration begin with `SEN
      
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1604,11 +1604,11 @@ SENSU_API_HOST="0.0.0.0"
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo systemctl restart sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo systemctl restart sensu-agent
 {{< /code >}}
 
@@ -1631,11 +1631,11 @@ For example, to create the labels `"region": "us-east-1"` and `"type": "website"
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1645,11 +1645,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1657,7 +1657,7 @@ echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.
 
 ### Use environment variables with the Sensu agent
 
-Any environment variables you create in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS) will be available to check and hook commands executed by the Sensu agent.
+Any environment variables you create in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family) will be available to check and hook commands executed by the Sensu agent.
 This includes your checks and plugins.
 
 For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-agent file, it will be available to use in your check and hook configurations as `$TEST_VARIABLE`.
@@ -1734,7 +1734,7 @@ Depending on your environment and preferences, you may want to create overrides 
 You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-agent start`.
-- Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+- Environment variables in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family).
 - Configuration settings in the agent.yml config file.
 
 {{% notice note %}}
@@ -1745,7 +1745,7 @@ Future package upgrades can overwrite changes in the systemd unit file.
 Sensu applies the following precedence to override settings:
 
 1. Arguments passed to the Sensu agent via command line configuration flags.
-2. Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+2. Environment variables in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family).
 3. Configuration in the agent.yml config file.
 
 For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-agent` or `/etc/sysconfig/sensu-agent` or the agent.yml config file.
@@ -1765,11 +1765,11 @@ To configure an environment variable for the desired agent log level:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/backend.md
@@ -18,7 +18,7 @@ menu:
 The Sensu backend is a service that manages check requests and observability data.
 Every Sensu backend includes an integrated structure for scheduling checks using [subscriptions][28], an event processing pipeline that applies [event filters][9], [mutators][10], [handlers][11], and [pipelines][70], an embedded [etcd][2] datastore for storing configuration and state, and the Sensu [API][14], Sensu [web UI][6], and [sensuctl][37] command line tool.
 
-The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
+The Sensu backend is available for Debian- and RHEL-family distributions of Linux.
 For these operating systems, the Sensu backend uses the Bourne shell (sh) for the execution environment.
 
 Read the [installation guide][1] to install the backend.
@@ -29,8 +29,8 @@ For a **new** installation, the backend database must be initialized by providin
 Although initialization is required for every new installation, the implementation differs depending on your method of installation:
 
 - If you are using Docker, you can use environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`) during [step 2 of the backend installation process][24].
-- If you are using Ubuntu/Debian or RHEL/CentOS, you must specify admin credentials during [step 3 of the backend installation process][25].
-Sensu does not apply default admin credentials for Ubuntu/Debian or RHEL/CentoOS installations.
+- If you are using a Debian- or RHEL-family distribution, you must specify admin credentials during [step 3 of the backend installation process][25].
+Sensu does not apply default admin credentials for Debian- or RHEL-family installations.
 
 The initialization step bootstraps the first admin user account for your Sensu installation.
 This first account will be granted the cluster admin role.
@@ -82,9 +82,9 @@ volumes:
 
 If you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process][24], we recommend [changing your default admin password][26] as soon as you have installed sensuctl.
 
-### Ubuntu/Debian or RHEL/CentOS initialization
+### Debian or RHEL family initialization
 
-For Ubuntu/Debian or RHEL/CentOS, set administrator credentials with environment variables at [initialization][25] as shown below.
+For Debian- or RHEL-family distributions, set administrator credentials with environment variables at [initialization][25] as shown below.
 
 To initialize with your username and password, replace `<username>` and `<password>` with the username and password you want to use:
 
@@ -145,7 +145,7 @@ volumes:
     driver: local
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian and RHEL/CentOS" >}}
+{{< code shell "Debian and RHEL families" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 export SENSU_BACKEND_CLUSTER_ADMIN_API_KEY=<api_key>
@@ -456,7 +456,7 @@ api-request-limit: 1024000{{< /code >}}
 -------------|------
 description  | URL used to connect to the API.
 type         | String
-default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+default      | `http://localhost:8080` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_API_URL`
@@ -886,7 +886,7 @@ description   | List of this member's client URLs to advertise to the rest of th
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
-default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
+default       | `http://localhost:2379` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
@@ -1034,7 +1034,7 @@ description                        | List of this member's peer URLs to advertis
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
-default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+default                            | `http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
@@ -1055,7 +1055,7 @@ description            | Initial cluster configuration for bootstrapping.{{% not
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
-default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+default                | `default=http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
@@ -1114,7 +1114,7 @@ description               | List of URLs to listen on for client traffic. Sensu'
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                      | List
-default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
+default                   | `http://127.0.0.1:2379` (Debian and RHEL families)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
@@ -1133,7 +1133,7 @@ description             | List of URLs to listen on for peer traffic. Sensu's de
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
-default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
+default                 | `http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
@@ -1440,11 +1440,11 @@ Here's how.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-backend
 {{< /code >}}
      
@@ -1464,11 +1464,11 @@ sudo touch /etc/sysconfig/sensu-backend
      
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1478,11 +1478,11 @@ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/s
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo systemctl restart sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo systemctl restart sensu-backend
 {{< /code >}}
 
@@ -1501,11 +1501,11 @@ For example, to create the labels `"region": "us-east-1"` and `"type": "website"
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1515,11 +1515,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1527,7 +1527,7 @@ echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hook
 
 ### Use environment variables with the Sensu backend
 
-Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
+Any environment variables you create in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family) will be available to handlers executed by the Sensu backend.
 
 For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-backend file, it will be available to use in your handler configurations as `$TEST_VARIABLE`.
 The following handler will print the `TEST_VARIABLE` value set in your sensu-backend file in `/tmp/test.txt`:
@@ -1576,7 +1576,7 @@ Depending on your environment and preferences, you may want to create overrides 
 You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-backend start`.
-- Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+- Environment variables in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family).
 - Configuration settings in the backend.yml config file.
 
 {{% notice note %}}
@@ -1587,7 +1587,7 @@ Future package upgrades can overwrite changes in the systemd unit file.
 Sensu applies the following precedence to override settings:
 
 1. Arguments passed to the Sensu backend via command line configuration flags.
-2. Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+2. Environment variables in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family).
 3. Configuration in the backend.yml config file.
 
 For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` or the backend.yml config file.
@@ -1606,11 +1606,11 @@ To configure an environment variable for the desired backend log level:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/generate-certificates.md
@@ -300,7 +300,7 @@ We recommend installing the CA root certificate in the trust store of both your 
 Installing the CA certificate in the trust store for these systems makes it easier to connect via web UI or sensuctl without being prompted to accept certificates signed by your self-generated CA.
 
 {{< language-toggle >}}
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 chmod 644 /etc/sensu/tls/ca.pem
 chown root /etc/sensu/tls/ca.pem
 sudo apt-get install ca-certificates -y
@@ -308,7 +308,7 @@ sudo ln -sfv /etc/sensu/tls/ca.pem /usr/local/share/ca-certificates/sensu-ca.crt
 sudo update-ca-certificates
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 chmod 644 /etc/sensu/tls/ca.pem
 chown root /etc/sensu/tls/ca.pem
 sudo yum install -y ca-certificates

--- a/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/install-sensu.md
@@ -82,7 +82,7 @@ The agent TCP and UDP sockets are deprecated in favor of the [agent API][27].
 
 ## Install the Sensu backend
 
-The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and Docker.
+The Sensu backend is available for Debian- and RHEL-family distributions and Docker.
 Review [supported platforms][5] for more information.
 
 ### 1. Download
@@ -99,7 +99,7 @@ docker pull sensu/sensu
 docker pull sensu/sensu-rhel
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -107,7 +107,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -166,7 +166,7 @@ volumes:
 
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
@@ -177,7 +177,7 @@ sudo systemctl start sensu-backend
 sudo systemctl status sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
@@ -211,13 +211,13 @@ Replace `<username>` and `<password>` with the username and password you want to
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 sensu-backend init
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 sensu-backend init
@@ -271,7 +271,7 @@ To install sensuctl:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -279,7 +279,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-cli
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -341,7 +341,7 @@ sensuctl user change-password --interactive
 
 ## Install Sensu agents
 
-The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
+The Sensu agent is available for Debian- and RHEL-family distributions, Windows, and Docker.
 Review [supported platforms][5] for more information.
 
 ### 1. Download {#agent-download}
@@ -358,7 +358,7 @@ docker pull sensu/sensu
 docker pull sensu/sensu-rhel
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -366,7 +366,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -429,7 +429,7 @@ volumes:
     driver: local
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
@@ -437,7 +437,7 @@ sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu
 sudo systemctl start sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/scale-event-storage.md
@@ -38,7 +38,7 @@ The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connect
 
 {{% notice warning %}}
 **IMPORTANT**: PostgreSQL configuration file locations differ depending on platform.
-The steps in this guide use common paths for RHEL/CentOS, but the files may be stored elsewhere on your system.
+The steps in this guide use common paths for RHEL-family distributions, but the files may be stored elsewhere on your system.
 Learn more about [PostgreSQL configuration file locations](https://www.postgresql.org/docs/current/runtime-config-file-locations.html).
 {{% /notice %}}
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/secure-postgres.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/secure-postgres.md
@@ -40,14 +40,14 @@ If not, run the following commands:
 
 {{< language-toggle >}}
 
-{{< code "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo curl -s -L -o /bin/cfssl https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl_1.6.2_linux_amd64
 sudo curl -s -L -o /bin/cfssljson https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssljson_1.6.2_linux_amd64
 sudo curl -s -L -o /bin/cfssl-certinfo https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl-certinfo_1.6.2_linux_amd64
 sudo chmod +x /bin/cfssl*
 {{< /code >}}
 
-{{< code "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 
 # Update apt repos
 sudo apt-get update
@@ -187,7 +187,7 @@ Working from your Sensu backend, follow these steps to configure Sensu to use ce
 
    {{< language-toggle >}}
 
-  {{< code "RHEL/CentOS" >}}
+  {{< code shell "RHEL family" >}}
 echo 'PGUSER=sensu
 PGSSLMODE="verify-full"
 PGSSLCERT="/etc/sensu/tls/sensu.pem"
@@ -195,7 +195,7 @@ PGSSLKEY="/etc/sensu/tls/sensu-key.pem"
 PGSSLROOTCERT="/etc/sensu/tls/ca.pem"' | sudo tee /etc/sysconfig/sensu-backend
 {{< /code >}}
 
-  {{< code "Ubuntu/Debian" >}}
+  {{< code shell "Debian family" >}}
 echo 'PGUSER=sensu
 PGSSLMODE="verify-full"
 PGSSLCERT="/etc/sensu/tls/sensu.pem"
@@ -281,7 +281,7 @@ scp ca.pem postgres.example.com:/home/user
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/CentOS">}}
+   {{< code shell "RHEL family" >}}
 sudo mkdir /var/lib/pgsql/14/data/tls
 cd /var/lib/pgsql/14/data/tls
 cp /home/user/postgres.example.com* /var/lib/pgsql/14/data/tls/
@@ -289,7 +289,7 @@ cp /home/user/ca.pem /var/lib/pgsql/14/data/tls/
 chown -R postgres:postgres /var/lib/pgsql/14/data
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian">}}
+   {{< code shell "Debian family" >}}
 sudo mkdir /etc/postgresql/14/main/tls
 cd /etc/postgresql/14/main/tls
 cp /home/user/postgres.example.com* /etc/postgresql/14/main/tls/
@@ -303,7 +303,7 @@ chown -R postgres:postgres /etc/postgresql/14/main/
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/CentOS">}}
+   {{< code shell "RHEL family" >}}
 # vim /var/lib/pgsql/14/data/postgresql.conf
 
 # - SSL -
@@ -314,7 +314,7 @@ ssl_cert_file = '/var/lib/pgsql/14/data/tls/postgres.example.com.pem'
 ssl_key_file = '/var/lib/pgsql/14/data/tls/postgres.example.com-key.pem'
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 # vim /etc/postgresql/14/main/postgresql.conf
 
 # - SSL -
@@ -333,7 +333,7 @@ ssl_key_file = '/etc/postgresql/14/main/tls/postgres.example.com-key.pem'
 
    {{< language-toggle >}}
 
-   {{< code shell  "RHEL/CentOS" >}}
+   {{< code shell "RHEL family" >}}
 
 # /var/lib/pgsql/14/data/pg_hba.conf (file location)
 
@@ -345,7 +345,7 @@ hostssl all             postgres        0.0.0.0/0               reject
 hostssl sensu_events    sensu           0.0.0.0/0               cert
 {{< /code >}}
 
-   {{< code shell  "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 
 # /etc/postgresql/14/main/pg_hba.conf (file location)
 
@@ -367,11 +367,11 @@ hostssl sensu_events    sensu           0.0.0.0/0               cert
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/Centos" >}}
+   {{< code shell "RHEL family" >}}
 sudo systemctl restart postgresql-14.service
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 sudo systemctl restart postgresql.service
 {{< /code >}}
 

--- a/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/migrate.md
@@ -21,7 +21,7 @@ The step for [translating integrations, contact routing, and LDAP authentication
 Sensu Go includes important changes to all parts of Sensu: architecture, installation, resource definitions, the observation data (event) model, check dependencies, filter evaluation, and more.
 Sensu Go also includes many powerful [commercial features][27] to make monitoring easier to build, scale, and offer as a self-service tool to your internal customers.
 
-Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
+Sensu Go is available for [Debian- and RHEL-family distributions and Docker][43].
 The Sensu Go agent is also available for Windows.
 
 {{% notice warning %}}
@@ -199,7 +199,7 @@ Read the [API overview][17] for more information.
 
 #### 1. Install the Sensu Go backend 
 
-The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and Docker.
+The Sensu backend is available for Debian- and RHEL-family distributions and Docker.
 Read the [installation guide][52] to install, configure, and start the Sensu backend according to your [deployment strategy][38].
 
 #### 2. Log in to the Sensu web UI
@@ -230,7 +230,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 
 #### 5. Install agents
 
-The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
+The Sensu agent is available for Debian- and RHEL-family distributions, Windows, and Docker.
 Read the [installation guide][55] to install, configure, and start Sensu agents.
 
 If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml` or `C:\ProgramData\sensu\config\agent.yml.example`).

--- a/content/sensu-go/6.6/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.6/operations/maintain-sensu/troubleshoot.md
@@ -32,7 +32,7 @@ Replace the `<service>` variable with the name of the desired service (for examp
 
 {{< language-toggle >}}
 
-{{< code shell "RHEL/CentOS >= 7" >}}
+{{< code shell "RHEL/family >= 7" >}}
 journalctl --follow --unit sensu-<service>
 {{< /code >}}
 
@@ -51,7 +51,7 @@ Replace the `<service>` variable with the name of the desired service (for examp
 
 {{< language-toggle >}}
 
-{{< code shell "RHEL/CentOS <= 6" >}}
+{{< code shell "RHEL/family <= 6" >}}
 tail --follow /var/log/sensu/sensu-<service>
 {{< /code >}}
 

--- a/content/sensu-go/6.6/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.6/operations/manage-secrets/secrets-management.md
@@ -67,11 +67,11 @@ Then, run the following code, replacing `INTEGRATION_KEY` with your PagerDuty In
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_PAGERDUTY_KEY=INTEGRATION_KEY' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_PAGERDUTY_KEY=INTEGRATION_KEY' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.6/platforms.md
+++ b/content/sensu-go/6.6/platforms.md
@@ -25,13 +25,13 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensu backend
 
-|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
+|  | RHEL family<br>6, 7, 8 | Debian 8, 9, 10 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
 |----------------------|---------|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} |
 
 ### Sensu agent
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL<br>family<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -41,7 +41,7 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensuctl command line tool
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL<br>family<br>6, 7, 8 | Debian<br>8, 9, 10 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |

--- a/content/sensu-go/6.6/plugins/install-plugins.md
+++ b/content/sensu-go/6.6/plugins/install-plugins.md
@@ -106,11 +106,11 @@ To download and update package information:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo apt-get update
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo yum update
 {{< /code >}}
 
@@ -120,11 +120,11 @@ Depending on the plugin, you may need to install developer tool packages:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo apt-get install build-essential
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo yum groupinstall "Development Tools"
 {{< /code >}}
 

--- a/content/sensu-go/6.6/release-notes.md
+++ b/content/sensu-go/6.6/release-notes.md
@@ -1257,7 +1257,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.16.0.
 
 **IMPORTANT:**
 
-- For Ubuntu/Debian and RHEL/CentOS installations, the backend is no longer seeded with a default admin username and password.
+- For Debian- and RHEL-family installations, the backend is no longer seeded with a default admin username and password.
 Users will need to [run 'sensu-backend init'][102] on every new installation and specify an admin username and password.
 
 **NEW FEATURES:**
@@ -1337,14 +1337,14 @@ Read the [blog announcement][91] for more information about our usage policy.
 ## 5.14.2 release notes
 
 **November 4, 2019** &mdash; The latest release of Sensu Go, version 5.14.2, is now available for download.
-This release includes an etcd upgrade, fixes that improve stability and performance, and a Sensu Go package for CentOS 8.
+This release includes an etcd upgrade, fixes that improve stability and performance, and a Sensu Go package for RHEL 8.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 5.14.2.
 
 **IMPROVEMENTS:**
 
 - Upgraded etcd to 3.3.17.
-- Added build package for CentOS 8 (`el/8`).
+- Added build package for RHEL 8 (`el/8`).
 - Sensu Go now uses serializable event reads, which helps improve performance.
 
 **FIXES:**
@@ -1577,8 +1577,8 @@ For a complete list of supported platforms, visit the [platforms page][73].
 - Multiple nested set handlers are now flagged correctly, fixing an issue in which they were flagged as deeply nested.
 - Round robin proxy checks now execute as expected in the event of updated entities.
 - The Sensu backend now avoids situations of high CPU usage in the event that watchers enter a tight loop.
-- Due to incompatibility with the Go programming language, Sensu is incompatible with CentOS/RHEL 5.
-As a result, CentOS/RHEL 5 has been removed as a [supported platform][73] for all versions of Sensu Go.
+- Due to incompatibility with the Go programming language, Sensu is incompatible with RHEL 5.
+As a result, RHEL 5 has been removed as a [supported platform][73] for all versions of Sensu Go.
 
 ## 5.10.2 release notes
 

--- a/content/sensu-go/6.7/get-started.md
+++ b/content/sensu-go/6.7/get-started.md
@@ -15,7 +15,7 @@ You can [install the commercial distribution][15] or [build Sensu from source][1
 
 ## Install the commercial distribution of Sensu Go
 
-Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windows.
+Sensu's [supported platforms][20] include Debian- and RHEL-family distributions and Windows.
 
 - [**Install Sensu Go**][2] with a commercial package and get started for free
 - Learn about Sensu's [commercial features][3] &mdash; all commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -167,11 +167,11 @@ If you have already created this file on your system, skip to step 2.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-backend
 {{< /code >}}
      
@@ -182,11 +182,11 @@ Run:
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SUMOLOGIC_URL=<SumoLogic_HTTPSourceAddress_URL>' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SUMOLOGIC_URL=<SumoLogic_HTTPSourceAddress_URL>' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
@@ -24,7 +24,7 @@ You can use pipelines to send email alerts, create or resolve incidents (in Page
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a pipeline and adding it to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][2] to add the check.
 
-Before you start, follow the RHEL/CentOS [install instructions][17] to install and configure the Sensu backend, the Sensu agent, and sensuctl.
+Before you start, follow the RHEL family [install instructions][17] to install and configure the Sensu backend, the Sensu agent, and sensuctl.
 
 ## Configure a Sensu entity
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/_index.md
@@ -31,7 +31,7 @@ Agent entities are responsible for creating [status and metrics events][6] to se
 The Sensu backend includes an integrated structure for scheduling checks using subscriptions and an event pipeline that applies [event filters][15], [mutators][16], and [handlers][17], an embedded [etcd][10] datastore for storing configuration and state, and the Sensu [API][4], Sensu [web UI][5], and [sensuctl][19] command line tool.
 
 The Sensu agent is available for Linux, macOS, and Windows.
-The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
+The Sensu backend is available for Debian- and RHEL-family distributions of Linux.
 Learn more in the [agent][11] and [backend][2] references.
 
 Follow the [installation guide][1] to install the agent and backend.

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/agent.md
@@ -844,7 +844,7 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
-default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+default       | `ws://127.0.0.1:8081`(Debian and RHEL families)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_URL`
@@ -1609,11 +1609,11 @@ Here's how.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1642,11 +1642,11 @@ All environment variables that control Sensu agent configuration begin with `SEN
      
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1663,11 +1663,11 @@ SENSU_API_HOST="0.0.0.0"
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo systemctl restart sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo systemctl restart sensu-agent
 {{< /code >}}
 
@@ -1690,11 +1690,11 @@ For example, to create the labels `"region": "us-east-1"` and `"type": "website"
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1704,11 +1704,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1716,7 +1716,7 @@ echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.
 
 ### Use environment variables with the Sensu agent
 
-Any environment variables you create in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS) will be available to check and hook commands executed by the Sensu agent.
+Any environment variables you create in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family) will be available to check and hook commands executed by the Sensu agent.
 This includes your checks and plugins.
 
 For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-agent file, it will be available to use in your check and hook configurations as `$TEST_VARIABLE`.
@@ -1793,7 +1793,7 @@ Depending on your environment and preferences, you may want to create overrides 
 You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-agent start`.
-- Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+- Environment variables in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family).
 - Configuration settings in the agent.yml config file.
 
 {{% notice note %}}
@@ -1804,7 +1804,7 @@ Future package upgrades can overwrite changes in the systemd unit file.
 Sensu applies the following precedence to override settings:
 
 1. Arguments passed to the Sensu agent via command line configuration flags.
-2. Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+2. Environment variables in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family).
 3. Configuration in the agent.yml config file.
 
 For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-agent` or `/etc/sysconfig/sensu-agent` or the agent.yml config file.
@@ -1824,11 +1824,11 @@ To configure an environment variable for the desired agent log level:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/backend.md
@@ -18,7 +18,7 @@ menu:
 The Sensu backend is a service that manages check requests and observability data.
 Every Sensu backend includes an integrated structure for scheduling checks using [subscriptions][28], an event processing pipeline that applies [event filters][9], [mutators][10], [handlers][11], and [pipelines][70], an embedded [etcd][2] datastore for storing configuration and state, and the Sensu [API][14], Sensu [web UI][6], and [sensuctl][37] command line tool.
 
-The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
+The Sensu backend is available for Debian- and RHEL-family distributions of Linux.
 For these operating systems, the Sensu backend uses the Bourne shell (sh) for the execution environment.
 
 Read the [installation guide][1] to install the backend.
@@ -29,8 +29,8 @@ For a **new** installation, the backend database must be initialized by providin
 Although initialization is required for every new installation, the implementation differs depending on your method of installation:
 
 - If you are using Docker, you can use environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`) during [step 2 of the backend installation process][24].
-- If you are using Ubuntu/Debian or RHEL/CentOS, you must specify admin credentials during [step 3 of the backend installation process][25].
-Sensu does not apply default admin credentials for Ubuntu/Debian or RHEL/CentoOS installations.
+- If you are using a Debian- or RHEL-family distribution, you must specify admin credentials during [step 3 of the backend installation process][25].
+Sensu does not apply default admin credentials for Debian- or RHEL-family installations.
 
 The initialization step bootstraps the first admin user account for your Sensu installation.
 This first account will be granted the cluster admin role.
@@ -82,9 +82,9 @@ volumes:
 
 If you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process][24], we recommend [changing your default admin password][26] as soon as you have installed sensuctl.
 
-### Ubuntu/Debian or RHEL/CentOS initialization
+### Debian or RHEL family initialization
 
-For Ubuntu/Debian or RHEL/CentOS, set administrator credentials with environment variables at [initialization][25] as shown below.
+For Debian- or RHEL-family distributions, set administrator credentials with environment variables at [initialization][25] as shown below.
 
 To initialize with your username and password, replace `<username>` and `<password>` with the username and password you want to use:
 
@@ -145,7 +145,7 @@ volumes:
     driver: local
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian and RHEL/CentOS" >}}
+{{< code shell "Debian and RHEL families" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 export SENSU_BACKEND_CLUSTER_ADMIN_API_KEY=<api_key>
@@ -468,7 +468,7 @@ api-request-limit: 1024000{{< /code >}}
 -------------|------
 description  | URL used to connect to the API.
 type         | String
-default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+default      | `http://localhost:8080` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_API_URL`
@@ -898,7 +898,7 @@ description   | List of this member's client URLs to advertise to the rest of th
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
-default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
+default       | `http://localhost:2379` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
@@ -1044,7 +1044,7 @@ description                        | List of this member's peer URLs to advertis
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
-default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+default                            | `http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
@@ -1065,7 +1065,7 @@ description            | Initial cluster configuration for bootstrapping.{{% not
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
-default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+default                | `default=http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
@@ -1124,7 +1124,7 @@ description               | List of URLs to listen on for client traffic. Sensu'
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                      | List
-default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
+default                   | `http://127.0.0.1:2379` (Debian and RHEL families)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
@@ -1143,7 +1143,7 @@ description             | List of URLs to listen on for peer traffic. Sensu's de
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
-default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
+default                 | `http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
@@ -1466,11 +1466,11 @@ Here's how.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-backend
 {{< /code >}}
      
@@ -1490,11 +1490,11 @@ sudo touch /etc/sysconfig/sensu-backend
      
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1504,11 +1504,11 @@ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/s
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo systemctl restart sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo systemctl restart sensu-backend
 {{< /code >}}
 
@@ -1527,11 +1527,11 @@ For example, to create the labels `"region": "us-east-1"` and `"type": "website"
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1541,11 +1541,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1553,7 +1553,7 @@ echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hook
 
 ### Use environment variables with the Sensu backend
 
-Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
+Any environment variables you create in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family) will be available to handlers executed by the Sensu backend.
 
 For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-backend file, it will be available to use in your handler configurations as `$TEST_VARIABLE`.
 The following handler will print the `TEST_VARIABLE` value set in your sensu-backend file in `/tmp/test.txt`:
@@ -1602,7 +1602,7 @@ Depending on your environment and preferences, you may want to create overrides 
 You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-backend start`.
-- Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+- Environment variables in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family).
 - Configuration settings in the backend.yml config file.
 
 {{% notice note %}}
@@ -1613,7 +1613,7 @@ Future package upgrades can overwrite changes in the systemd unit file.
 Sensu applies the following precedence to override settings:
 
 1. Arguments passed to the Sensu backend via command line configuration flags.
-2. Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+2. Environment variables in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family).
 3. Configuration in the backend.yml config file.
 
 For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` or the backend.yml config file.
@@ -1632,11 +1632,11 @@ To configure an environment variable for the desired backend log level:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.7/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/generate-certificates.md
@@ -300,7 +300,7 @@ We recommend installing the CA root certificate in the trust store of both your 
 Installing the CA certificate in the trust store for these systems makes it easier to connect via web UI or sensuctl without being prompted to accept certificates signed by your self-generated CA.
 
 {{< language-toggle >}}
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 chmod 644 /etc/sensu/tls/ca.pem
 chown root /etc/sensu/tls/ca.pem
 sudo apt-get install ca-certificates -y
@@ -308,7 +308,7 @@ sudo ln -sfv /etc/sensu/tls/ca.pem /usr/local/share/ca-certificates/sensu-ca.crt
 sudo update-ca-certificates
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 chmod 644 /etc/sensu/tls/ca.pem
 chown root /etc/sensu/tls/ca.pem
 sudo yum install -y ca-certificates

--- a/content/sensu-go/6.7/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/install-sensu.md
@@ -82,7 +82,7 @@ The agent TCP and UDP sockets are deprecated in favor of the [agent API][27].
 
 ## Install the Sensu backend
 
-The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and Docker.
+The Sensu backend is available for Debian- and RHEL-family distributions and Docker.
 Review [supported platforms][5] for more information.
 
 ### 1. Download
@@ -99,7 +99,7 @@ docker pull sensu/sensu
 docker pull sensu/sensu-rhel
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -107,7 +107,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -166,7 +166,7 @@ volumes:
 
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
@@ -177,7 +177,7 @@ sudo systemctl start sensu-backend
 sudo systemctl status sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
@@ -211,13 +211,13 @@ Replace `<username>` and `<password>` with the username and password you want to
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 sensu-backend init
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 sensu-backend init
@@ -271,7 +271,7 @@ To install sensuctl:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -279,7 +279,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-cli
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -341,7 +341,7 @@ sensuctl user change-password --interactive
 
 ## Install Sensu agents
 
-The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
+The Sensu agent is available for Debian- and RHEL-family distributions, Windows, and Docker.
 Review [supported platforms][5] for more information.
 
 ### 1. Download {#agent-download}
@@ -358,7 +358,7 @@ docker pull sensu/sensu
 docker pull sensu/sensu-rhel
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -366,7 +366,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -429,7 +429,7 @@ volumes:
     driver: local
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
@@ -437,7 +437,7 @@ sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu
 sudo systemctl start sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 

--- a/content/sensu-go/6.7/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/scale-event-storage.md
@@ -38,7 +38,7 @@ The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connect
 
 {{% notice warning %}}
 **IMPORTANT**: PostgreSQL configuration file locations differ depending on platform.
-The steps in this guide use common paths for RHEL/CentOS, but the files may be stored elsewhere on your system.
+The steps in this guide use common paths for RHEL-family distributions, but the files may be stored elsewhere on your system.
 Learn more about [PostgreSQL configuration file locations](https://www.postgresql.org/docs/current/runtime-config-file-locations.html).
 {{% /notice %}}
 

--- a/content/sensu-go/6.7/operations/deploy-sensu/secure-postgres.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/secure-postgres.md
@@ -40,14 +40,14 @@ If not, run the following commands:
 
 {{< language-toggle >}}
 
-{{< code "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo curl -s -L -o /bin/cfssl https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl_1.6.2_linux_amd64
 sudo curl -s -L -o /bin/cfssljson https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssljson_1.6.2_linux_amd64
 sudo curl -s -L -o /bin/cfssl-certinfo https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl-certinfo_1.6.2_linux_amd64
 sudo chmod +x /bin/cfssl*
 {{< /code >}}
 
-{{< code "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 
 # Update apt repos
 sudo apt-get update
@@ -187,7 +187,7 @@ Working from your Sensu backend, follow these steps to configure Sensu to use ce
 
    {{< language-toggle >}}
 
-  {{< code "RHEL/CentOS" >}}
+  {{< code shell "RHEL family" >}}
 echo 'PGUSER=sensu
 PGSSLMODE="verify-full"
 PGSSLCERT="/etc/sensu/tls/sensu.pem"
@@ -195,7 +195,7 @@ PGSSLKEY="/etc/sensu/tls/sensu-key.pem"
 PGSSLROOTCERT="/etc/sensu/tls/ca.pem"' | sudo tee /etc/sysconfig/sensu-backend
 {{< /code >}}
 
-  {{< code "Ubuntu/Debian" >}}
+  {{< code shell "Debian family" >}}
 echo 'PGUSER=sensu
 PGSSLMODE="verify-full"
 PGSSLCERT="/etc/sensu/tls/sensu.pem"
@@ -281,7 +281,7 @@ scp ca.pem postgres.example.com:/home/user
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/CentOS">}}
+   {{< code shell "RHEL family" >}}
 sudo mkdir /var/lib/pgsql/14/data/tls
 cd /var/lib/pgsql/14/data/tls
 cp /home/user/postgres.example.com* /var/lib/pgsql/14/data/tls/
@@ -289,7 +289,7 @@ cp /home/user/ca.pem /var/lib/pgsql/14/data/tls/
 chown -R postgres:postgres /var/lib/pgsql/14/data
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian">}}
+   {{< code shell "Debian family" >}}
 sudo mkdir /etc/postgresql/14/main/tls
 cd /etc/postgresql/14/main/tls
 cp /home/user/postgres.example.com* /etc/postgresql/14/main/tls/
@@ -303,7 +303,7 @@ chown -R postgres:postgres /etc/postgresql/14/main/
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/CentOS">}}
+   {{< code shell "RHEL family" >}}
 # vim /var/lib/pgsql/14/data/postgresql.conf
 
 # - SSL -
@@ -314,7 +314,7 @@ ssl_cert_file = '/var/lib/pgsql/14/data/tls/postgres.example.com.pem'
 ssl_key_file = '/var/lib/pgsql/14/data/tls/postgres.example.com-key.pem'
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 # vim /etc/postgresql/14/main/postgresql.conf
 
 # - SSL -
@@ -333,7 +333,7 @@ ssl_key_file = '/etc/postgresql/14/main/tls/postgres.example.com-key.pem'
 
    {{< language-toggle >}}
 
-   {{< code shell  "RHEL/CentOS" >}}
+   {{< code shell "RHEL family" >}}
 
 # /var/lib/pgsql/14/data/pg_hba.conf (file location)
 
@@ -345,7 +345,7 @@ hostssl all             postgres        0.0.0.0/0               reject
 hostssl sensu_events    sensu           0.0.0.0/0               cert
 {{< /code >}}
 
-   {{< code shell  "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 
 # /etc/postgresql/14/main/pg_hba.conf (file location)
 
@@ -367,11 +367,11 @@ hostssl sensu_events    sensu           0.0.0.0/0               cert
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/Centos" >}}
+   {{< code shell "RHEL family" >}}
 sudo systemctl restart postgresql-14.service
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 sudo systemctl restart postgresql.service
 {{< /code >}}
 

--- a/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/migrate.md
@@ -21,7 +21,7 @@ The step for [translating integrations, contact routing, and LDAP authentication
 Sensu Go includes important changes to all parts of Sensu: architecture, installation, resource definitions, the observation data (event) model, check dependencies, filter evaluation, and more.
 Sensu Go also includes many powerful [commercial features][27] to make monitoring easier to build, scale, and offer as a self-service tool to your internal customers.
 
-Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
+Sensu Go is available for [Debian- and RHEL-family distributions and Docker][43].
 The Sensu Go agent is also available for Windows.
 
 {{% notice warning %}}
@@ -201,7 +201,7 @@ Read the [API overview][17] for more information.
 
 #### 1. Install the Sensu Go backend 
 
-The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and Docker.
+The Sensu backend is available for Debian- and RHEL-family distributions and Docker.
 Read the [installation guide][52] to install, configure, and start the Sensu backend according to your [deployment strategy][38].
 
 #### 2. Log in to the Sensu web UI
@@ -232,7 +232,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 
 #### 5. Install agents
 
-The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
+The Sensu agent is available for Debian- and RHEL-family distributions, Windows, and Docker.
 Read the [installation guide][55] to install, configure, and start Sensu agents.
 
 If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml` or `C:\ProgramData\sensu\config\agent.yml.example`).

--- a/content/sensu-go/6.7/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.7/operations/maintain-sensu/troubleshoot.md
@@ -32,7 +32,7 @@ Replace the `<service>` variable with the name of the desired service (for examp
 
 {{< language-toggle >}}
 
-{{< code shell "RHEL/CentOS >= 7" >}}
+{{< code shell "RHEL/family >= 7" >}}
 journalctl --follow --unit sensu-<service>
 {{< /code >}}
 
@@ -51,7 +51,7 @@ Replace the `<service>` variable with the name of the desired service (for examp
 
 {{< language-toggle >}}
 
-{{< code shell "RHEL/CentOS <= 6" >}}
+{{< code shell "RHEL/family <= 6" >}}
 tail --follow /var/log/sensu/sensu-<service>
 {{< /code >}}
 

--- a/content/sensu-go/6.7/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.7/operations/manage-secrets/secrets-management.md
@@ -67,11 +67,11 @@ Then, run the following code, replacing `INTEGRATION_KEY` with your PagerDuty In
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_PAGERDUTY_KEY=INTEGRATION_KEY' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_PAGERDUTY_KEY=INTEGRATION_KEY' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.7/platforms.md
+++ b/content/sensu-go/6.7/platforms.md
@@ -25,7 +25,7 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensu backend
 
-|  | RHEL/CentOS<br>6, 7, 8 | Debian 8, 9, 10, 11 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
+|  | RHEL family<br>6, 7, 8 | Debian 8, 9, 10, 11 | Ubuntu 14.04<br>16.04, 18.04<br>18.10, 19.04<br>19.10, 20.04 |
 |----------------------|---------|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} |
 | `arm64` | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -33,11 +33,11 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 As of Sensu Go 6.7.2, supported packages for the Sensu backend also include **Ubuntu 22.04** (`amd64`, `arm64`, `ppe64le`).
 
-As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RHEL/CentOS 9** (`amd64`, `arm64`, `ppe64le`).
+As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RHEL 9** (`amd64`, `arm64`, `ppe64le`).
 
 ### Sensu agent
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL<br>family<br>6, 7, 8 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -47,11 +47,11 @@ As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RH
 
 As of Sensu Go 6.7.2, supported packages for the Sensu agent also include **Ubuntu 22.04** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
 
-As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RHEL/CentOS 9** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
+As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RHEL 9** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
 
 ### Sensuctl command line tool
 
-|  | RHEL/<br>CentOS<br>6, 7, 8 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL<br>family<br>6, 7, 8 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -61,7 +61,7 @@ As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RH
 
 As of Sensu Go 6.7.2, supported packages for the sensuctl command line tool also include **Ubuntu 22.04** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
 
-As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RHEL/CentOS 9** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
+As of Sensu Go 6.7.5, supported packages for the Sensu backend also include **RHEL 9** (`amd64`, `arm64`, `arm7`, `ppe64le`, `s390x`).
 
 ## Docker images
 

--- a/content/sensu-go/6.7/plugins/install-plugins.md
+++ b/content/sensu-go/6.7/plugins/install-plugins.md
@@ -106,11 +106,11 @@ To download and update package information:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo apt-get update
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo yum update
 {{< /code >}}
 
@@ -120,11 +120,11 @@ Depending on the plugin, you may need to install developer tool packages:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo apt-get install build-essential
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo yum groupinstall "Development Tools"
 {{< /code >}}
 

--- a/content/sensu-go/6.7/release-notes.md
+++ b/content/sensu-go/6.7/release-notes.md
@@ -141,7 +141,7 @@ This patch release includes a change in how agents execute check requests to pre
 Read the [upgrade guide][1] to upgrade Sensu to version 6.7.3.
 
 **IMPROVEMENTS**
-- ([Commercial feature][268]) Added supported packages for the Sensu backend, Sensu agent, and sensuctl for RHEL/CentOS 9.
+- ([Commercial feature][268]) Added supported packages for the Sensu backend, Sensu agent, and sensuctl for RHEL 9.
 
 **FIXES**
 - ([Commercial feature][268]) When using the business service monitoring (BSM) feature, service component metadata is now included in the [`check` scope][291] of events the service component generates.
@@ -1387,7 +1387,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.16.0.
 
 **IMPORTANT:**
 
-- For Ubuntu/Debian and RHEL/CentOS installations, the backend is no longer seeded with a default admin username and password.
+- For Debian- and RHEL-family installations, the backend is no longer seeded with a default admin username and password.
 Users will need to [run 'sensu-backend init'][102] on every new installation and specify an admin username and password.
 
 **NEW FEATURES:**
@@ -1467,14 +1467,14 @@ Read the [blog announcement][91] for more information about our usage policy.
 ## 5.14.2 release notes
 
 **November 4, 2019** &mdash; The latest release of Sensu Go, version 5.14.2, is now available for download.
-This release includes an etcd upgrade, fixes that improve stability and performance, and a Sensu Go package for CentOS 8.
+This release includes an etcd upgrade, fixes that improve stability and performance, and a Sensu Go package for RHEL 8.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 5.14.2.
 
 **IMPROVEMENTS:**
 
 - Upgraded etcd to 3.3.17.
-- Added build package for CentOS 8 (`el/8`).
+- Added build package for RHEL 8 (`el/8`).
 - Sensu Go now uses serializable event reads, which helps improve performance.
 
 **FIXES:**
@@ -1707,8 +1707,8 @@ For a complete list of supported platforms, visit the [platforms page][73].
 - Multiple nested set handlers are now flagged correctly, fixing an issue in which they were flagged as deeply nested.
 - Round robin proxy checks now execute as expected in the event of updated entities.
 - The Sensu backend now avoids situations of high CPU usage in the event that watchers enter a tight loop.
-- Due to incompatibility with the Go programming language, Sensu is incompatible with CentOS/RHEL 5.
-As a result, CentOS/RHEL 5 has been removed as a [supported platform][73] for all versions of Sensu Go.
+- Due to incompatibility with the Go programming language, Sensu is incompatible with RHEL 5.
+As a result, RHEL 5 has been removed as a [supported platform][73] for all versions of Sensu Go.
 
 ## 5.10.2 release notes
 

--- a/content/sensu-go/6.8/get-started.md
+++ b/content/sensu-go/6.8/get-started.md
@@ -15,7 +15,7 @@ You can [install the commercial distribution][15] or [build Sensu from source][1
 
 ## Install the commercial distribution of Sensu Go
 
-Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windows.
+Sensu's [supported platforms][20] include Debian- and RHEL-family distributions and Windows.
 
 - [**Install Sensu Go**][2] with a commercial package and get started for free
 - Learn about Sensu's [commercial features][3] &mdash; all commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -167,11 +167,11 @@ If you have already created this file on your system, skip to step 2.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-backend
 {{< /code >}}
      
@@ -182,11 +182,11 @@ Run:
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SUMOLOGIC_URL=<SumoLogic_HTTPSourceAddress_URL>' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SUMOLOGIC_URL=<SumoLogic_HTTPSourceAddress_URL>' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/send-slack-alerts.md
@@ -24,7 +24,7 @@ You can use pipelines to send email alerts, create or resolve incidents (in Page
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a pipeline and adding it to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][2] to add the check.
 
-Before you start, follow the RHEL/CentOS [install instructions][17] to install and configure the Sensu backend, the Sensu agent, and sensuctl.
+Before you start, follow the RHEL family [install instructions][17] to install and configure the Sensu backend, the Sensu agent, and sensuctl.
 
 ## Configure a Sensu entity
 

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/_index.md
@@ -31,7 +31,7 @@ Agent entities are responsible for creating [status and metrics events][6] to se
 The Sensu backend includes an integrated structure for scheduling checks using subscriptions and an event pipeline that applies [event filters][15], [mutators][16], and [handlers][17], an embedded [etcd][10] datastore for storing configuration and state, and the Sensu [API][4], Sensu [web UI][5], and [sensuctl][19] command line tool.
 
 The Sensu agent is available for Linux, macOS, and Windows.
-The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
+The Sensu backend is available for Debian- and RHEL-family distributions of Linux.
 Learn more in the [agent][11] and [backend][2] references.
 
 Follow the [installation guide][1] to install the agent and backend.

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/agent.md
@@ -844,7 +844,7 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
-default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+default       | `ws://127.0.0.1:8081`(Debian and RHEL families)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_URL`
@@ -1609,11 +1609,11 @@ Here's how.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1642,11 +1642,11 @@ All environment variables that control Sensu agent configuration begin with `SEN
      
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1663,11 +1663,11 @@ SENSU_API_HOST="0.0.0.0"
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo systemctl restart sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo systemctl restart sensu-agent
 {{< /code >}}
 
@@ -1690,11 +1690,11 @@ For example, to create the labels `"region": "us-east-1"` and `"type": "website"
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1704,11 +1704,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1716,7 +1716,7 @@ echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.
 
 ### Use environment variables with the Sensu agent
 
-Any environment variables you create in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS) will be available to check and hook commands executed by the Sensu agent.
+Any environment variables you create in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family) will be available to check and hook commands executed by the Sensu agent.
 This includes your checks and plugins.
 
 For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-agent file, it will be available to use in your check and hook configurations as `$TEST_VARIABLE`.
@@ -1793,7 +1793,7 @@ Depending on your environment and preferences, you may want to create overrides 
 You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-agent start`.
-- Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+- Environment variables in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family).
 - Configuration settings in the agent.yml config file.
 
 {{% notice note %}}
@@ -1804,7 +1804,7 @@ Future package upgrades can overwrite changes in the systemd unit file.
 Sensu applies the following precedence to override settings:
 
 1. Arguments passed to the Sensu agent via command line configuration flags.
-2. Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+2. Environment variables in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family).
 3. Configuration in the agent.yml config file.
 
 For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-agent` or `/etc/sysconfig/sensu-agent` or the agent.yml config file.
@@ -1824,11 +1824,11 @@ To configure an environment variable for the desired agent log level:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/backend.md
@@ -18,7 +18,7 @@ menu:
 The Sensu backend is a service that manages check requests and observability data.
 Every Sensu backend includes an integrated structure for scheduling checks using [subscriptions][28], an event processing pipeline that applies [event filters][9], [mutators][10], [handlers][11], and [pipelines][70], an embedded [etcd][2] datastore for storing configuration and state, and the Sensu [API][14], Sensu [web UI][6], and [sensuctl][37] command line tool.
 
-The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
+The Sensu backend is available for Debian- and RHEL-family distributions of Linux.
 For these operating systems, the Sensu backend uses the Bourne shell (sh) for the execution environment.
 
 Read the [installation guide][1] to install the backend.
@@ -29,8 +29,8 @@ For a **new** installation, the backend database must be initialized by providin
 Although initialization is required for every new installation, the implementation differs depending on your method of installation:
 
 - If you are using Docker, you can use environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`) during [step 2 of the backend installation process][24].
-- If you are using Ubuntu/Debian or RHEL/CentOS, you must specify admin credentials during [step 3 of the backend installation process][25].
-Sensu does not apply default admin credentials for Ubuntu/Debian or RHEL/CentoOS installations.
+- If you are using a Debian- or RHEL-family distribution, you must specify admin credentials during [step 3 of the backend installation process][25].
+Sensu does not apply default admin credentials for Debian- or RHEL-family installations.
 
 The initialization step bootstraps the first admin user account for your Sensu installation.
 This first account will be granted the cluster admin role.
@@ -82,9 +82,9 @@ volumes:
 
 If you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process][24], we recommend [changing your default admin password][26] as soon as you have installed sensuctl.
 
-### Ubuntu/Debian or RHEL/CentOS initialization
+### Debian or RHEL family initialization
 
-For Ubuntu/Debian or RHEL/CentOS, set administrator credentials with environment variables at [initialization][25] as shown below.
+For Debian- or RHEL-family distributions, set administrator credentials with environment variables at [initialization][25] as shown below.
 
 To initialize with your username and password, replace `<username>` and `<password>` with the username and password you want to use:
 
@@ -145,7 +145,7 @@ volumes:
     driver: local
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian and RHEL/CentOS" >}}
+{{< code shell "Debian and RHEL families" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 export SENSU_BACKEND_CLUSTER_ADMIN_API_KEY=<api_key>
@@ -483,7 +483,7 @@ api-serve-wait-time: 10s{{< /code >}}
 -------------|------
 description  | URL used to connect to the API.
 type         | String
-default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+default      | `http://localhost:8080` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_API_URL`
@@ -926,7 +926,7 @@ description   | List of this member's client URLs to advertise to the rest of th
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
-default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
+default       | `http://localhost:2379` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
@@ -1072,7 +1072,7 @@ description                        | List of this member's peer URLs to advertis
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
-default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+default                            | `http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
@@ -1093,7 +1093,7 @@ description            | Initial cluster configuration for bootstrapping.{{% not
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
-default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+default                | `default=http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
@@ -1152,7 +1152,7 @@ description               | List of URLs to listen on for client traffic. Sensu'
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                      | List
-default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
+default                   | `http://127.0.0.1:2379` (Debian and RHEL families)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
@@ -1171,7 +1171,7 @@ description             | List of URLs to listen on for peer traffic. Sensu's de
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
-default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
+default                 | `http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
@@ -1491,11 +1491,11 @@ Here's how.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-backend
 {{< /code >}}
      
@@ -1515,11 +1515,11 @@ sudo touch /etc/sysconfig/sensu-backend
      
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1529,11 +1529,11 @@ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/s
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo systemctl restart sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo systemctl restart sensu-backend
 {{< /code >}}
 
@@ -1552,11 +1552,11 @@ For example, to create the labels `"region": "us-east-1"` and `"type": "website"
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1566,11 +1566,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1578,7 +1578,7 @@ echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hook
 
 ### Use environment variables with the Sensu backend
 
-Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
+Any environment variables you create in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family) will be available to handlers executed by the Sensu backend.
 
 For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-backend file, it will be available to use in your handler configurations as `$TEST_VARIABLE`.
 The following handler will print the `TEST_VARIABLE` value set in your sensu-backend file in `/tmp/test.txt`:
@@ -1627,7 +1627,7 @@ Depending on your environment and preferences, you may want to create overrides 
 You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-backend start`.
-- Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+- Environment variables in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family).
 - Configuration settings in the backend.yml config file.
 
 {{% notice note %}}
@@ -1638,7 +1638,7 @@ Future package upgrades can overwrite changes in the systemd unit file.
 Sensu applies the following precedence to override settings:
 
 1. Arguments passed to the Sensu backend via command line configuration flags.
-2. Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+2. Environment variables in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family).
 3. Configuration in the backend.yml config file.
 
 For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` or the backend.yml config file.
@@ -1657,11 +1657,11 @@ To configure an environment variable for the desired backend log level:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.8/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/generate-certificates.md
@@ -300,7 +300,7 @@ We recommend installing the CA root certificate in the trust store of both your 
 Installing the CA certificate in the trust store for these systems makes it easier to connect via web UI or sensuctl without being prompted to accept certificates signed by your self-generated CA.
 
 {{< language-toggle >}}
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 chmod 644 /etc/sensu/tls/ca.pem
 chown root /etc/sensu/tls/ca.pem
 sudo apt-get install ca-certificates -y
@@ -308,7 +308,7 @@ sudo ln -sfv /etc/sensu/tls/ca.pem /usr/local/share/ca-certificates/sensu-ca.crt
 sudo update-ca-certificates
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 chmod 644 /etc/sensu/tls/ca.pem
 chown root /etc/sensu/tls/ca.pem
 sudo yum install -y ca-certificates

--- a/content/sensu-go/6.8/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/install-sensu.md
@@ -82,7 +82,7 @@ The agent TCP and UDP sockets are deprecated in favor of the [agent API][27].
 
 ## Install the Sensu backend
 
-The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and Docker.
+The Sensu backend is available for Debian- and RHEL-family distributions and Docker.
 Review [supported platforms][5] for more information.
 
 ### 1. Download
@@ -99,7 +99,7 @@ docker pull sensu/sensu
 docker pull sensu/sensu-rhel
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -107,7 +107,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -166,7 +166,7 @@ volumes:
 
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
@@ -177,7 +177,7 @@ sudo systemctl start sensu-backend
 sudo systemctl status sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
@@ -211,13 +211,13 @@ Replace `<username>` and `<password>` with the username and password you want to
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 sensu-backend init
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 sensu-backend init
@@ -271,7 +271,7 @@ To install sensuctl:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -279,7 +279,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-cli
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -341,7 +341,7 @@ sensuctl user change-password --interactive
 
 ## Install Sensu agents
 
-The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
+The Sensu agent is available for Debian- and RHEL-family distributions, Windows, and Docker.
 Review [supported platforms][5] for more information.
 
 ### 1. Download {#agent-download}
@@ -358,7 +358,7 @@ docker pull sensu/sensu
 docker pull sensu/sensu-rhel
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -366,7 +366,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -429,7 +429,7 @@ volumes:
     driver: local
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
@@ -437,7 +437,7 @@ sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu
 sudo systemctl start sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 

--- a/content/sensu-go/6.8/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/scale-event-storage.md
@@ -38,7 +38,7 @@ The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connect
 
 {{% notice warning %}}
 **IMPORTANT**: PostgreSQL configuration file locations differ depending on platform.
-The steps in this guide use common paths for RHEL/CentOS, but the files may be stored elsewhere on your system.
+The steps in this guide use common paths for RHEL-family distributions, but the files may be stored elsewhere on your system.
 Learn more about [PostgreSQL configuration file locations](https://www.postgresql.org/docs/current/runtime-config-file-locations.html).
 {{% /notice %}}
 

--- a/content/sensu-go/6.8/operations/deploy-sensu/secure-postgres.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/secure-postgres.md
@@ -40,14 +40,14 @@ If not, run the following commands:
 
 {{< language-toggle >}}
 
-{{< code "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo curl -s -L -o /bin/cfssl https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl_1.6.2_linux_amd64
 sudo curl -s -L -o /bin/cfssljson https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssljson_1.6.2_linux_amd64
 sudo curl -s -L -o /bin/cfssl-certinfo https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl-certinfo_1.6.2_linux_amd64
 sudo chmod +x /bin/cfssl*
 {{< /code >}}
 
-{{< code "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 
 # Update apt repos
 sudo apt-get update
@@ -187,7 +187,7 @@ Working from your Sensu backend, follow these steps to configure Sensu to use ce
 
    {{< language-toggle >}}
 
-  {{< code "RHEL/CentOS" >}}
+  {{< code shell "RHEL family" >}}
 echo 'PGUSER=sensu
 PGSSLMODE="verify-full"
 PGSSLCERT="/etc/sensu/tls/sensu.pem"
@@ -195,7 +195,7 @@ PGSSLKEY="/etc/sensu/tls/sensu-key.pem"
 PGSSLROOTCERT="/etc/sensu/tls/ca.pem"' | sudo tee /etc/sysconfig/sensu-backend
 {{< /code >}}
 
-  {{< code "Ubuntu/Debian" >}}
+  {{< code shell "Debian family" >}}
 echo 'PGUSER=sensu
 PGSSLMODE="verify-full"
 PGSSLCERT="/etc/sensu/tls/sensu.pem"
@@ -281,7 +281,7 @@ scp ca.pem postgres.example.com:/home/user
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/CentOS">}}
+   {{< code shell "RHEL family" >}}
 sudo mkdir /var/lib/pgsql/14/data/tls
 cd /var/lib/pgsql/14/data/tls
 cp /home/user/postgres.example.com* /var/lib/pgsql/14/data/tls/
@@ -289,7 +289,7 @@ cp /home/user/ca.pem /var/lib/pgsql/14/data/tls/
 chown -R postgres:postgres /var/lib/pgsql/14/data
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian">}}
+   {{< code shell "Debian family" >}}
 sudo mkdir /etc/postgresql/14/main/tls
 cd /etc/postgresql/14/main/tls
 cp /home/user/postgres.example.com* /etc/postgresql/14/main/tls/
@@ -303,7 +303,7 @@ chown -R postgres:postgres /etc/postgresql/14/main/
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/CentOS">}}
+   {{< code shell "RHEL family" >}}
 # vim /var/lib/pgsql/14/data/postgresql.conf
 
 # - SSL -
@@ -314,7 +314,7 @@ ssl_cert_file = '/var/lib/pgsql/14/data/tls/postgres.example.com.pem'
 ssl_key_file = '/var/lib/pgsql/14/data/tls/postgres.example.com-key.pem'
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 # vim /etc/postgresql/14/main/postgresql.conf
 
 # - SSL -
@@ -333,7 +333,7 @@ ssl_key_file = '/etc/postgresql/14/main/tls/postgres.example.com-key.pem'
 
    {{< language-toggle >}}
 
-   {{< code shell  "RHEL/CentOS" >}}
+   {{< code shell "RHEL family" >}}
 
 # /var/lib/pgsql/14/data/pg_hba.conf (file location)
 
@@ -345,7 +345,7 @@ hostssl all             postgres        0.0.0.0/0               reject
 hostssl sensu_events    sensu           0.0.0.0/0               cert
 {{< /code >}}
 
-   {{< code shell  "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 
 # /etc/postgresql/14/main/pg_hba.conf (file location)
 
@@ -367,11 +367,11 @@ hostssl sensu_events    sensu           0.0.0.0/0               cert
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/Centos" >}}
+   {{< code shell "RHEL family" >}}
 sudo systemctl restart postgresql-14.service
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 sudo systemctl restart postgresql.service
 {{< /code >}}
 

--- a/content/sensu-go/6.8/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.8/operations/maintain-sensu/migrate.md
@@ -21,7 +21,7 @@ The step for [translating integrations, contact routing, and LDAP authentication
 Sensu Go includes important changes to all parts of Sensu: architecture, installation, resource definitions, the observation data (event) model, check dependencies, filter evaluation, and more.
 Sensu Go also includes many powerful [commercial features][27] to make monitoring easier to build, scale, and offer as a self-service tool to your internal customers.
 
-Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
+Sensu Go is available for [Debian- and RHEL-family distributions and Docker][43].
 The Sensu Go agent is also available for Windows.
 
 {{% notice warning %}}
@@ -201,7 +201,7 @@ Read the [API overview][17] for more information.
 
 #### 1. Install the Sensu Go backend 
 
-The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and Docker.
+The Sensu backend is available for Debian- and RHEL-family distributions and Docker.
 Read the [installation guide][52] to install, configure, and start the Sensu backend according to your [deployment strategy][38].
 
 #### 2. Log in to the Sensu web UI
@@ -232,7 +232,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 
 #### 5. Install agents
 
-The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
+The Sensu agent is available for Debian- and RHEL-family distributions, Windows, and Docker.
 Read the [installation guide][55] to install, configure, and start Sensu agents.
 
 If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml` or `C:\ProgramData\sensu\config\agent.yml.example`).

--- a/content/sensu-go/6.8/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.8/operations/maintain-sensu/troubleshoot.md
@@ -32,7 +32,7 @@ Replace the `<service>` variable with the name of the desired service (for examp
 
 {{< language-toggle >}}
 
-{{< code shell "RHEL/CentOS >= 7" >}}
+{{< code shell "RHEL/family >= 7" >}}
 journalctl --follow --unit sensu-<service>
 {{< /code >}}
 
@@ -51,7 +51,7 @@ Replace the `<service>` variable with the name of the desired service (for examp
 
 {{< language-toggle >}}
 
-{{< code shell "RHEL/CentOS <= 6" >}}
+{{< code shell "RHEL/family <= 6" >}}
 tail --follow /var/log/sensu/sensu-<service>
 {{< /code >}}
 

--- a/content/sensu-go/6.8/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.8/operations/manage-secrets/secrets-management.md
@@ -67,11 +67,11 @@ Then, run the following code, replacing `INTEGRATION_KEY` with your PagerDuty In
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_PAGERDUTY_KEY=INTEGRATION_KEY' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_PAGERDUTY_KEY=INTEGRATION_KEY' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.8/platforms.md
+++ b/content/sensu-go/6.8/platforms.md
@@ -25,7 +25,7 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensu backend
 
-|  | RHEL/CentOS<br>6, 7, 8, 9 | Debian 8, 9, 10, 11 | Ubuntu 14.04<br>16.04, 18.04, 18.10<br>19.04, 19.10, 20.04<br>22.04 |
+|  | RHEL family<br>6, 7, 8, 9 | Debian 8, 9, 10, 11 | Ubuntu 14.04<br>16.04, 18.04, 18.10<br>19.04, 19.10, 20.04<br>22.04 |
 |----------------------|---------|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} |
 | `arm64` | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -33,7 +33,7 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensu agent
 
-|  | RHEL/<br>CentOS<br>6, 7, 8, 9 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04<br>22.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL<br>family<br>6, 7, 8, 9 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04<br>22.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -43,7 +43,7 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensuctl command line tool
 
-|  | RHEL/<br>CentOS<br>6, 7, 8, 9 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04<br>22.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL<br>family<br>6, 7, 8, 9 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04<br>22.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |

--- a/content/sensu-go/6.8/plugins/install-plugins.md
+++ b/content/sensu-go/6.8/plugins/install-plugins.md
@@ -106,11 +106,11 @@ To download and update package information:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo apt-get update
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo yum update
 {{< /code >}}
 
@@ -120,11 +120,11 @@ Depending on the plugin, you may need to install developer tool packages:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo apt-get install build-essential
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo yum groupinstall "Development Tools"
 {{< /code >}}
 

--- a/content/sensu-go/6.8/release-notes.md
+++ b/content/sensu-go/6.8/release-notes.md
@@ -217,7 +217,7 @@ This patch release includes a change in how agents execute check requests to pre
 Read the [upgrade guide][1] to upgrade Sensu to version 6.7.3.
 
 **IMPROVEMENTS**
-- ([Commercial feature][268]) Added supported packages for the Sensu backend, Sensu agent, and sensuctl for RHEL/CentOS 9.
+- ([Commercial feature][268]) Added supported packages for the Sensu backend, Sensu agent, and sensuctl for RHEL 9.
 
 **FIXES**
 - ([Commercial feature][268]) When using the business service monitoring (BSM) feature, service component metadata is now included in the [`check` scope][291] of events the service component generates.
@@ -1463,7 +1463,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.16.0.
 
 **IMPORTANT:**
 
-- For Ubuntu/Debian and RHEL/CentOS installations, the backend is no longer seeded with a default admin username and password.
+- For Debian- and RHEL-family installations, the backend is no longer seeded with a default admin username and password.
 Users will need to [run 'sensu-backend init'][102] on every new installation and specify an admin username and password.
 
 **NEW FEATURES:**
@@ -1543,14 +1543,14 @@ Read the [blog announcement][91] for more information about our usage policy.
 ## 5.14.2 release notes
 
 **November 4, 2019** &mdash; The latest release of Sensu Go, version 5.14.2, is now available for download.
-This release includes an etcd upgrade, fixes that improve stability and performance, and a Sensu Go package for CentOS 8.
+This release includes an etcd upgrade, fixes that improve stability and performance, and a Sensu Go package for RHEL 8.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 5.14.2.
 
 **IMPROVEMENTS:**
 
 - Upgraded etcd to 3.3.17.
-- Added build package for CentOS 8 (`el/8`).
+- Added build package for RHEL 8 (`el/8`).
 - Sensu Go now uses serializable event reads, which helps improve performance.
 
 **FIXES:**
@@ -1783,8 +1783,8 @@ For a complete list of supported platforms, visit the [platforms page][73].
 - Multiple nested set handlers are now flagged correctly, fixing an issue in which they were flagged as deeply nested.
 - Round robin proxy checks now execute as expected in the event of updated entities.
 - The Sensu backend now avoids situations of high CPU usage in the event that watchers enter a tight loop.
-- Due to incompatibility with the Go programming language, Sensu is incompatible with CentOS/RHEL 5.
-As a result, CentOS/RHEL 5 has been removed as a [supported platform][73] for all versions of Sensu Go.
+- Due to incompatibility with the Go programming language, Sensu is incompatible with RHEL 5.
+As a result, RHEL 5 has been removed as a [supported platform][73] for all versions of Sensu Go.
 
 ## 5.10.2 release notes
 

--- a/content/sensu-go/6.9/get-started.md
+++ b/content/sensu-go/6.9/get-started.md
@@ -15,7 +15,7 @@ You can [install the commercial distribution][15] or [build Sensu from source][1
 
 ## Install the commercial distribution of Sensu Go
 
-Sensu's [supported platforms][20] include CentOS/RHEL, Debian, Ubuntu, and Windows.
+Sensu's [supported platforms][20] include Debian- and RHEL-family distributions and Windows.
 
 - [**Install Sensu Go**][2] with a commercial package and get started for free
 - Learn about Sensu's [commercial features][3] &mdash; all commercial features are available for free in the packaged Sensu Go distribution up to an entity limit of 100

--- a/content/sensu-go/6.9/observability-pipeline/observe-process/send-data-sumo-logic.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-process/send-data-sumo-logic.md
@@ -167,11 +167,11 @@ If you have already created this file on your system, skip to step 2.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-backend
 {{< /code >}}
      
@@ -182,11 +182,11 @@ Run:
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SUMOLOGIC_URL=<SumoLogic_HTTPSourceAddress_URL>' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SUMOLOGIC_URL=<SumoLogic_HTTPSourceAddress_URL>' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.9/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-process/send-slack-alerts.md
@@ -24,7 +24,7 @@ You can use pipelines to send email alerts, create or resolve incidents (in Page
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a pipeline and adding it to a check named `check_cpu`.
 If you don't already have this check in place, follow [Monitor server resources][2] to add the check.
 
-Before you start, follow the RHEL/CentOS [install instructions][17] to install and configure the Sensu backend, the Sensu agent, and sensuctl.
+Before you start, follow the RHEL family [install instructions][17] to install and configure the Sensu backend, the Sensu agent, and sensuctl.
 
 ## Configure a Sensu entity
 

--- a/content/sensu-go/6.9/observability-pipeline/observe-schedule/_index.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-schedule/_index.md
@@ -31,7 +31,7 @@ Agent entities are responsible for creating [status and metrics events][6] to se
 The Sensu backend includes an integrated structure for scheduling checks using subscriptions and an event pipeline that applies [event filters][15], [mutators][16], and [handlers][17], an embedded [etcd][10] datastore for storing configuration and state, and the Sensu [API][4], Sensu [web UI][5], and [sensuctl][19] command line tool.
 
 The Sensu agent is available for Linux, macOS, and Windows.
-The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
+The Sensu backend is available for Debian- and RHEL-family distributions of Linux.
 Learn more in the [agent][11] and [backend][2] references.
 
 Follow the [installation guide][1] to install the agent and backend.

--- a/content/sensu-go/6.9/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-schedule/agent.md
@@ -844,7 +844,7 @@ description   | ws or wss URL of the Sensu backend server. To specify multiple b
 **NOTE**: If you do not specify a port for your backend-url values, the agent will automatically append the default backend port (8081).
 {{% /notice %}}
 type          | List
-default       | `ws://127.0.0.1:8081`(CentOS/RHEL, Debian, and Ubuntu)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+default       | `ws://127.0.0.1:8081`(Debian and RHEL families)<br><br>`$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_URL`
@@ -1609,11 +1609,11 @@ Here's how.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1642,11 +1642,11 @@ All environment variables that control Sensu agent configuration begin with `SEN
      
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_API_HOST="0.0.0.0"' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1663,11 +1663,11 @@ SENSU_API_HOST="0.0.0.0"
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo systemctl restart sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo systemctl restart sensu-agent
 {{< /code >}}
 
@@ -1690,11 +1690,11 @@ For example, to create the labels `"region": "us-east-1"` and `"type": "website"
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1704,11 +1704,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 
@@ -1716,7 +1716,7 @@ echo 'SENSU_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.
 
 ### Use environment variables with the Sensu agent
 
-Any environment variables you create in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS) will be available to check and hook commands executed by the Sensu agent.
+Any environment variables you create in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family) will be available to check and hook commands executed by the Sensu agent.
 This includes your checks and plugins.
 
 For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-agent file, it will be available to use in your check and hook configurations as `$TEST_VARIABLE`.
@@ -1793,7 +1793,7 @@ Depending on your environment and preferences, you may want to create overrides 
 You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-agent start`.
-- Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+- Environment variables in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family).
 - Configuration settings in the agent.yml config file.
 
 {{% notice note %}}
@@ -1804,7 +1804,7 @@ Future package upgrades can overwrite changes in the systemd unit file.
 Sensu applies the following precedence to override settings:
 
 1. Arguments passed to the Sensu agent via command line configuration flags.
-2. Environment variables in `/etc/default/sensu-agent` (Debian/Ubuntu) or `/etc/sysconfig/sensu-agent` (RHEL/CentOS).
+2. Environment variables in `/etc/default/sensu-agent` (Debian family) or `/etc/sysconfig/sensu-agent` (RHEL family).
 3. Configuration in the agent.yml config file.
 
 For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-agent` or `/etc/sysconfig/sensu-agent` or the agent.yml config file.
@@ -1824,11 +1824,11 @@ To configure an environment variable for the desired agent log level:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-agent
 {{< /code >}}
 

--- a/content/sensu-go/6.9/observability-pipeline/observe-schedule/backend.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-schedule/backend.md
@@ -18,7 +18,7 @@ menu:
 The Sensu backend is a service that manages check requests and observability data.
 Every Sensu backend includes an integrated structure for scheduling checks using [subscriptions][28], an event processing pipeline that applies [event filters][9], [mutators][10], [handlers][11], and [pipelines][70], an embedded [etcd][2] datastore for storing configuration and state, and the Sensu [API][14], Sensu [web UI][6], and [sensuctl][37] command line tool.
 
-The Sensu backend is available for Ubuntu/Debian and RHEL/CentOS distributions of Linux.
+The Sensu backend is available for Debian- and RHEL-family distributions of Linux.
 For these operating systems, the Sensu backend uses the Bourne shell (sh) for the execution environment.
 
 Read the [installation guide][1] to install the backend.
@@ -29,8 +29,8 @@ For a **new** installation, the backend database must be initialized by providin
 Although initialization is required for every new installation, the implementation differs depending on your method of installation:
 
 - If you are using Docker, you can use environment variables to override the default admin username (`admin`) and password (`P@ssw0rd!`) during [step 2 of the backend installation process][24].
-- If you are using Ubuntu/Debian or RHEL/CentOS, you must specify admin credentials during [step 3 of the backend installation process][25].
-Sensu does not apply default admin credentials for Ubuntu/Debian or RHEL/CentoOS installations.
+- If you are using a Debian- or RHEL-family distribution, you must specify admin credentials during [step 3 of the backend installation process][25].
+Sensu does not apply default admin credentials for Debian- or RHEL-family installations.
 
 The initialization step bootstraps the first admin user account for your Sensu installation.
 This first account will be granted the cluster admin role.
@@ -82,9 +82,9 @@ volumes:
 
 If you did not use environment variables to override the default admin credentials in [step 2 of the backend installation process][24], we recommend [changing your default admin password][26] as soon as you have installed sensuctl.
 
-### Ubuntu/Debian or RHEL/CentOS initialization
+### Debian or RHEL family initialization
 
-For Ubuntu/Debian or RHEL/CentOS, set administrator credentials with environment variables at [initialization][25] as shown below.
+For Debian- or RHEL-family distributions, set administrator credentials with environment variables at [initialization][25] as shown below.
 
 To initialize with your username and password, replace `<username>` and `<password>` with the username and password you want to use:
 
@@ -145,7 +145,7 @@ volumes:
     driver: local
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian and RHEL/CentOS" >}}
+{{< code shell "Debian and RHEL families" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 export SENSU_BACKEND_CLUSTER_ADMIN_API_KEY=<api_key>
@@ -483,7 +483,7 @@ api-serve-wait-time: 10s{{< /code >}}
 -------------|------
 description  | URL used to connect to the API.
 type         | String
-default      | `http://localhost:8080` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
+default      | `http://localhost:8080` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:8080` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_API_URL`
@@ -926,7 +926,7 @@ description   | List of this member's client URLs to advertise to the rest of th
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type          | List
-default       | `http://localhost:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
+default       | `http://localhost:2379` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:2379` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable | `SENSU_BACKEND_ETCD_ADVERTISE_CLIENT_URLS`
@@ -1072,7 +1072,7 @@ description                        | List of this member's peer URLs to advertis
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                               | List
-default                            | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+default                            | `http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable               | `SENSU_BACKEND_ETCD_INITIAL_ADVERTISE_PEER_URLS`
@@ -1093,7 +1093,7 @@ description            | Initial cluster configuration for bootstrapping.{{% not
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                   | String
-default                | `default=http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
+default                | `default=http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`default=http://$SENSU_HOSTNAME:2380` (Docker){{% notice note %}}
 **NOTE**: Docker-only Sensu binds to the hostnames of containers, represented here as `SENSU_HOSTNAME` in Docker default values.
 {{% /notice %}}
 environment variable   | `SENSU_BACKEND_ETCD_INITIAL_CLUSTER`
@@ -1152,7 +1152,7 @@ description               | List of URLs to listen on for client traffic. Sensu'
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                      | List
-default                   | `http://127.0.0.1:2379` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2379` (Docker)
+default                   | `http://127.0.0.1:2379` (Debian and RHEL families)<br><br>`http://[::]:2379` (Docker)
 environment variable      | `SENSU_BACKEND_ETCD_LISTEN_CLIENT_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-client-urls https://10.0.0.1:2379,https://10.1.0.1:2379
@@ -1171,7 +1171,7 @@ description             | List of URLs to listen on for peer traffic. Sensu's de
 Do not configure external etcd in Sensu via backend command line flags or the backend configuration file (`/etc/sensu/backend.yml`).
 {{% /notice %}}
 type                    | List
-default                 | `http://127.0.0.1:2380` (CentOS/RHEL, Debian, and Ubuntu)<br><br>`http://[::]:2380` (Docker)
+default                 | `http://127.0.0.1:2380` (Debian and RHEL families)<br><br>`http://[::]:2380` (Docker)
 environment variable    | `SENSU_BACKEND_ETCD_LISTEN_PEER_URLS`
 command line example   | {{< code shell >}}
 sensu-backend start --etcd-listen-peer-urls https://10.0.0.1:2380,https://10.1.0.1:2380
@@ -1491,11 +1491,11 @@ Here's how.
 
      {{< language-toggle >}}
      
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo touch /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo touch /etc/sysconfig/sensu-backend
 {{< /code >}}
      
@@ -1515,11 +1515,11 @@ sudo touch /etc/sysconfig/sensu-backend
      
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1529,11 +1529,11 @@ echo 'SENSU_BACKEND_API_LISTEN_ADDRESS=192.168.100.20:8080' | sudo tee -a /etc/s
 
      {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo systemctl restart sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo systemctl restart sensu-backend
 {{< /code >}}
 
@@ -1552,11 +1552,11 @@ For example, to create the labels `"region": "us-east-1"` and `"type": "website"
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'BACKEND_LABELS='{"region": "us-east-1", "type": "website"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1566,11 +1566,11 @@ To create the annotations `"maintainer": "Team A"` and `"webhook-url": "https://
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hooks.slack.com/services/T0000/B00000/XXXXX"}'' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 
@@ -1578,7 +1578,7 @@ echo 'BACKEND_ANNOTATIONS='{"maintainer": "Team A", "webhook-url": "https://hook
 
 ### Use environment variables with the Sensu backend
 
-Any environment variables you create in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS) will be available to handlers executed by the Sensu backend.
+Any environment variables you create in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family) will be available to handlers executed by the Sensu backend.
 
 For example, if you create a custom environment variable `TEST_VARIABLE` in your sensu-backend file, it will be available to use in your handler configurations as `$TEST_VARIABLE`.
 The following handler will print the `TEST_VARIABLE` value set in your sensu-backend file in `/tmp/test.txt`:
@@ -1627,7 +1627,7 @@ Depending on your environment and preferences, you may want to create overrides 
 You can create configuration overrides in several ways:
 
 - Command line configuration flag arguments for `sensu-backend start`.
-- Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+- Environment variables in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family).
 - Configuration settings in the backend.yml config file.
 
 {{% notice note %}}
@@ -1638,7 +1638,7 @@ Future package upgrades can overwrite changes in the systemd unit file.
 Sensu applies the following precedence to override settings:
 
 1. Arguments passed to the Sensu backend via command line configuration flags.
-2. Environment variables in `/etc/default/sensu-backend` (Debian/Ubuntu) or `/etc/sysconfig/sensu-backend` (RHEL/CentOS).
+2. Environment variables in `/etc/default/sensu-backend` (Debian family) or `/etc/sysconfig/sensu-backend` (RHEL family).
 3. Configuration in the backend.yml config file.
 
 For example, if you create overrides using all three methods, the command line configuration flag values will take precedence over the values you specify in `/etc/default/sensu-backend` or `/etc/sysconfig/sensu-backend` or the backend.yml config file.
@@ -1657,11 +1657,11 @@ To configure an environment variable for the desired backend log level:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_BACKEND_LOG_LEVEL=debug' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.9/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.9/operations/deploy-sensu/generate-certificates.md
@@ -300,7 +300,7 @@ We recommend installing the CA root certificate in the trust store of both your 
 Installing the CA certificate in the trust store for these systems makes it easier to connect via web UI or sensuctl without being prompted to accept certificates signed by your self-generated CA.
 
 {{< language-toggle >}}
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 chmod 644 /etc/sensu/tls/ca.pem
 chown root /etc/sensu/tls/ca.pem
 sudo apt-get install ca-certificates -y
@@ -308,7 +308,7 @@ sudo ln -sfv /etc/sensu/tls/ca.pem /usr/local/share/ca-certificates/sensu-ca.crt
 sudo update-ca-certificates
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 chmod 644 /etc/sensu/tls/ca.pem
 chown root /etc/sensu/tls/ca.pem
 sudo yum install -y ca-certificates

--- a/content/sensu-go/6.9/operations/deploy-sensu/install-sensu.md
+++ b/content/sensu-go/6.9/operations/deploy-sensu/install-sensu.md
@@ -82,7 +82,7 @@ The agent TCP and UDP sockets are deprecated in favor of the [agent API][27].
 
 ## Install the Sensu backend
 
-The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and Docker.
+The Sensu backend is available for Debian- and RHEL-family distributions and Docker.
 Review [supported platforms][5] for more information.
 
 ### 1. Download
@@ -99,7 +99,7 @@ docker pull sensu/sensu
 docker pull sensu/sensu-rhel
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -107,7 +107,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -166,7 +166,7 @@ volumes:
 
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
@@ -177,7 +177,7 @@ sudo systemctl start sensu-backend
 sudo systemctl status sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/backend.yml -o /etc/sensu/backend.yml
 
@@ -211,13 +211,13 @@ Replace `<username>` and `<password>` with the username and password you want to
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 sensu-backend init
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 export SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=<username>
 export SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=<password>
 sensu-backend init
@@ -271,7 +271,7 @@ To install sensuctl:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -279,7 +279,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-cli
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -341,7 +341,7 @@ sensuctl user change-password --interactive
 
 ## Install Sensu agents
 
-The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
+The Sensu agent is available for Debian- and RHEL-family distributions, Windows, and Docker.
 Review [supported platforms][5] for more information.
 
 ### 1. Download {#agent-download}
@@ -358,7 +358,7 @@ docker pull sensu/sensu
 docker pull sensu/sensu-rhel
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh | sudo bash
 
@@ -366,7 +366,7 @@ curl -s https://packagecloud.io/install/repositories/sensu/stable/script.deb.sh 
 sudo apt-get install sensu-go-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Add the Sensu repository
 curl -s https://packagecloud.io/install/repositories/sensu/stable/script.rpm.sh | sudo bash
 
@@ -429,7 +429,7 @@ volumes:
     driver: local
 {{< /code >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 
@@ -437,7 +437,7 @@ sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu
 sudo systemctl start sensu-agent
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 # Copy the config template from the docs
 sudo curl -L https://docs.sensu.io/sensu-go/latest/files/agent.yml -o /etc/sensu/agent.yml
 

--- a/content/sensu-go/6.9/operations/deploy-sensu/scale-event-storage.md
+++ b/content/sensu-go/6.9/operations/deploy-sensu/scale-event-storage.md
@@ -38,7 +38,7 @@ The `sensu-perf` test environment comfortably handles 40,000 Sensu agent connect
 
 {{% notice warning %}}
 **IMPORTANT**: PostgreSQL configuration file locations differ depending on platform.
-The steps in this guide use common paths for RHEL/CentOS, but the files may be stored elsewhere on your system.
+The steps in this guide use common paths for RHEL-family distributions, but the files may be stored elsewhere on your system.
 Learn more about [PostgreSQL configuration file locations](https://www.postgresql.org/docs/current/runtime-config-file-locations.html).
 {{% /notice %}}
 

--- a/content/sensu-go/6.9/operations/deploy-sensu/secure-postgres.md
+++ b/content/sensu-go/6.9/operations/deploy-sensu/secure-postgres.md
@@ -40,14 +40,14 @@ If not, run the following commands:
 
 {{< language-toggle >}}
 
-{{< code "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo curl -s -L -o /bin/cfssl https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl_1.6.2_linux_amd64
 sudo curl -s -L -o /bin/cfssljson https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssljson_1.6.2_linux_amd64
 sudo curl -s -L -o /bin/cfssl-certinfo https://github.com/cloudflare/cfssl/releases/download/v1.6.2/cfssl-certinfo_1.6.2_linux_amd64
 sudo chmod +x /bin/cfssl*
 {{< /code >}}
 
-{{< code "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 
 # Update apt repos
 sudo apt-get update
@@ -187,7 +187,7 @@ Working from your Sensu backend, follow these steps to configure Sensu to use ce
 
    {{< language-toggle >}}
 
-  {{< code "RHEL/CentOS" >}}
+  {{< code shell "RHEL family" >}}
 echo 'PGUSER=sensu
 PGSSLMODE="verify-full"
 PGSSLCERT="/etc/sensu/tls/sensu.pem"
@@ -195,7 +195,7 @@ PGSSLKEY="/etc/sensu/tls/sensu-key.pem"
 PGSSLROOTCERT="/etc/sensu/tls/ca.pem"' | sudo tee /etc/sysconfig/sensu-backend
 {{< /code >}}
 
-  {{< code "Ubuntu/Debian" >}}
+  {{< code shell "Debian family" >}}
 echo 'PGUSER=sensu
 PGSSLMODE="verify-full"
 PGSSLCERT="/etc/sensu/tls/sensu.pem"
@@ -281,7 +281,7 @@ scp ca.pem postgres.example.com:/home/user
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/CentOS">}}
+   {{< code shell "RHEL family" >}}
 sudo mkdir /var/lib/pgsql/14/data/tls
 cd /var/lib/pgsql/14/data/tls
 cp /home/user/postgres.example.com* /var/lib/pgsql/14/data/tls/
@@ -289,7 +289,7 @@ cp /home/user/ca.pem /var/lib/pgsql/14/data/tls/
 chown -R postgres:postgres /var/lib/pgsql/14/data
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian">}}
+   {{< code shell "Debian family" >}}
 sudo mkdir /etc/postgresql/14/main/tls
 cd /etc/postgresql/14/main/tls
 cp /home/user/postgres.example.com* /etc/postgresql/14/main/tls/
@@ -303,7 +303,7 @@ chown -R postgres:postgres /etc/postgresql/14/main/
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/CentOS">}}
+   {{< code shell "RHEL family" >}}
 # vim /var/lib/pgsql/14/data/postgresql.conf
 
 # - SSL -
@@ -314,7 +314,7 @@ ssl_cert_file = '/var/lib/pgsql/14/data/tls/postgres.example.com.pem'
 ssl_key_file = '/var/lib/pgsql/14/data/tls/postgres.example.com-key.pem'
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 # vim /etc/postgresql/14/main/postgresql.conf
 
 # - SSL -
@@ -333,7 +333,7 @@ ssl_key_file = '/etc/postgresql/14/main/tls/postgres.example.com-key.pem'
 
    {{< language-toggle >}}
 
-   {{< code shell  "RHEL/CentOS" >}}
+   {{< code shell "RHEL family" >}}
 
 # /var/lib/pgsql/14/data/pg_hba.conf (file location)
 
@@ -345,7 +345,7 @@ hostssl all             postgres        0.0.0.0/0               reject
 hostssl sensu_events    sensu           0.0.0.0/0               cert
 {{< /code >}}
 
-   {{< code shell  "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 
 # /etc/postgresql/14/main/pg_hba.conf (file location)
 
@@ -367,11 +367,11 @@ hostssl sensu_events    sensu           0.0.0.0/0               cert
 
    {{< language-toggle >}}
 
-   {{< code shell "RHEL/Centos" >}}
+   {{< code shell "RHEL family" >}}
 sudo systemctl restart postgresql-14.service
 {{< /code >}}
 
-   {{< code shell "Ubuntu/Debian" >}}
+   {{< code shell "Debian family" >}}
 sudo systemctl restart postgresql.service
 {{< /code >}}
 

--- a/content/sensu-go/6.9/operations/maintain-sensu/migrate.md
+++ b/content/sensu-go/6.9/operations/maintain-sensu/migrate.md
@@ -21,7 +21,7 @@ The step for [translating integrations, contact routing, and LDAP authentication
 Sensu Go includes important changes to all parts of Sensu: architecture, installation, resource definitions, the observation data (event) model, check dependencies, filter evaluation, and more.
 Sensu Go also includes many powerful [commercial features][27] to make monitoring easier to build, scale, and offer as a self-service tool to your internal customers.
 
-Sensu Go is available for [RHEL/CentOS, Debian, Ubuntu, and Docker][43].
+Sensu Go is available for [Debian- and RHEL-family distributions and Docker][43].
 The Sensu Go agent is also available for Windows.
 
 {{% notice warning %}}
@@ -201,7 +201,7 @@ Read the [API overview][17] for more information.
 
 #### 1. Install the Sensu Go backend 
 
-The Sensu backend is available for Ubuntu/Debian, RHEL/CentOS, and Docker.
+The Sensu backend is available for Debian- and RHEL-family distributions and Docker.
 Read the [installation guide][52] to install, configure, and start the Sensu backend according to your [deployment strategy][38].
 
 #### 2. Log in to the Sensu web UI
@@ -232,7 +232,7 @@ In addition to built-in RBAC, Sensu Go's [commercial features][27] include suppo
 
 #### 5. Install agents
 
-The Sensu agent is available for Ubuntu/Debian, RHEL/CentOS, Windows, and Docker.
+The Sensu agent is available for Debian- and RHEL-family distributions, Windows, and Docker.
 Read the [installation guide][55] to install, configure, and start Sensu agents.
 
 If you're doing a side-by-side migration, add `api-port` (default: `3031`) and `socket-port` (default: `3030`) to your [agent configuration][56] (`/etc/sensu/agent.yml` or `C:\ProgramData\sensu\config\agent.yml.example`).

--- a/content/sensu-go/6.9/operations/maintain-sensu/troubleshoot.md
+++ b/content/sensu-go/6.9/operations/maintain-sensu/troubleshoot.md
@@ -32,7 +32,7 @@ Replace the `<service>` variable with the name of the desired service (for examp
 
 {{< language-toggle >}}
 
-{{< code shell "RHEL/CentOS >= 7" >}}
+{{< code shell "RHEL/family >= 7" >}}
 journalctl --follow --unit sensu-<service>
 {{< /code >}}
 
@@ -51,7 +51,7 @@ Replace the `<service>` variable with the name of the desired service (for examp
 
 {{< language-toggle >}}
 
-{{< code shell "RHEL/CentOS <= 6" >}}
+{{< code shell "RHEL/family <= 6" >}}
 tail --follow /var/log/sensu/sensu-<service>
 {{< /code >}}
 

--- a/content/sensu-go/6.9/operations/manage-secrets/secrets-management.md
+++ b/content/sensu-go/6.9/operations/manage-secrets/secrets-management.md
@@ -73,11 +73,11 @@ Then, run the following code, replacing `INTEGRATION_KEY` with your PagerDuty In
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 echo 'SENSU_PAGERDUTY_KEY=INTEGRATION_KEY' | sudo tee -a /etc/default/sensu-backend
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 echo 'SENSU_PAGERDUTY_KEY=INTEGRATION_KEY' | sudo tee -a /etc/sysconfig/sensu-backend
 {{< /code >}}
 

--- a/content/sensu-go/6.9/platforms.md
+++ b/content/sensu-go/6.9/platforms.md
@@ -25,7 +25,7 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensu backend
 
-|  | RHEL/CentOS<br>6, 7, 8, 9 | Debian 8, 9, 10, 11 | Ubuntu 14.04<br>16.04, 18.04, 18.10<br>19.04, 19.10, 20.04<br>22.04 |
+|  | RHEL family<br>6, 7, 8, 9 | Debian 8, 9, 10, 11 | Ubuntu 14.04<br>16.04, 18.04, 18.10<br>19.04, 19.10, 20.04<br>22.04 |
 |----------------------|---------|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} |
 | `arm64` | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -33,7 +33,7 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensu agent
 
-|  | RHEL/<br>CentOS<br>6, 7, 8, 9 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04<br>22.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL<br>family<br>6, 7, 8, 9 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04<br>22.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
@@ -43,7 +43,7 @@ Supported packages for common platforms are available from [sensu/stable][8] on 
 
 ### Sensuctl command line tool
 
-|  | RHEL/<br>CentOS<br>6, 7, 8, 9 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04<br>22.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
+|  | RHEL<br>family<br>6, 7, 8, 9 | Debian<br>8, 9, 10, 11 | Ubuntu<br>14.04<br>16.04<br>18.04<br>18.10<br>19.04<br>19.10<br>20.04<br>22.04 | Windows 7<br>and later | Windows<br>Server<br>2008 R2<br>and later |
 |----------------------|---------|---|---|---|---|
 | `amd64` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |
 | `386` | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} | {{< check >}} |

--- a/content/sensu-go/6.9/plugins/install-plugins.md
+++ b/content/sensu-go/6.9/plugins/install-plugins.md
@@ -106,11 +106,11 @@ To download and update package information:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo apt-get update
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo yum update
 {{< /code >}}
 
@@ -120,11 +120,11 @@ Depending on the plugin, you may need to install developer tool packages:
 
 {{< language-toggle >}}
 
-{{< code shell "Ubuntu/Debian" >}}
+{{< code shell "Debian family" >}}
 sudo apt-get install build-essential
 {{< /code >}}
 
-{{< code shell "RHEL/CentOS" >}}
+{{< code shell "RHEL family" >}}
 sudo yum groupinstall "Development Tools"
 {{< /code >}}
 

--- a/content/sensu-go/6.9/release-notes.md
+++ b/content/sensu-go/6.9/release-notes.md
@@ -217,7 +217,7 @@ This patch release includes a change in how agents execute check requests to pre
 Read the [upgrade guide][1] to upgrade Sensu to version 6.7.3.
 
 **IMPROVEMENTS**
-- ([Commercial feature][268]) Added supported packages for the Sensu backend, Sensu agent, and sensuctl for RHEL/CentOS 9.
+- ([Commercial feature][268]) Added supported packages for the Sensu backend, Sensu agent, and sensuctl for RHEL 9.
 
 **FIXES**
 - ([Commercial feature][268]) When using the business service monitoring (BSM) feature, service component metadata is now included in the [`check` scope][291] of events the service component generates.
@@ -1463,7 +1463,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 5.16.0.
 
 **IMPORTANT:**
 
-- For Ubuntu/Debian and RHEL/CentOS installations, the backend is no longer seeded with a default admin username and password.
+- For Debian- and RHEL-family installations, the backend is no longer seeded with a default admin username and password.
 Users will need to [run 'sensu-backend init'][102] on every new installation and specify an admin username and password.
 
 **NEW FEATURES:**
@@ -1543,14 +1543,14 @@ Read the [blog announcement][91] for more information about our usage policy.
 ## 5.14.2 release notes
 
 **November 4, 2019** &mdash; The latest release of Sensu Go, version 5.14.2, is now available for download.
-This release includes an etcd upgrade, fixes that improve stability and performance, and a Sensu Go package for CentOS 8.
+This release includes an etcd upgrade, fixes that improve stability and performance, and a Sensu Go package for RHEL 8.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 5.14.2.
 
 **IMPROVEMENTS:**
 
 - Upgraded etcd to 3.3.17.
-- Added build package for CentOS 8 (`el/8`).
+- Added build package for RHEL 8 (`el/8`).
 - Sensu Go now uses serializable event reads, which helps improve performance.
 
 **FIXES:**
@@ -1783,8 +1783,8 @@ For a complete list of supported platforms, visit the [platforms page][73].
 - Multiple nested set handlers are now flagged correctly, fixing an issue in which they were flagged as deeply nested.
 - Round robin proxy checks now execute as expected in the event of updated entities.
 - The Sensu backend now avoids situations of high CPU usage in the event that watchers enter a tight loop.
-- Due to incompatibility with the Go programming language, Sensu is incompatible with CentOS/RHEL 5.
-As a result, CentOS/RHEL 5 has been removed as a [supported platform][73] for all versions of Sensu Go.
+- Due to incompatibility with the Go programming language, Sensu is incompatible with RHEL 5.
+As a result, RHEL 5 has been removed as a [supported platform][73] for all versions of Sensu Go.
 
 ## 5.10.2 release notes
 


### PR DESCRIPTION
## Description
Replaces `RHEL/CentOS` with `RHEL family` and `Ubuntu/Debian` with `Debian family` throughout the docs. Makes similar updates in text and in table headings on the supported platforms page.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/4036