### PR TITLE
Update gitignore for code-workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ static/js/lunr/PagesIndex.json
 mix-manifest.json
 webpack.mix.js
 *.map
-*.code-workspace
+sensu-docs.code-workspace


### PR DESCRIPTION
## Description
Updates the gitignore file to replace `*.code-workspace` with `sensu-docs.code-workspace`

## Motivation and Context
The code-workspace file was included in https://github.com/sensu/sensu-docs/pull/4099