### PR TITLE
Fix commercial features link on Catalog index page

### DIFF
--- a/content/sensu-go/6.7/catalog/_index.md
+++ b/content/sensu-go/6.7/catalog/_index.md
@@ -13,7 +13,7 @@ menu:
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Catalog in the packaged Sensu Go distribution.
-For more information, read [Get started with commercial features](../../commercial/).
+For more information, read [Get started with commercial features](../commercial/).
 {{% /notice %}}
 
 {{% notice note %}}

--- a/content/sensu-go/6.8/catalog/_index.md
+++ b/content/sensu-go/6.8/catalog/_index.md
@@ -13,7 +13,7 @@ menu:
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Catalog in the packaged Sensu Go distribution.
-For more information, read [Get started with commercial features](../../commercial/).
+For more information, read [Get started with commercial features](../commercial/).
 {{% /notice %}}
 
 {{% notice note %}}

--- a/content/sensu-go/6.9/catalog/_index.md
+++ b/content/sensu-go/6.9/catalog/_index.md
@@ -13,7 +13,7 @@ menu:
 
 {{% notice commercial %}}
 **COMMERCIAL FEATURE**: Access the Sensu Catalog in the packaged Sensu Go distribution.
-For more information, read [Get started with commercial features](../../commercial/).
+For more information, read [Get started with commercial features](../commercial/).
 {{% /notice %}}
 
 {{% notice note %}}


### PR DESCRIPTION
## Description
Fixes link to commercial features page in notice at the top of the Sensu Catalog category index page.