### PR TITLE
Improve silencing guide

### DIFF
--- a/content/sensu-go/6.6/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -21,7 +21,7 @@ This guide explains how to use a proxy entity to monitor website status, as well
 
 ## Requirements
 
-To follow this guide, install the Sensu [backend][19], make sure at least one Sensu [agent][30] is running, and configure [sensuctl][31] to connect to the backend as the [`admin` user][32].
+To follow this guide, install the Sensu [backend][19], make sure at least one Sensu [agent][31] is running, and configure [sensuctl][30] to connect to the backend as the [`admin` user][32].
 
 ## Use a proxy entity to monitor a website
 
@@ -471,6 +471,8 @@ Follow any of these guides to learn how to configure event filters, handlers, an
 * [Send PagerDuty alerts with Sensu][6]
 * [Send Slack alerts with a pipeline][7]
 
+You can also send metrics and status data to [Sumo Logic][33].
+
 Read more about the Sensu features you used in this guide:
 
 - [Dynamic runtime assets][13] and [sensu/http-checks][16]
@@ -511,3 +513,4 @@ Monitoring as code makes it possible to move to a more robust deployment without
 [30]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [31]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [32]: ../../../operations/control-access/rbac/#default-users
+[33]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/plan-maintenance.md
@@ -20,7 +20,9 @@ This feature is useful when you're planning maintenance.
 You can configure silences to prevent handlers from taking actions based on check name, entity subscription, entity name, or a combination of these factors.
 In this guide, you'll create a silenced entry for a specific entity and its associated check to prevent alerts and create a time window for maintenance.
 
-To follow this guide, you’ll need to [install][10] the Sensu backend, have at least one Sensu agent running, and install and configure sensuctl.
+## Requirements
+
+To follow this guide, install the Sensu [backend][10], make sure at least one Sensu [agent][21] is running, and configure [sensuctl][22] to connect to the backend as the [`admin` user][23].
 
 {{% notice note %}}
 **NOTE**: If you already have an entity and running check to use as the silencing target, skip ahead to [Create the silenced entry](#create-the-silenced-entry).
@@ -55,8 +57,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the http-checks dynamic runtime asset
 
-To power the check in your silenced entry, you'll use the [sensu/http-checks][12] dynamic runtime asset.
-This community-tier asset includes `http-check`, the http status check command that [your check][11] will rely on.
+To power the check in your silenced entry, you'll use the sensu/http-checks dynamic runtime asset.
+This community-tier asset includes `http-check`, the http status check command that your check will rely on.
 
 Register the sensu/http-checks dynamic runtime asset:
 
@@ -88,7 +90,6 @@ The response should list the sensu/http-checks dynamic runtime asset (renamed to
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create the check
@@ -178,11 +179,6 @@ sensuctl silenced create \
 --reason 'Planned site maintenance'
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: Sensuctl supports several [time formats](../../../sensuctl/create-manage-resources/#time-formats) for the `begin` flag.
-This example uses [RFC 3339 format](https://www.ietf.org/rfc/rfc3339.txt) with space delimiters and numeric zone offset.
-{{% /notice %}}
-
 Use sensuctl to verify that the silenced entry against the entity `sensu-site` was created properly:
 
 {{< language-toggle >}}
@@ -239,7 +235,7 @@ spec:
 
 {{< /language-toggle >}}
 
-## Next steps
+## What's next
 
 When your silence goes into effect at the designated `begin` time, you will still see events for `check-http` on the `sensu-site` entity in the Sensu web UI.
 This is because **silences do not stop events from being produced &mdash; they stop events from being handled**.
@@ -254,19 +250,15 @@ The pipeline must include a workflow with the built-in [`not_silenced`][13] even
 
 Follow one of these guides to add a pipeline to your check:
 
-- [Send data to Sumo Logic with Sensu][16]
 - [Send email alerts with a pipeline][17]
 - [Send PagerDuty alerts with Sensu][18]
 - [Send Slack alerts with a pipeline][19]
 
-Read the [silencing reference][7] for in-depth documentation about silenced entries and more examples:
+Read the [silencing reference][7] for in-depth documentation about silenced entries and more examples for other silencing scenarios.
 
-- [Silence all checks on a specific entity][2]
-- [Silence a specific check on a specific entity][3]
-- [Silence all checks with a specific subscription][4]
-- [Silence all checks for entities with a specific subscription][9]
-- [Silence a specific check on entities with a specific subscription][5]
-- [Silence a specific check on every entity][6]
+Learn more about the [sensu/http-checks][12] [dynamic runtime asset][24].
+
+The example in this guide uses [RFC 3339 format][25] with space delimiters and numeric zone offset, but sensuctl supports several [time formats][26] for the `begin` flag.
 
 
 [1]: ../handlers/
@@ -278,7 +270,7 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [7]: ../silencing/
 [8]: ../../../sensuctl/create-manage-resources/#time-formats
 [9]: ../silencing/#silence-all-checks-for-entities-with-a-specific-subscription
-[10]: ../../../operations/deploy-sensu/install-sensu/
+[10]: ../../../operations/deploy-sensu/install-sensu/#install-the-sensu-backend
 [11]: #create-the-check
 [12]: https://bonsai.sensu.io/assets/sensu/http-checks
 [13]: ../../observe-filter/filters/#built-in-filter-not_silenced
@@ -289,3 +281,9 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [18]: ../send-pagerduty-alerts/
 [19]: ../send-slack-alerts/
 [20]: https://www.ietf.org/rfc/rfc3339.txt
+[21]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
+[22]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[23]: ../../../operations/control-access/rbac/#default-users
+[24]: ../../../plugins/assets/
+[25]: https://www.ietf.org/rfc/rfc3339.txt
+[26]: ../../../sensuctl/create-manage-resources/#time-formats

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -450,8 +450,7 @@ The event will include a top-level metrics section populated with metrics points
 
 ## What's next
 
-Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5].
-For a turnkey experience with the Sensu InfluxDB Handler plugin, use our curated, configurable [quick-start template][6] to integrate Sensu with your existing workflows and store Sensu metrics in InfluxDB.
+Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5] or [send data to Sumo Logic][20].
 
 Read [Monitor server resources with checks][2] to learn how to monitor an NGINX webserver rather than collect metrics.
 You can also learn to use Sensu to [collect Prometheus metrics][14].
@@ -487,3 +486,4 @@ Visit Bonsai, the Sensu asset index, for more information about the [sensu/http-
 [17]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [18]: ../../observe-process/handlers/
 [19]: ../../../plugins/assets/
+[20]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -20,7 +20,7 @@ This guide includes two check examples to help you monitor server resources: spe
 
 ## Requirements
 
-To follow this guide, install the Sensu [backend][4], make sure at least one Sensu [agent][17] is running, and configure [sensuctl][18] to connect to the backend as the [`admin` user][19].
+To follow this guide, install the Sensu [backend][4], make sure at least one Sensu [agent][18] is running, and configure [sensuctl][17] to connect to the backend as the [`admin` user][19].
 
 ## Configure a Sensu entity
 
@@ -512,6 +512,7 @@ Now that you know how to create checks to monitor CPU usage and NGINX webserver 
 Or, learn how to [collect and analyze metrics][7] or [monitor external resources with proxy checks and entities][5].
 
 You can also create pipelines to send alerts to [email][13], [PagerDuty][9], or [Slack][6] based on the status events your checks are generating.
+Or, send status and metrics data to [Sumo Logic][20].
 Read the [pipelines reference][10] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
 
 To share, reuse, and maintain the checks you created in this guide just like you would code, [save the check definitions to a file][11] and start building a [monitoring as code repository][12].
@@ -538,3 +539,4 @@ Learn more about the [dynamic runtime assets][2] this guide uses: [sensu/check-c
 [17]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [18]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [19]: ../../../operations/control-access/rbac/#default-users
+[20]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.6/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -516,6 +516,8 @@ Learn more about the Sensu resources you created in this guide:
 - [Handlers][12] and [pipelines][20]
 - [Subscriptions][16]
 
+Now that you know how to extract metrics from check output, you can use a pipeline to [send data to Sumo Logic][23].
+
 Visit Bonsai, the Sensu asset index, for more information about the [sensu/sensu-influxdb-handler][18] and [sensu/sensu-prometheus-collector][19] assets.
 With the sensu/sensu-prometheus-collector in your Sensu ecosystem, you can use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
@@ -544,3 +546,4 @@ Read about [sensuctl][15] and the Sensu [web UI][14] to learn how to use these f
 [20]: ../../observe-process/pipelines/
 [21]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [22]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[23]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.7/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -26,7 +26,7 @@ This guide also explains how to use [proxy checks to monitor a group of websites
 
 ## Requirements
 
-To follow this guide, install the Sensu [backend][19], make sure at least one Sensu [agent][30] is running, and configure [sensuctl][31] to connect to the backend as the [`admin` user][32].
+To follow this guide, install the Sensu [backend][19], make sure at least one Sensu [agent][31] is running, and configure [sensuctl][30] to connect to the backend as the [`admin` user][32].
 
 ## Use a proxy entity to monitor a website (Sensu Catalog configuration)
 
@@ -554,6 +554,8 @@ Follow any of these guides to learn how to configure event filters, handlers, an
 * [Send PagerDuty alerts with Sensu][6]
 * [Send Slack alerts with a pipeline][7]
 
+You can also send metrics and status data to [Sumo Logic][33].
+
 Read more about the Sensu features you used in this guide:
 
 - [Sensu Catalog][25]
@@ -601,3 +603,4 @@ Monitoring as code makes it possible to move to a more robust deployment without
 [30]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [31]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [32]: ../../../operations/control-access/rbac/#default-users
+[33]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/plan-maintenance.md
@@ -20,7 +20,9 @@ This feature is useful when you're planning maintenance.
 You can configure silences to prevent handlers from taking actions based on check name, entity subscription, entity name, or a combination of these factors.
 In this guide, you'll create a silenced entry for a specific entity and its associated check to prevent alerts and create a time window for maintenance.
 
-To follow this guide, you’ll need to [install][10] the Sensu backend, have at least one Sensu agent running, and install and configure sensuctl.
+## Requirements
+
+To follow this guide, install the Sensu [backend][10], make sure at least one Sensu [agent][21] is running, and configure [sensuctl][22] to connect to the backend as the [`admin` user][23].
 
 {{% notice note %}}
 **NOTE**: If you already have an entity and running check to use as the silencing target, skip ahead to [Create the silenced entry](#create-the-silenced-entry).
@@ -55,8 +57,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the http-checks dynamic runtime asset
 
-To power the check in your silenced entry, you'll use the [sensu/http-checks][12] dynamic runtime asset.
-This community-tier asset includes `http-check`, the http status check command that [your check][11] will rely on.
+To power the check in your silenced entry, you'll use the sensu/http-checks dynamic runtime asset.
+This community-tier asset includes `http-check`, the http status check command that your check will rely on.
 
 Register the sensu/http-checks dynamic runtime asset:
 
@@ -88,7 +90,6 @@ The response should list the sensu/http-checks dynamic runtime asset (renamed to
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create the check
@@ -178,11 +179,6 @@ sensuctl silenced create \
 --reason 'Planned site maintenance'
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: Sensuctl supports several [time formats](../../../sensuctl/create-manage-resources/#time-formats) for the `begin` flag.
-This example uses [RFC 3339 format](https://www.ietf.org/rfc/rfc3339.txt) with space delimiters and numeric zone offset.
-{{% /notice %}}
-
 Use sensuctl to verify that the silenced entry against the entity `sensu-site` was created properly:
 
 {{< language-toggle >}}
@@ -239,7 +235,7 @@ spec:
 
 {{< /language-toggle >}}
 
-## Next steps
+## What's next
 
 When your silence goes into effect at the designated `begin` time, you will still see events for `check-http` on the `sensu-site` entity in the Sensu web UI.
 This is because **silences do not stop events from being produced &mdash; they stop events from being handled**.
@@ -254,19 +250,15 @@ The pipeline must include a workflow with the built-in [`not_silenced`][13] even
 
 Follow one of these guides to add a pipeline to your check:
 
-- [Send data to Sumo Logic with Sensu][16]
 - [Send email alerts with a pipeline][17]
 - [Send PagerDuty alerts with Sensu][18]
 - [Send Slack alerts with a pipeline][19]
 
-Read the [silencing reference][7] for in-depth documentation about silenced entries and more examples:
+Read the [silencing reference][7] for in-depth documentation about silenced entries and more examples for other silencing scenarios.
 
-- [Silence all checks on a specific entity][2]
-- [Silence a specific check on a specific entity][3]
-- [Silence all checks with a specific subscription][4]
-- [Silence all checks for entities with a specific subscription][9]
-- [Silence a specific check on entities with a specific subscription][5]
-- [Silence a specific check on every entity][6]
+Learn more about the [sensu/http-checks][12] [dynamic runtime asset][24].
+
+The example in this guide uses [RFC 3339 format][25] with space delimiters and numeric zone offset, but sensuctl supports several [time formats][26] for the `begin` flag.
 
 
 [1]: ../handlers/
@@ -278,7 +270,7 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [7]: ../silencing/
 [8]: ../../../sensuctl/create-manage-resources/#time-formats
 [9]: ../silencing/#silence-all-checks-for-entities-with-a-specific-subscription
-[10]: ../../../operations/deploy-sensu/install-sensu/
+[10]: ../../../operations/deploy-sensu/install-sensu/#install-the-sensu-backend
 [11]: #create-the-check
 [12]: https://bonsai.sensu.io/assets/sensu/http-checks
 [13]: ../../observe-filter/filters/#built-in-filter-not_silenced
@@ -289,3 +281,9 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [18]: ../send-pagerduty-alerts/
 [19]: ../send-slack-alerts/
 [20]: https://www.ietf.org/rfc/rfc3339.txt
+[21]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
+[22]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[23]: ../../../operations/control-access/rbac/#default-users
+[24]: ../../../plugins/assets/
+[25]: https://www.ietf.org/rfc/rfc3339.txt
+[26]: ../../../sensuctl/create-manage-resources/#time-formats

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -455,8 +455,7 @@ The event will include a top-level metrics section populated with metrics points
 
 ## What's next
 
-Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5].
-For a turnkey experience with the Sensu InfluxDB Handler plugin, use our curated, configurable [quick-start template][6] to integrate Sensu with your existing workflows and store Sensu metrics in InfluxDB.
+Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5] or [send data to Sumo Logic][20].
 
 Read [Monitor server resources with checks][2] to learn how to monitor an NGINX webserver rather than collect metrics.
 You can also learn to use Sensu to [collect Prometheus metrics][14].
@@ -492,3 +491,4 @@ Visit Bonsai, the Sensu asset index, for more information about the [sensu/http-
 [17]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [18]: ../../observe-process/handlers/
 [19]: ../../../plugins/assets/
+[20]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -20,7 +20,7 @@ This guide includes two check examples to help you monitor server resources: spe
 
 ## Requirements
 
-To follow this guide, install the Sensu [backend][4], make sure at least one Sensu [agent][17] is running, and configure [sensuctl][18] to connect to the backend as the [`admin` user][19].
+To follow this guide, install the Sensu [backend][4], make sure at least one Sensu [agent][18] is running, and configure [sensuctl][17] to connect to the backend as the [`admin` user][19].
 
 ## Configure a Sensu entity
 
@@ -512,6 +512,7 @@ Now that you know how to create checks to monitor CPU usage and NGINX webserver 
 Or, learn how to [collect and analyze metrics][7] or [monitor external resources with proxy checks and entities][5].
 
 You can also create pipelines to send alerts to [email][13], [PagerDuty][9], or [Slack][6] based on the status events your checks are generating.
+Or, send status and metrics data to [Sumo Logic][20].
 Read the [pipelines reference][10] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
 
 To share, reuse, and maintain the checks you created in this guide just like you would code, [save the check definitions to a file][11] and start building a [monitoring as code repository][12].
@@ -538,3 +539,4 @@ Learn more about the [dynamic runtime assets][2] this guide uses: [sensu/check-c
 [17]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [18]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [19]: ../../../operations/control-access/rbac/#default-users
+[20]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.7/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -516,6 +516,8 @@ Learn more about the Sensu resources you created in this guide:
 - [Handlers][12] and [pipelines][20]
 - [Subscriptions][16]
 
+Now that you know how to extract metrics from check output, you can use a pipeline to [send data to Sumo Logic][23].
+
 Visit Bonsai, the Sensu asset index, for more information about the [sensu/sensu-influxdb-handler][18] and [sensu/sensu-prometheus-collector][19] assets.
 With the sensu/sensu-prometheus-collector in your Sensu ecosystem, you can use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
@@ -544,3 +546,4 @@ Read about [sensuctl][15] and the Sensu [web UI][14] to learn how to use these f
 [20]: ../../observe-process/pipelines/
 [21]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [22]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[23]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.8/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -26,7 +26,7 @@ This guide also explains how to use [proxy checks to monitor a group of websites
 
 ## Requirements
 
-To follow this guide, install the Sensu [backend][19], make sure at least one Sensu [agent][30] is running, and configure [sensuctl][31] to connect to the backend as the [`admin` user][32].
+To follow this guide, install the Sensu [backend][19], make sure at least one Sensu [agent][31] is running, and configure [sensuctl][30] to connect to the backend as the [`admin` user][32].
 
 ## Use a proxy entity to monitor a website (Sensu Catalog configuration)
 
@@ -554,6 +554,8 @@ Follow any of these guides to learn how to configure event filters, handlers, an
 * [Send PagerDuty alerts with Sensu][6]
 * [Send Slack alerts with a pipeline][7]
 
+You can also send metrics and status data to [Sumo Logic][33].
+
 Read more about the Sensu features you used in this guide:
 
 - [Sensu Catalog][25]
@@ -601,3 +603,4 @@ Monitoring as code makes it possible to move to a more robust deployment without
 [30]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [31]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [32]: ../../../operations/control-access/rbac/#default-users
+[33]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/plan-maintenance.md
@@ -20,7 +20,9 @@ This feature is useful when you're planning maintenance.
 You can configure silences to prevent handlers from taking actions based on check name, entity subscription, entity name, or a combination of these factors.
 In this guide, you'll create a silenced entry for a specific entity and its associated check to prevent alerts and create a time window for maintenance.
 
-To follow this guide, you’ll need to [install][10] the Sensu backend, have at least one Sensu agent running, and install and configure sensuctl.
+## Requirements
+
+To follow this guide, install the Sensu [backend][10], make sure at least one Sensu [agent][21] is running, and configure [sensuctl][22] to connect to the backend as the [`admin` user][23].
 
 {{% notice note %}}
 **NOTE**: If you already have an entity and running check to use as the silencing target, skip ahead to [Create the silenced entry](#create-the-silenced-entry).
@@ -55,8 +57,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the http-checks dynamic runtime asset
 
-To power the check in your silenced entry, you'll use the [sensu/http-checks][12] dynamic runtime asset.
-This community-tier asset includes `http-check`, the http status check command that [your check][11] will rely on.
+To power the check in your silenced entry, you'll use the sensu/http-checks dynamic runtime asset.
+This community-tier asset includes `http-check`, the http status check command that your check will rely on.
 
 Register the sensu/http-checks dynamic runtime asset:
 
@@ -88,7 +90,6 @@ The response should list the sensu/http-checks dynamic runtime asset (renamed to
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create the check
@@ -178,11 +179,6 @@ sensuctl silenced create \
 --reason 'Planned site maintenance'
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: Sensuctl supports several [time formats](../../../sensuctl/create-manage-resources/#time-formats) for the `begin` flag.
-This example uses [RFC 3339 format](https://www.ietf.org/rfc/rfc3339.txt) with space delimiters and numeric zone offset.
-{{% /notice %}}
-
 Use sensuctl to verify that the silenced entry against the entity `sensu-site` was created properly:
 
 {{< language-toggle >}}
@@ -239,7 +235,7 @@ spec:
 
 {{< /language-toggle >}}
 
-## Next steps
+## What's next
 
 When your silence goes into effect at the designated `begin` time, you will still see events for `check-http` on the `sensu-site` entity in the Sensu web UI.
 This is because **silences do not stop events from being produced &mdash; they stop events from being handled**.
@@ -254,19 +250,15 @@ The pipeline must include a workflow with the built-in [`not_silenced`][13] even
 
 Follow one of these guides to add a pipeline to your check:
 
-- [Send data to Sumo Logic with Sensu][16]
 - [Send email alerts with a pipeline][17]
 - [Send PagerDuty alerts with Sensu][18]
 - [Send Slack alerts with a pipeline][19]
 
-Read the [silencing reference][7] for in-depth documentation about silenced entries and more examples:
+Read the [silencing reference][7] for in-depth documentation about silenced entries and more examples for other silencing scenarios.
 
-- [Silence all checks on a specific entity][2]
-- [Silence a specific check on a specific entity][3]
-- [Silence all checks with a specific subscription][4]
-- [Silence all checks for entities with a specific subscription][9]
-- [Silence a specific check on entities with a specific subscription][5]
-- [Silence a specific check on every entity][6]
+Learn more about the [sensu/http-checks][12] [dynamic runtime asset][24].
+
+The example in this guide uses [RFC 3339 format][25] with space delimiters and numeric zone offset, but sensuctl supports several [time formats][26] for the `begin` flag.
 
 
 [1]: ../handlers/
@@ -278,7 +270,7 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [7]: ../silencing/
 [8]: ../../../sensuctl/create-manage-resources/#time-formats
 [9]: ../silencing/#silence-all-checks-for-entities-with-a-specific-subscription
-[10]: ../../../operations/deploy-sensu/install-sensu/
+[10]: ../../../operations/deploy-sensu/install-sensu/#install-the-sensu-backend
 [11]: #create-the-check
 [12]: https://bonsai.sensu.io/assets/sensu/http-checks
 [13]: ../../observe-filter/filters/#built-in-filter-not_silenced
@@ -289,3 +281,9 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [18]: ../send-pagerduty-alerts/
 [19]: ../send-slack-alerts/
 [20]: https://www.ietf.org/rfc/rfc3339.txt
+[21]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
+[22]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[23]: ../../../operations/control-access/rbac/#default-users
+[24]: ../../../plugins/assets/
+[25]: https://www.ietf.org/rfc/rfc3339.txt
+[26]: ../../../sensuctl/create-manage-resources/#time-formats

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -455,8 +455,7 @@ The event will include a top-level metrics section populated with metrics points
 
 ## What's next
 
-Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5].
-For a turnkey experience with the Sensu InfluxDB Handler plugin, use our curated, configurable [quick-start template][6] to integrate Sensu with your existing workflows and store Sensu metrics in InfluxDB.
+Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5] or [send data to Sumo Logic][20].
 
 Read [Monitor server resources with checks][2] to learn how to monitor an NGINX webserver rather than collect metrics.
 You can also learn to use Sensu to [collect Prometheus metrics][14].
@@ -492,3 +491,4 @@ Visit Bonsai, the Sensu asset index, for more information about the [sensu/http-
 [17]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [18]: ../../observe-process/handlers/
 [19]: ../../../plugins/assets/
+[20]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -20,7 +20,7 @@ This guide includes two check examples to help you monitor server resources: spe
 
 ## Requirements
 
-To follow this guide, install the Sensu [backend][4], make sure at least one Sensu [agent][17] is running, and configure [sensuctl][18] to connect to the backend as the [`admin` user][19].
+To follow this guide, install the Sensu [backend][4], make sure at least one Sensu [agent][18] is running, and configure [sensuctl][17] to connect to the backend as the [`admin` user][19].
 
 ## Configure a Sensu entity
 
@@ -512,6 +512,7 @@ Now that you know how to create checks to monitor CPU usage and NGINX webserver 
 Or, learn how to [collect and analyze metrics][7] or [monitor external resources with proxy checks and entities][5].
 
 You can also create pipelines to send alerts to [email][13], [PagerDuty][9], or [Slack][6] based on the status events your checks are generating.
+Or, send status and metrics data to [Sumo Logic][20].
 Read the [pipelines reference][10] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
 
 To share, reuse, and maintain the checks you created in this guide just like you would code, [save the check definitions to a file][11] and start building a [monitoring as code repository][12].
@@ -538,3 +539,4 @@ Learn more about the [dynamic runtime assets][2] this guide uses: [sensu/check-c
 [17]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [18]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [19]: ../../../operations/control-access/rbac/#default-users
+[20]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.8/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -516,6 +516,8 @@ Learn more about the Sensu resources you created in this guide:
 - [Handlers][12] and [pipelines][20]
 - [Subscriptions][16]
 
+Now that you know how to extract metrics from check output, you can use a pipeline to [send data to Sumo Logic][23].
+
 Visit Bonsai, the Sensu asset index, for more information about the [sensu/sensu-influxdb-handler][18] and [sensu/sensu-prometheus-collector][19] assets.
 With the sensu/sensu-prometheus-collector in your Sensu ecosystem, you can use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
@@ -544,3 +546,4 @@ Read about [sensuctl][15] and the Sensu [web UI][14] to learn how to use these f
 [20]: ../../observe-process/pipelines/
 [21]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [22]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[23]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.9/observability-pipeline/observe-entities/monitor-external-resources.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-entities/monitor-external-resources.md
@@ -26,7 +26,7 @@ This guide also explains how to use [proxy checks to monitor a group of websites
 
 ## Requirements
 
-To follow this guide, install the Sensu [backend][19], make sure at least one Sensu [agent][30] is running, and configure [sensuctl][31] to connect to the backend as the [`admin` user][32].
+To follow this guide, install the Sensu [backend][19], make sure at least one Sensu [agent][31] is running, and configure [sensuctl][30] to connect to the backend as the [`admin` user][32].
 
 ## Use a proxy entity to monitor a website (Sensu Catalog configuration)
 
@@ -554,6 +554,8 @@ Follow any of these guides to learn how to configure event filters, handlers, an
 * [Send PagerDuty alerts with Sensu][6]
 * [Send Slack alerts with a pipeline][7]
 
+You can also send metrics and status data to [Sumo Logic][33].
+
 Read more about the Sensu features you used in this guide:
 
 - [Sensu Catalog][25]
@@ -601,3 +603,4 @@ Monitoring as code makes it possible to move to a more robust deployment without
 [30]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [31]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [32]: ../../../operations/control-access/rbac/#default-users
+[33]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.9/observability-pipeline/observe-process/plan-maintenance.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-process/plan-maintenance.md
@@ -20,7 +20,9 @@ This feature is useful when you're planning maintenance.
 You can configure silences to prevent handlers from taking actions based on check name, entity subscription, entity name, or a combination of these factors.
 In this guide, you'll create a silenced entry for a specific entity and its associated check to prevent alerts and create a time window for maintenance.
 
-To follow this guide, you’ll need to [install][10] the Sensu backend, have at least one Sensu agent running, and install and configure sensuctl.
+## Requirements
+
+To follow this guide, install the Sensu [backend][10], make sure at least one Sensu [agent][21] is running, and configure [sensuctl][22] to connect to the backend as the [`admin` user][23].
 
 {{% notice note %}}
 **NOTE**: If you already have an entity and running check to use as the silencing target, skip ahead to [Create the silenced entry](#create-the-silenced-entry).
@@ -55,8 +57,8 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the http-checks dynamic runtime asset
 
-To power the check in your silenced entry, you'll use the [sensu/http-checks][12] dynamic runtime asset.
-This community-tier asset includes `http-check`, the http status check command that [your check][11] will rely on.
+To power the check in your silenced entry, you'll use the sensu/http-checks dynamic runtime asset.
+This community-tier asset includes `http-check`, the http status check command that your check will rely on.
 
 Register the sensu/http-checks dynamic runtime asset:
 
@@ -88,7 +90,6 @@ The response should list the sensu/http-checks dynamic runtime asset (renamed to
 
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
 
 ## Create the check
@@ -178,11 +179,6 @@ sensuctl silenced create \
 --reason 'Planned site maintenance'
 {{< /code >}}
 
-{{% notice note %}}
-**NOTE**: Sensuctl supports several [time formats](../../../sensuctl/create-manage-resources/#time-formats) for the `begin` flag.
-This example uses [RFC 3339 format](https://www.ietf.org/rfc/rfc3339.txt) with space delimiters and numeric zone offset.
-{{% /notice %}}
-
 Use sensuctl to verify that the silenced entry against the entity `sensu-site` was created properly:
 
 {{< language-toggle >}}
@@ -239,7 +235,7 @@ spec:
 
 {{< /language-toggle >}}
 
-## Next steps
+## What's next
 
 When your silence goes into effect at the designated `begin` time, you will still see events for `check-http` on the `sensu-site` entity in the Sensu web UI.
 This is because **silences do not stop events from being produced &mdash; they stop events from being handled**.
@@ -254,19 +250,15 @@ The pipeline must include a workflow with the built-in [`not_silenced`][13] even
 
 Follow one of these guides to add a pipeline to your check:
 
-- [Send data to Sumo Logic with Sensu][16]
 - [Send email alerts with a pipeline][17]
 - [Send PagerDuty alerts with Sensu][18]
 - [Send Slack alerts with a pipeline][19]
 
-Read the [silencing reference][7] for in-depth documentation about silenced entries and more examples:
+Read the [silencing reference][7] for in-depth documentation about silenced entries and more examples for other silencing scenarios.
 
-- [Silence all checks on a specific entity][2]
-- [Silence a specific check on a specific entity][3]
-- [Silence all checks with a specific subscription][4]
-- [Silence all checks for entities with a specific subscription][9]
-- [Silence a specific check on entities with a specific subscription][5]
-- [Silence a specific check on every entity][6]
+Learn more about the [sensu/http-checks][12] [dynamic runtime asset][24].
+
+The example in this guide uses [RFC 3339 format][25] with space delimiters and numeric zone offset, but sensuctl supports several [time formats][26] for the `begin` flag.
 
 
 [1]: ../handlers/
@@ -278,7 +270,7 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [7]: ../silencing/
 [8]: ../../../sensuctl/create-manage-resources/#time-formats
 [9]: ../silencing/#silence-all-checks-for-entities-with-a-specific-subscription
-[10]: ../../../operations/deploy-sensu/install-sensu/
+[10]: ../../../operations/deploy-sensu/install-sensu/#install-the-sensu-backend
 [11]: #create-the-check
 [12]: https://bonsai.sensu.io/assets/sensu/http-checks
 [13]: ../../observe-filter/filters/#built-in-filter-not_silenced
@@ -289,3 +281,9 @@ Read the [silencing reference][7] for in-depth documentation about silenced entr
 [18]: ../send-pagerduty-alerts/
 [19]: ../send-slack-alerts/
 [20]: https://www.ietf.org/rfc/rfc3339.txt
+[21]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
+[22]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[23]: ../../../operations/control-access/rbac/#default-users
+[24]: ../../../plugins/assets/
+[25]: https://www.ietf.org/rfc/rfc3339.txt
+[26]: ../../../sensuctl/create-manage-resources/#time-formats

--- a/content/sensu-go/6.9/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-schedule/collect-metrics-with-checks.md
@@ -455,8 +455,7 @@ The event will include a top-level metrics section populated with metrics points
 
 ## What's next
 
-Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5].
-For a turnkey experience with the Sensu InfluxDB Handler plugin, use our curated, configurable [quick-start template][6] to integrate Sensu with your existing workflows and store Sensu metrics in InfluxDB.
+Now that you know how to extract metrics from check output, learn to use a metrics handler to [populate service and time-series metrics in InfluxDB][5] or [send data to Sumo Logic][20].
 
 Read [Monitor server resources with checks][2] to learn how to monitor an NGINX webserver rather than collect metrics.
 You can also learn to use Sensu to [collect Prometheus metrics][14].
@@ -492,3 +491,4 @@ Visit Bonsai, the Sensu asset index, for more information about the [sensu/http-
 [17]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [18]: ../../observe-process/handlers/
 [19]: ../../../plugins/assets/
+[20]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.9/observability-pipeline/observe-schedule/monitor-server-resources.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-schedule/monitor-server-resources.md
@@ -20,7 +20,7 @@ This guide includes two check examples to help you monitor server resources: spe
 
 ## Requirements
 
-To follow this guide, install the Sensu [backend][4], make sure at least one Sensu [agent][17] is running, and configure [sensuctl][18] to connect to the backend as the [`admin` user][19].
+To follow this guide, install the Sensu [backend][4], make sure at least one Sensu [agent][18] is running, and configure [sensuctl][17] to connect to the backend as the [`admin` user][19].
 
 ## Configure a Sensu entity
 
@@ -512,6 +512,7 @@ Now that you know how to create checks to monitor CPU usage and NGINX webserver 
 Or, learn how to [collect and analyze metrics][7] or [monitor external resources with proxy checks and entities][5].
 
 You can also create pipelines to send alerts to [email][13], [PagerDuty][9], or [Slack][6] based on the status events your checks are generating.
+Or, send status and metrics data to [Sumo Logic][20].
 Read the [pipelines reference][10] for information about configuring observability event processing workflows with event filters, mutators, and handlers.
 
 To share, reuse, and maintain the checks you created in this guide just like you would code, [save the check definitions to a file][11] and start building a [monitoring as code repository][12].
@@ -538,3 +539,4 @@ Learn more about the [dynamic runtime assets][2] this guide uses: [sensu/check-c
 [17]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
 [18]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [19]: ../../../operations/control-access/rbac/#default-users
+[20]: ../../observe-process/send-data-sumo-logic/

--- a/content/sensu-go/6.9/observability-pipeline/observe-schedule/prometheus-metrics.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-schedule/prometheus-metrics.md
@@ -516,6 +516,8 @@ Learn more about the Sensu resources you created in this guide:
 - [Handlers][12] and [pipelines][20]
 - [Subscriptions][16]
 
+Now that you know how to extract metrics from check output, you can use a pipeline to [send data to Sumo Logic][23].
+
 Visit Bonsai, the Sensu asset index, for more information about the [sensu/sensu-influxdb-handler][18] and [sensu/sensu-prometheus-collector][19] assets.
 With the sensu/sensu-prometheus-collector in your Sensu ecosystem, you can use Prometheus to gather metrics and use Sensu to send them to the proper final destination.
 Prometheus has a [comprehensive list][7] of additional exporters to pull in metrics.
@@ -544,3 +546,4 @@ Read about [sensuctl][15] and the Sensu [web UI][14] to learn how to use these f
 [20]: ../../observe-process/pipelines/
 [21]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [22]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[23]: ../../observe-process/send-data-sumo-logic/


### PR DESCRIPTION
## Description
Improves https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/plan-maintenance/ by adding a Requirements section, moving most links to the What's next section, and adding content to the What's next section.

Also fixes incorrect links and adds the Sumo Logic guide in a couple other guides.

## Motivation and Context
Relevant to https://github.com/sensu/sensu-docs/issues/4034
