### PR TITLE
Case sensitivity in user and group names

### DIFF
--- a/content/sensu-go/6.6/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.6/operations/control-access/ad-auth.md
@@ -444,7 +444,7 @@ allowed_groups:
 {{< /code >}}
 {{< code json >}}
 {
-    "allowed_groups": [
+  "allowed_groups": [
     "Sensu_Viewers",
     "Sensu_Operators"
   ]

--- a/content/sensu-go/6.6/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.6/operations/control-access/ad-auth.md
@@ -157,6 +157,10 @@ spec:
 
 {{< /language-toggle >}}
 
+{{% notice note %}}
+**NOTE**: If you specify allowed groups, the group names must exactly match the names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
+
 **Example AD configuration: Use `memberOf` attribute instead of `group_search`**
 
 AD automatically returns a `memberOf` attribute in users' accounts.
@@ -428,20 +432,21 @@ servers:
 
 | allowed_groups |   |
 -------------|------
-description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.{{% notice note %}}**NOTE**: Allowed group names are case-sensitive and must exactly match the group names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
 required     | false
 type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 allowed_groups:
-- sensu-viewers
-- sensu-operators
+- Sensu_Viewers
+- Sensu_Operators
 {{< /code >}}
 {{< code json >}}
 {
-  "allowed_groups": [
-    "sensu-viewers",
-    "sensu-operators"
+    "allowed_groups": [
+    "Sensu_Viewers",
+    "Sensu_Operators"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.6/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.6/operations/control-access/ldap-auth.md
@@ -152,6 +152,10 @@ spec:
 
 {{< /language-toggle >}}
 
+{{% notice note %}}
+**NOTE**: If you specify allowed groups, the group names must exactly match the names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
+
 **Example LDAP configuration: Use `memberOf` attribute instead of `group_search`**
 
 If your LDAP server is configured to return a `memberOf` attribute when you perform a query, you can use `memberOf` in your Sensu LDAP implementation instead of `group_search`.
@@ -422,14 +426,14 @@ type         | Array of strings
 example      | {{< language-toggle >}}
 {{< code yml >}}
 allowed_groups:
-- sensu-viewers
-- sensu-operators
+- Sensu_Viewers
+- Sensu_Operators
 {{< /code >}}
 {{< code json >}}
 {
-  "allowed_groups": [
-    "sensu-viewers",
-    "sensu-operators"
+    "allowed_groups": [
+    "Sensu_Viewers",
+    "Sensu_Operators"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.6/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.6/operations/control-access/ldap-auth.md
@@ -431,7 +431,7 @@ allowed_groups:
 {{< /code >}}
 {{< code json >}}
 {
-    "allowed_groups": [
+  "allowed_groups": [
     "Sensu_Viewers",
     "Sensu_Operators"
   ]

--- a/content/sensu-go/6.6/operations/control-access/rbac.md
+++ b/content/sensu-go/6.6/operations/control-access/rbac.md
@@ -757,7 +757,7 @@ spec:
     name: cluster-admin
     type: ClusterRole
   subjects:
-  - name: cluster-admins
+  - name: Cluster_Admins
     type: Group
 {{< /code >}}
 
@@ -775,7 +775,7 @@ spec:
     },
     "subjects": [
       {
-        "name": "cluster-admins",
+        "name": "Cluster_Admins",
         "type": "Group"
       }
     ]

--- a/content/sensu-go/6.7/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.7/operations/control-access/ad-auth.md
@@ -444,7 +444,7 @@ allowed_groups:
 {{< /code >}}
 {{< code json >}}
 {
-    "allowed_groups": [
+  "allowed_groups": [
     "Sensu_Viewers",
     "Sensu_Operators"
   ]

--- a/content/sensu-go/6.7/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.7/operations/control-access/ad-auth.md
@@ -157,6 +157,10 @@ spec:
 
 {{< /language-toggle >}}
 
+{{% notice note %}}
+**NOTE**: If you specify allowed groups, the group names must exactly match the names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
+
 **Example AD configuration: Use `memberOf` attribute instead of `group_search`**
 
 AD automatically returns a `memberOf` attribute in users' accounts.
@@ -428,20 +432,21 @@ servers:
 
 | allowed_groups |   |
 -------------|------
-description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.{{% notice note %}}**NOTE**: Allowed group names are case-sensitive and must exactly match the group names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
 required     | false
 type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 allowed_groups:
-- sensu-viewers
-- sensu-operators
+- Sensu_Viewers
+- Sensu_Operators
 {{< /code >}}
 {{< code json >}}
 {
-  "allowed_groups": [
-    "sensu-viewers",
-    "sensu-operators"
+    "allowed_groups": [
+    "Sensu_Viewers",
+    "Sensu_Operators"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.7/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.7/operations/control-access/ldap-auth.md
@@ -152,6 +152,10 @@ spec:
 
 {{< /language-toggle >}}
 
+{{% notice note %}}
+**NOTE**: If you specify allowed groups, the group names must exactly match the names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
+
 **Example LDAP configuration: Use `memberOf` attribute instead of `group_search`**
 
 If your LDAP server is configured to return a `memberOf` attribute when you perform a query, you can use `memberOf` in your Sensu LDAP implementation instead of `group_search`.
@@ -422,14 +426,14 @@ type         | Array of strings
 example      | {{< language-toggle >}}
 {{< code yml >}}
 allowed_groups:
-- sensu-viewers
-- sensu-operators
+- Sensu_Viewers
+- Sensu_Operators
 {{< /code >}}
 {{< code json >}}
 {
-  "allowed_groups": [
-    "sensu-viewers",
-    "sensu-operators"
+    "allowed_groups": [
+    "Sensu_Viewers",
+    "Sensu_Operators"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.7/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.7/operations/control-access/ldap-auth.md
@@ -431,7 +431,7 @@ allowed_groups:
 {{< /code >}}
 {{< code json >}}
 {
-    "allowed_groups": [
+  "allowed_groups": [
     "Sensu_Viewers",
     "Sensu_Operators"
   ]

--- a/content/sensu-go/6.7/operations/control-access/rbac.md
+++ b/content/sensu-go/6.7/operations/control-access/rbac.md
@@ -757,7 +757,7 @@ spec:
     name: cluster-admin
     type: ClusterRole
   subjects:
-  - name: cluster-admins
+  - name: Cluster_Admins
     type: Group
 {{< /code >}}
 
@@ -775,7 +775,7 @@ spec:
     },
     "subjects": [
       {
-        "name": "cluster-admins",
+        "name": "Cluster_Admins",
         "type": "Group"
       }
     ]

--- a/content/sensu-go/6.8/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.8/operations/control-access/ad-auth.md
@@ -444,7 +444,7 @@ allowed_groups:
 {{< /code >}}
 {{< code json >}}
 {
-    "allowed_groups": [
+  "allowed_groups": [
     "Sensu_Viewers",
     "Sensu_Operators"
   ]

--- a/content/sensu-go/6.8/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.8/operations/control-access/ad-auth.md
@@ -157,6 +157,10 @@ spec:
 
 {{< /language-toggle >}}
 
+{{% notice note %}}
+**NOTE**: If you specify allowed groups, the group names must exactly match the names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
+
 **Example AD configuration: Use `memberOf` attribute instead of `group_search`**
 
 AD automatically returns a `memberOf` attribute in users' accounts.
@@ -428,20 +432,21 @@ servers:
 
 | allowed_groups |   |
 -------------|------
-description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.{{% notice note %}}**NOTE**: Allowed group names are case-sensitive and must exactly match the group names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
 required     | false
 type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 allowed_groups:
-- sensu-viewers
-- sensu-operators
+- Sensu_Viewers
+- Sensu_Operators
 {{< /code >}}
 {{< code json >}}
 {
-  "allowed_groups": [
-    "sensu-viewers",
-    "sensu-operators"
+    "allowed_groups": [
+    "Sensu_Viewers",
+    "Sensu_Operators"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.8/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.8/operations/control-access/ldap-auth.md
@@ -152,6 +152,10 @@ spec:
 
 {{< /language-toggle >}}
 
+{{% notice note %}}
+**NOTE**: If you specify allowed groups, the group names must exactly match the names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
+
 **Example LDAP configuration: Use `memberOf` attribute instead of `group_search`**
 
 If your LDAP server is configured to return a `memberOf` attribute when you perform a query, you can use `memberOf` in your Sensu LDAP implementation instead of `group_search`.
@@ -422,14 +426,14 @@ type         | Array of strings
 example      | {{< language-toggle >}}
 {{< code yml >}}
 allowed_groups:
-- sensu-viewers
-- sensu-operators
+- Sensu_Viewers
+- Sensu_Operators
 {{< /code >}}
 {{< code json >}}
 {
-  "allowed_groups": [
-    "sensu-viewers",
-    "sensu-operators"
+    "allowed_groups": [
+    "Sensu_Viewers",
+    "Sensu_Operators"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.8/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.8/operations/control-access/ldap-auth.md
@@ -431,7 +431,7 @@ allowed_groups:
 {{< /code >}}
 {{< code json >}}
 {
-    "allowed_groups": [
+  "allowed_groups": [
     "Sensu_Viewers",
     "Sensu_Operators"
   ]

--- a/content/sensu-go/6.8/operations/control-access/rbac.md
+++ b/content/sensu-go/6.8/operations/control-access/rbac.md
@@ -757,7 +757,7 @@ spec:
     name: cluster-admin
     type: ClusterRole
   subjects:
-  - name: cluster-admins
+  - name: Cluster_Admins
     type: Group
 {{< /code >}}
 
@@ -775,7 +775,7 @@ spec:
     },
     "subjects": [
       {
-        "name": "cluster-admins",
+        "name": "Cluster_Admins",
         "type": "Group"
       }
     ]

--- a/content/sensu-go/6.9/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.9/operations/control-access/ad-auth.md
@@ -444,7 +444,7 @@ allowed_groups:
 {{< /code >}}
 {{< code json >}}
 {
-    "allowed_groups": [
+  "allowed_groups": [
     "Sensu_Viewers",
     "Sensu_Operators"
   ]

--- a/content/sensu-go/6.9/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.9/operations/control-access/ad-auth.md
@@ -428,7 +428,8 @@ servers:
 
 | allowed_groups |   |
 -------------|------
-description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+description  | An array of allowed AD group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated AD user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.{{% notice note %}}**NOTE**: Allowed group names are case-sensitive and must exactly match the group names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
 required     | false
 type         | Array
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.9/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.9/operations/control-access/ad-auth.md
@@ -439,14 +439,14 @@ type         | Array
 example      | {{< language-toggle >}}
 {{< code yml >}}
 allowed_groups:
-- sensu-viewers
-- sensu-operators
+- Sensu_Viewers
+- Sensu_Operators
 {{< /code >}}
 {{< code json >}}
 {
-  "allowed_groups": [
-    "sensu-viewers",
-    "sensu-operators"
+    "allowed_groups": [
+    "Sensu_Viewers",
+    "Sensu_Operators"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.9/operations/control-access/ad-auth.md
+++ b/content/sensu-go/6.9/operations/control-access/ad-auth.md
@@ -157,6 +157,10 @@ spec:
 
 {{< /language-toggle >}}
 
+{{% notice note %}}
+**NOTE**: If you specify allowed groups, the group names must exactly match the names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
+
 **Example AD configuration: Use `memberOf` attribute instead of `group_search`**
 
 AD automatically returns a `memberOf` attribute in users' accounts.

--- a/content/sensu-go/6.9/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.9/operations/control-access/ldap-auth.md
@@ -432,7 +432,7 @@ allowed_groups:
 {{< /code >}}
 {{< code json >}}
 {
-    "allowed_groups": [
+  "allowed_groups": [
     "Sensu_Viewers",
     "Sensu_Operators"
   ]

--- a/content/sensu-go/6.9/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.9/operations/control-access/ldap-auth.md
@@ -416,7 +416,8 @@ servers:
 
 | allowed_groups |   |
 -------------|------
-description  | An array of allowed LDAP group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated LDAP user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.
+description  | An array of allowed LDAP group strings to include in the tokenized identity claim. Use to specify which groups to encode in the authentication provider's JSON Web Token (JWT) when the authenticated LDAP user is a member of many groups and the tokenized identity claim would be too large for correct web client operation.{{% notice note %}}**NOTE**: Allowed group names are case-sensitive and must exactly match the group names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
 required     | false
 type         | Array of strings
 example      | {{< language-toggle >}}

--- a/content/sensu-go/6.9/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.9/operations/control-access/ldap-auth.md
@@ -152,6 +152,10 @@ spec:
 
 {{< /language-toggle >}}
 
+{{% notice note %}}
+**NOTE**: If you specify allowed groups, the group names must exactly match the names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
+
 **Example LDAP configuration: Use `memberOf` attribute instead of `group_search`**
 
 If your LDAP server is configured to return a `memberOf` attribute when you perform a query, you can use `memberOf` in your Sensu LDAP implementation instead of `group_search`.

--- a/content/sensu-go/6.9/operations/control-access/ldap-auth.md
+++ b/content/sensu-go/6.9/operations/control-access/ldap-auth.md
@@ -427,14 +427,14 @@ type         | Array of strings
 example      | {{< language-toggle >}}
 {{< code yml >}}
 allowed_groups:
-- sensu-viewers
-- sensu-operators
+- Sensu_Viewers
+- Sensu_Operators
 {{< /code >}}
 {{< code json >}}
 {
-  "allowed_groups": [
-    "sensu-viewers",
-    "sensu-operators"
+    "allowed_groups": [
+    "Sensu_Viewers",
+    "Sensu_Operators"
   ]
 }
 {{< /code >}}

--- a/content/sensu-go/6.9/operations/control-access/rbac.md
+++ b/content/sensu-go/6.9/operations/control-access/rbac.md
@@ -757,7 +757,7 @@ spec:
     name: cluster-admin
     type: ClusterRole
   subjects:
-  - name: cluster-admins
+  - name: Cluster_Admins
     type: Group
 {{< /code >}}
 
@@ -775,7 +775,7 @@ spec:
     },
     "subjects": [
       {
-        "name": "cluster-admins",
+        "name": "Cluster_Admins",
         "type": "Group"
       }
     ]

--- a/content/sensu-go/6.9/operations/control-access/rbac.md
+++ b/content/sensu-go/6.9/operations/control-access/rbac.md
@@ -785,6 +785,10 @@ spec:
 
 {{< /language-toggle >}}
 
+{{% notice note %}}
+**NOTE**: If you are using Active Directory (AD) or Lightweight Directory Access Protocol (LDAP) authentication, the names of users and groups listed in the subjects array must exactly match the user and group names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
+
 To create this cluster role binding with [`sensuctl create`][31], first save the definition to a file like `clusterrolebindings.yml` or `clusterrolebindings.json`.
 Then, run:
 
@@ -3200,7 +3204,8 @@ type: Role
 
 name         | 
 -------------|------ 
-description  | Name of the user resource or group resource to bind in the role binding or cluster role binding.
+description  | Name of the user resource or group resource to bind in the role binding or cluster role binding.{{% notice note %}}**NOTE**: If you are using Active Directory (AD) or Lightweight Directory Access Protocol (LDAP) authentication, names of users and groups are case-sensitive. The user and group names listed in the cluster role binding configuration must exactly match the user and group names the authentication provider returns to the Sensu backend.
+{{% /notice %}}
 required     | true
 type         | String
 example      | {{< language-toggle >}}


### PR DESCRIPTION
## Description
Adds note that allowed_groups and group/user names listed in cluster role binding definitions must exactly match the names in AD/LDAP

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/4142