### PR TITLE
Correct docs landing page link to catalog pages

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -61,11 +61,11 @@
       <!--Source at https://lucid.app/lucidchart/invitations/accept/inv_68eb508a-78c5-4bf1-ad5f-3b9e135c9107--> </svg>
     </div>
     <div class="inline">
-        <a class="catalog" href="./sensu-go/latest/web-ui/sensu-catalog/">
+        <a class="catalog" href="./sensu-go/latest/catalog/sensu-catalog/">
           <h2>Sensu Catalog</h2>
           <p>Use our self-service online marketplace to integrate with the tools, products, and services you rely on.<br><br>Catalog integrations include baseline configurations so you can deploy Sensu's comprehensive infrastructure and application monitoring solutions in minutes.</p>
         </a>
-        <a href="./sensu-go/latest/web-ui/sensu-catalog/">
+        <a href="./sensu-go/latest/catalog/sensu-catalog/">
           <img src="/images/catalog_landing_page.png" alt="Sensu Catalog" />
         </a>
     </div>


### PR DESCRIPTION
## Description
Corrects the link to catalog pages on the docs landing page (from `web-ui/sensu-catalog/` to `catalog/sensu-catalog/`)

## Motivation and Context
Found when working on accessibility project