### PR TITLE
Add archetype for Sensu Go docs

### DIFF
--- a/archetypes/sensu-go.md
+++ b/archetypes/sensu-go.md
@@ -1,0 +1,14 @@
+---
+title: "{{ replace .TranslationBaseName "-" " " | title }}"
+linkTitle: ""
+guide_title: ""
+reference_title: ""
+type: ""
+description: ""
+weight: 
+version: ""
+product: "Sensu Go"
+platformContent: false
+menu:
+---
+


### PR DESCRIPTION
## Description
Adds a front matter archetype for new Sensu Go docs pages.

## Motivation and Context
Needed for https://github.com/sensu/sensu-docs/wiki/Hugo-and-the-Sensu-docs#hugo-front-matter