### PR TITLE
Improvements to statsd guide

### DIFF
--- a/content/sensu-go/6.6/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -13,31 +13,19 @@ menu:
     parent: observe-process
 ---
 
+Sensu implements a StatsD listener on its agents.
 [StatsD][1] is a daemon, tool, and protocol that you can use to send, collect, and aggregate custom metrics.
-Services that implement StatsD typically expose UDP port 8125 to receive metrics according to the line protocol `<metricname>:<value>|<type>`.
 
 With StatsD, you can measure anything and everything.
 Collect custom metrics in your code and send them to a StatsD server to monitor applicaton performance.
 Monitor CPU, I/O, and network system levels with collection daemons.
 You can feed the metrics that StatsD aggregates to multiple different backends to store or visualize the data.
 
-## Use Sensu to implement StatsD
-
-Sensu implements a StatsD listener on its agents.
-Each `sensu-agent` listens on the default port 8125 for UDP messages that follow the StatsD line protocol.
-StatsD aggregates the metrics, and Sensu translates them to Sensu metrics and events that can be passed to the event pipeline.
-You can [configure the StatsD listener][4] and access it with the [netcat][4] utility command:
-
-{{< code shell >}}
-echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
-{{< /code >}}
-
-Metrics received through the StatsD listener are not stored in etcd.
-Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like [InfluxDB][3]).
+Services that implement StatsD typically expose UDP port 8125 to receive metrics according to the line protocol `<metricname>:<value>|<type>`.
 
 ## Configure the StatsD listener
 
-Use configuration flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
+Use configuration flags to configure the Sensu StatsD Server when you start up a Sensu agent.
 
 The following flags allow you to configure event handlers, flush interval, address, and port:
 
@@ -55,18 +43,31 @@ For example:
 sensu-agent start --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd-metrics-host "123.4.5.6" --statsd-metrics-port 8125
 {{< /code >}}
 
-## Next steps
+Each Sensu agent listens on the default port 8125 for UDP messages that follow the StatsD line protocol.
+StatsD aggregates the metrics, and Sensu translates them to Sensu metrics and events that can be passed to the event pipeline.
+
+## Access the StatsD listener
+
+After you configure the StatsD listener, access it with the netcat utility command:
+
+{{< code shell >}}
+echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
+{{< /code >}}
+
+Metrics received through the StatsD listener are not stored in etcd.
+Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like InfluxDB).
+
+## What's next
 
 Now that you know how to feed StatsD metrics into Sensu, check out these resources to learn how to handle the StatsD metrics:
 
+* [InfluxDB handler guide][3]: instructions for using Sensu's built-in metric handler
 * [Handlers reference][2]: in-depth documentation for Sensu handlers
-* [InfluxDB handler guide][3]: instructions on Sensu's built-in metric handler
 * [Pipelines reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
 
 
 [1]: https://github.com/statsd/statsd
 [2]: ../handlers/
 [3]: ../populate-metrics-influxdb/
-[4]: #configure-the-statsd-listener
-[5]: https://github.com/statsd/statsd
+[4]: https://nc110.sourceforge.io/
 [6]: ../pipelines/

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -13,31 +13,19 @@ menu:
     parent: observe-process
 ---
 
+Sensu implements a StatsD listener on its agents.
 [StatsD][1] is a daemon, tool, and protocol that you can use to send, collect, and aggregate custom metrics.
-Services that implement StatsD typically expose UDP port 8125 to receive metrics according to the line protocol `<metricname>:<value>|<type>`.
 
 With StatsD, you can measure anything and everything.
 Collect custom metrics in your code and send them to a StatsD server to monitor applicaton performance.
 Monitor CPU, I/O, and network system levels with collection daemons.
 You can feed the metrics that StatsD aggregates to multiple different backends to store or visualize the data.
 
-## Use Sensu to implement StatsD
-
-Sensu implements a StatsD listener on its agents.
-Each `sensu-agent` listens on the default port 8125 for UDP messages that follow the StatsD line protocol.
-StatsD aggregates the metrics, and Sensu translates them to Sensu metrics and events that can be passed to the event pipeline.
-You can [configure the StatsD listener][4] and access it with the [netcat][4] utility command:
-
-{{< code shell >}}
-echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
-{{< /code >}}
-
-Metrics received through the StatsD listener are not stored in etcd.
-Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like [InfluxDB][3]).
+Services that implement StatsD typically expose UDP port 8125 to receive metrics according to the line protocol `<metricname>:<value>|<type>`.
 
 ## Configure the StatsD listener
 
-Use configuration flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
+Use configuration flags to configure the Sensu StatsD Server when you start up a Sensu agent.
 
 The following flags allow you to configure event handlers, flush interval, address, and port:
 
@@ -55,18 +43,31 @@ For example:
 sensu-agent start --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd-metrics-host "123.4.5.6" --statsd-metrics-port 8125
 {{< /code >}}
 
-## Next steps
+Each Sensu agent listens on the default port 8125 for UDP messages that follow the StatsD line protocol.
+StatsD aggregates the metrics, and Sensu translates them to Sensu metrics and events that can be passed to the event pipeline.
+
+## Access the StatsD listener
+
+After you configure the StatsD listener, access it with the netcat utility command:
+
+{{< code shell >}}
+echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
+{{< /code >}}
+
+Metrics received through the StatsD listener are not stored in etcd.
+Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like InfluxDB).
+
+## What's next
 
 Now that you know how to feed StatsD metrics into Sensu, check out these resources to learn how to handle the StatsD metrics:
 
+* [InfluxDB handler guide][3]: instructions for using Sensu's built-in metric handler
 * [Handlers reference][2]: in-depth documentation for Sensu handlers
-* [InfluxDB handler guide][3]: instructions on Sensu's built-in metric handler
 * [Pipelines reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
 
 
 [1]: https://github.com/statsd/statsd
 [2]: ../handlers/
 [3]: ../populate-metrics-influxdb/
-[4]: #configure-the-statsd-listener
-[5]: https://github.com/statsd/statsd
+[4]: https://nc110.sourceforge.io/
 [6]: ../pipelines/

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -13,31 +13,19 @@ menu:
     parent: observe-process
 ---
 
+Sensu implements a StatsD listener on its agents.
 [StatsD][1] is a daemon, tool, and protocol that you can use to send, collect, and aggregate custom metrics.
-Services that implement StatsD typically expose UDP port 8125 to receive metrics according to the line protocol `<metricname>:<value>|<type>`.
 
 With StatsD, you can measure anything and everything.
 Collect custom metrics in your code and send them to a StatsD server to monitor applicaton performance.
 Monitor CPU, I/O, and network system levels with collection daemons.
 You can feed the metrics that StatsD aggregates to multiple different backends to store or visualize the data.
 
-## Use Sensu to implement StatsD
-
-Sensu implements a StatsD listener on its agents.
-Each `sensu-agent` listens on the default port 8125 for UDP messages that follow the StatsD line protocol.
-StatsD aggregates the metrics, and Sensu translates them to Sensu metrics and events that can be passed to the event pipeline.
-You can [configure the StatsD listener][4] and access it with the [netcat][4] utility command:
-
-{{< code shell >}}
-echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
-{{< /code >}}
-
-Metrics received through the StatsD listener are not stored in etcd.
-Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like [InfluxDB][3]).
+Services that implement StatsD typically expose UDP port 8125 to receive metrics according to the line protocol `<metricname>:<value>|<type>`.
 
 ## Configure the StatsD listener
 
-Use configuration flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
+Use configuration flags to configure the Sensu StatsD Server when you start up a Sensu agent.
 
 The following flags allow you to configure event handlers, flush interval, address, and port:
 
@@ -55,18 +43,31 @@ For example:
 sensu-agent start --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd-metrics-host "123.4.5.6" --statsd-metrics-port 8125
 {{< /code >}}
 
-## Next steps
+Each Sensu agent listens on the default port 8125 for UDP messages that follow the StatsD line protocol.
+StatsD aggregates the metrics, and Sensu translates them to Sensu metrics and events that can be passed to the event pipeline.
+
+## Access the StatsD listener
+
+After you configure the StatsD listener, access it with the netcat utility command:
+
+{{< code shell >}}
+echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
+{{< /code >}}
+
+Metrics received through the StatsD listener are not stored in etcd.
+Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like InfluxDB).
+
+## What's next
 
 Now that you know how to feed StatsD metrics into Sensu, check out these resources to learn how to handle the StatsD metrics:
 
+* [InfluxDB handler guide][3]: instructions for using Sensu's built-in metric handler
 * [Handlers reference][2]: in-depth documentation for Sensu handlers
-* [InfluxDB handler guide][3]: instructions on Sensu's built-in metric handler
 * [Pipelines reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
 
 
 [1]: https://github.com/statsd/statsd
 [2]: ../handlers/
 [3]: ../populate-metrics-influxdb/
-[4]: #configure-the-statsd-listener
-[5]: https://github.com/statsd/statsd
+[4]: https://nc110.sourceforge.io/
 [6]: ../pipelines/

--- a/content/sensu-go/6.9/observability-pipeline/observe-process/aggregate-metrics-statsd.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-process/aggregate-metrics-statsd.md
@@ -13,31 +13,19 @@ menu:
     parent: observe-process
 ---
 
+Sensu implements a StatsD listener on its agents.
 [StatsD][1] is a daemon, tool, and protocol that you can use to send, collect, and aggregate custom metrics.
-Services that implement StatsD typically expose UDP port 8125 to receive metrics according to the line protocol `<metricname>:<value>|<type>`.
 
 With StatsD, you can measure anything and everything.
 Collect custom metrics in your code and send them to a StatsD server to monitor applicaton performance.
 Monitor CPU, I/O, and network system levels with collection daemons.
 You can feed the metrics that StatsD aggregates to multiple different backends to store or visualize the data.
 
-## Use Sensu to implement StatsD
-
-Sensu implements a StatsD listener on its agents.
-Each `sensu-agent` listens on the default port 8125 for UDP messages that follow the StatsD line protocol.
-StatsD aggregates the metrics, and Sensu translates them to Sensu metrics and events that can be passed to the event pipeline.
-You can [configure the StatsD listener][4] and access it with the [netcat][4] utility command:
-
-{{< code shell >}}
-echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
-{{< /code >}}
-
-Metrics received through the StatsD listener are not stored in etcd.
-Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like [InfluxDB][3]).
+Services that implement StatsD typically expose UDP port 8125 to receive metrics according to the line protocol `<metricname>:<value>|<type>`.
 
 ## Configure the StatsD listener
 
-Use configuration flags to configure the Sensu StatsD Server when you start up a `sensu-agent`.
+Use configuration flags to configure the Sensu StatsD Server when you start up a Sensu agent.
 
 The following flags allow you to configure event handlers, flush interval, address, and port:
 
@@ -55,18 +43,31 @@ For example:
 sensu-agent start --statsd-event-handlers influx-db --statsd-flush-interval 1 --statsd-metrics-host "123.4.5.6" --statsd-metrics-port 8125
 {{< /code >}}
 
-## Next steps
+Each Sensu agent listens on the default port 8125 for UDP messages that follow the StatsD line protocol.
+StatsD aggregates the metrics, and Sensu translates them to Sensu metrics and events that can be passed to the event pipeline.
+
+## Access the StatsD listener
+
+After you configure the StatsD listener, access it with the netcat utility command:
+
+{{< code shell >}}
+echo 'abc.def.g:10|c' | nc -w1 -u localhost 8125
+{{< /code >}}
+
+Metrics received through the StatsD listener are not stored in etcd.
+Instead, you must configure event handlers to send the data to a storage solution (for example, a time-series database like InfluxDB).
+
+## What's next
 
 Now that you know how to feed StatsD metrics into Sensu, check out these resources to learn how to handle the StatsD metrics:
 
+* [InfluxDB handler guide][3]: instructions for using Sensu's built-in metric handler
 * [Handlers reference][2]: in-depth documentation for Sensu handlers
-* [InfluxDB handler guide][3]: instructions on Sensu's built-in metric handler
 * [Pipelines reference][6]: information about the Sensu pipeline resource, which you can use to create event processing workflows with event filters, mutators, and handlers
 
 
 [1]: https://github.com/statsd/statsd
 [2]: ../handlers/
 [3]: ../populate-metrics-influxdb/
-[4]: #configure-the-statsd-listener
-[5]: https://github.com/statsd/statsd
+[4]: https://nc110.sourceforge.io/
 [6]: ../pipelines/


### PR DESCRIPTION
## Description
Improves https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/aggregate-metrics-statsd/ by removing links in the main body of the instructions, reordering the instructions so that setup comes before usage, and moving exposition from the instructions to the introduction. 

## Motivation and Context
Relevant to https://github.com/sensu/sensu-docs/issues/4034