### PR TITLE
Fix a minor typo in pipelines ref

### DIFF
--- a/content/sensu-go/6.6/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/pipelines.md
@@ -167,7 +167,7 @@ spec:
 
 ## Workflows
 
-The workflow attribute is an array of event processing workflows that Sensu will apply for events produced by any check that references the pipeline.
+The workflows attribute is an array of event processing workflows that Sensu will apply for events produced by any check that references the pipeline.
 
 Workflows do not have to include an event filter or mutator, but they must specify at least one handler.
 

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/pipelines.md
@@ -167,7 +167,7 @@ spec:
 
 ## Workflows
 
-The workflow attribute is an array of event processing workflows that Sensu will apply for events produced by any check that references the pipeline.
+The workflows attribute is an array of event processing workflows that Sensu will apply for events produced by any check that references the pipeline.
 
 Workflows do not have to include an event filter or mutator, but they must specify at least one handler.
 

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/pipelines.md
@@ -167,7 +167,7 @@ spec:
 
 ## Workflows
 
-The workflow attribute is an array of event processing workflows that Sensu will apply for events produced by any check that references the pipeline.
+The workflows attribute is an array of event processing workflows that Sensu will apply for events produced by any check that references the pipeline.
 
 Workflows do not have to include an event filter or mutator, but they must specify at least one handler.
 

--- a/content/sensu-go/6.9/observability-pipeline/observe-process/pipelines.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-process/pipelines.md
@@ -167,7 +167,7 @@ spec:
 
 ## Workflows
 
-The workflow attribute is an array of event processing workflows that Sensu will apply for events produced by any check that references the pipeline.
+The workflows attribute is an array of event processing workflows that Sensu will apply for events produced by any check that references the pipeline.
 
 Workflows do not have to include an event filter or mutator, but they must specify at least one handler.
 


### PR DESCRIPTION
## Description
Fixes a typo in pipelines reference (attribute name is `workflows` plural)