### PR TITLE
Document catalog object and disable attribute

### DIFF
--- a/content/sensu-go/6.9/api/enterprise/webconfig.md
+++ b/content/sensu-go/6.9/api/enterprise/webconfig.md
@@ -48,6 +48,9 @@ The request results in a successful `HTTP/1.1 200 OK` response and a JSON array 
     },
     "spec": {
       "always_show_local_cluster": false,
+      "catalog": {
+        "disabled": false
+      },
       "default_preferences": {
         "poll_interval": 120000,
         "page_size": 500,
@@ -104,6 +107,9 @@ output         | {{< code text >}}
     },
     "spec": {
       "always_show_local_cluster": false,
+      "catalog": {
+        "disabled": false
+      },
       "default_preferences": {
         "poll_interval": 120000,
         "page_size": 500,
@@ -167,6 +173,9 @@ The request will return a successful `HTTP/1.1 200 OK` response and a JSON map t
   },
   "spec": {
     "always_show_local_cluster": false,
+    "catalog": {
+      "disabled": false
+    },
     "default_preferences": {
       "poll_interval": 120000,
       "page_size": 500,
@@ -221,6 +230,9 @@ output               | {{< code text >}}
   },
   "spec": {
     "always_show_local_cluster": false,
+    "catalog": {
+      "disabled": false
+    },
     "default_preferences": {
       "poll_interval": 120000,
       "page_size": 500,
@@ -277,6 +289,9 @@ curl -X PUT \
   },
   "spec": {
     "always_show_local_cluster": false,
+    "catalog": {
+      "disabled": false
+    },
     "default_preferences": {
       "poll_interval": 120000,
       "page_size": 500,
@@ -331,6 +346,9 @@ payload         | {{< code json >}}
   },
   "spec": {
     "always_show_local_cluster": false,
+    "catalog": {
+      "disabled": false
+    },
     "default_preferences": {
       "poll_interval": 120000,
       "page_size": 500,

--- a/content/sensu-go/6.9/web-ui/webconfig-reference.md
+++ b/content/sensu-go/6.9/web-ui/webconfig-reference.md
@@ -49,6 +49,8 @@ metadata:
 spec:
   signin_message: with your *LDAP or system credentials*
   always_show_local_cluster: false
+  catalog:
+    disabled: false
   default_preferences:
     poll_interval: 120000
     page_size: 50
@@ -84,6 +86,9 @@ spec:
   "spec": {
     "signin_message": "with your *LDAP or system credentials*",
     "always_show_local_cluster": false,
+    "catalog": {
+      "disabled": false
+    },
     "default_preferences": {
       "poll_interval": 120000,
       "page_size": 50,
@@ -187,6 +192,8 @@ example      | {{< language-toggle >}}
 spec:
   signin_message: with your *LDAP or system credentials*
   always_show_local_cluster: false
+  catalog:
+    disabled: false
   default_preferences:
     poll_interval: 120000
     page_size: 50
@@ -216,6 +223,9 @@ spec:
   "spec": {
     "signin_message": "with your *LDAP or system credentials*",
     "always_show_local_cluster": false,
+    "catalog": {
+      "disabled": false
+    },
     "default_preferences": {
       "poll_interval": 120000,
       "page_size": 50,
@@ -319,6 +329,27 @@ always_show_local_cluster: false
 {{< code json >}}
 {
   "always_show_local_cluster": false
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+<a id="catalog-config-object"></a>
+
+catalog      | 
+-------------|------ 
+description  | [Sensu Catalog][14] configuration preferences. Read [Catalog attributes][13] for more information.
+required     | false
+type         | Map of key-value pairs
+example      | {{< language-toggle >}}
+{{< code yml >}}
+catalog:
+  disabled: false
+{{< /code >}}
+{{< code json >}}
+{
+  "catalog": {
+    "disabled": false
+  }
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -452,6 +483,24 @@ signin_message: with your *LDAP or system credentials*
 {{< code json >}}
 {
   "signin_message": "with your *LDAP or system credentials*"
+}
+{{< /code >}}
+{{< /language-toggle >}}
+
+#### Catalog attributes
+
+disabled     | 
+-------------|------ 
+description  | Set to `true` to disable the Sensu Catalog in the web UI. Otherwise, `false`.
+required     | false
+type         | Boolean
+example      | {{< language-toggle >}}
+{{< code yml >}}
+disabled: false
+{{< /code >}}
+{{< code json >}}
+{
+  "disabled": false
 }
 {{< /code >}}
 {{< /language-toggle >}}
@@ -665,3 +714,5 @@ urls:
 [10]: https://www.markdownguide.org/
 [11]: #page-preferences-attribute
 [12]: ../#license-expiration-banner
+[13]: #catalog-attributes
+[14]: ../sensu-catalog/


### PR DESCRIPTION
## Description
Adds minimum documentation for the GlobalConfig `catalog.disable` attribute.

## Motivation and Context
Required due to 6.9.0 fix relevant to the catalog object `disable` attribute (https://github.com/sensu/sensu-enterprise-go/pull/2478) but waiting on more info from AG