### PR TITLE
Remove Graphite as example of format that does not support tags

### DIFF
--- a/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.5/observability-pipeline/observe-schedule/metrics.md
@@ -1033,7 +1033,7 @@ output_metric_tags:
 
 ### Collect metrics in formats that do not support tags
 
-Output metric tags are useful when you want to collect metrics in a format that does not natively support tags, like Graphite Plaintext Protocol or Nagios Performance Data.
+Output metric tags are useful when you want to collect metrics in a format that does not natively support tags, like Nagios Performance Data.
 
 For example, you might want to collect and transmit metrics in Nagios Performance Data format, which does not support tags, and store the metrics in Prometheus, which does support tags.
 In this case, you can specify the tags to include with metrics with output metric tags.

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/metrics.md
@@ -1033,7 +1033,7 @@ output_metric_tags:
 
 ### Collect metrics in formats that do not support tags
 
-Output metric tags are useful when you want to collect metrics in a format that does not natively support tags, like Graphite Plaintext Protocol or Nagios Performance Data.
+Output metric tags are useful when you want to collect metrics in a format that does not natively support tags, like Nagios Performance Data.
 
 For example, you might want to collect and transmit metrics in Nagios Performance Data format, which does not support tags, and store the metrics in Prometheus, which does support tags.
 In this case, you can specify the tags to include with metrics with output metric tags.

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/metrics.md
@@ -1033,7 +1033,7 @@ output_metric_tags:
 
 ### Collect metrics in formats that do not support tags
 
-Output metric tags are useful when you want to collect metrics in a format that does not natively support tags, like Graphite Plaintext Protocol or Nagios Performance Data.
+Output metric tags are useful when you want to collect metrics in a format that does not natively support tags, like Nagios Performance Data.
 
 For example, you might want to collect and transmit metrics in Nagios Performance Data format, which does not support tags, and store the metrics in Prometheus, which does support tags.
 In this case, you can specify the tags to include with metrics with output metric tags.

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/metrics.md
@@ -1033,7 +1033,7 @@ output_metric_tags:
 
 ### Collect metrics in formats that do not support tags
 
-Output metric tags are useful when you want to collect metrics in a format that does not natively support tags, like Graphite Plaintext Protocol or Nagios Performance Data.
+Output metric tags are useful when you want to collect metrics in a format that does not natively support tags, like Nagios Performance Data.
 
 For example, you might want to collect and transmit metrics in Nagios Performance Data format, which does not support tags, and store the metrics in Prometheus, which does support tags.
 In this case, you can specify the tags to include with metrics with output metric tags.

--- a/content/sensu-go/6.9/observability-pipeline/observe-schedule/metrics.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-schedule/metrics.md
@@ -1033,7 +1033,7 @@ output_metric_tags:
 
 ### Collect metrics in formats that do not support tags
 
-Output metric tags are useful when you want to collect metrics in a format that does not natively support tags, like Graphite Plaintext Protocol or Nagios Performance Data.
+Output metric tags are useful when you want to collect metrics in a format that does not natively support tags, like Nagios Performance Data.
 
 For example, you might want to collect and transmit metrics in Nagios Performance Data format, which does not support tags, and store the metrics in Prometheus, which does support tags.
 In this case, you can specify the tags to include with metrics with output metric tags.


### PR DESCRIPTION
## Description
The metrics reference lists Graphite as an example of a format that does not support tags, but it seems Graphite has supported tags since 1.1.x. This PR removes Graphite from the examples.

## Motivation and Context
Found when working on 6.9.0 docs