### PR TITLE
Use a higher-contrast color for older/prerelease banner

### DIFF
--- a/layouts/partials/alertSection.html
+++ b/layouts/partials/alertSection.html
@@ -4,7 +4,7 @@
   {{ if and (isset .Params "version") (ne $product_info.latest .Params.version) }}
     {{ $message := (printf "You're viewing documentation for an older or pre-release version of %s. Click here for the latest." .Params.product) }}
     {{ $link := replace .RelPermalink .Params.version $product_info.latest }}
-    {{ $params := slice "#d5ab73" $message $link }}
+    {{ $params := slice "#7a4595" $message $link }}
     {{ partial "alert" $params }}
   {{ end }}
 </div>


### PR DESCRIPTION
## Description
Changes color in https://github.com/sensu/sensu-docs/blob/main/layouts/partials/alertSection.html from `d5ab73` to `7a4595`.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/4092