### PR TITLE
6.8.2: Correct 6.9 release notes

### DIFF
--- a/content/sensu-go/6.9/release-notes.md
+++ b/content/sensu-go/6.9/release-notes.md
@@ -115,13 +115,12 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
 
 **October 6, 2022** &mdash; The latest release of Sensu Go, version 6.8.2, is now available for download.
 
-Sensu Go 6.8.2 includes logging improvements: logs now include login attempts, check names for failed check execution requests, and backend entity names for agent websocket connections. We also added a label to events with a truncated check output and now automatically restart the agent on Windows platforms after failures. The 6.8.2 patch release also modifies the keepalive startup logic and fixes a number of web UI issues in the Entities and configuration resource pages.
+Sensu Go 6.8.2 includes logging improvements with the addition of check names for failed check execution requests. We also added a label to events with a truncated check output and now automatically restart the agent on Windows platforms after failures. The 6.8.2 patch release also modifies the keepalive startup logic and fixes a number of web UI issues in the Entities and configuration resource pages.
 
 Read the [upgrade guide][1] to upgrade Sensu to version 6.8.2.
 
 **IMPROVEMENTS:**
 
-- Agent websocket connection logging now includes backend entity name.
 - When check output is truncated due to the [max_output_size][302] configuration, the events the check produces will include a `sensu.io/output_truncated_bytes` label.
 - Agent log messages now include the check name when a check execution request fails.
 - On Windows platforms, the Sensu Agent service now automatically restarts after failures.
@@ -139,9 +138,7 @@ Read the [upgrade guide][1] to upgrade Sensu to version 6.8.2.
 - ([Commercial feature][295]) In the web UI, temporarily disabled saved searches on Entity, Services, Silences, and Check pages.
 - ([Commercial feature][295]) In the web UI, fixed a bug that prevented individual resource pages from displaying annotations and labels on initial page load.
 - ([Commercial feature][295]) In the web UI, when users do not have the required permissions to perform a specific action, the action's button is now disabled with a tooltip to explain the reason.
-- Fixed an issue that prevented multi-expression, exclusive event filters set to `deny` from being evaluated properly.
 - Modified keepalive startup so that etcd lease errors will not cause sensu-backend crashes.
-
 
 ## 6.8.1 release notes
 


### PR DESCRIPTION
## Description
Follow-up for https://github.com/sensu/sensu-docs/pull/4096 -- I remembered that the 6.8.2 release notes also need to be fixed in 6.9 docs.