### PR TITLE
Improve send Slack alerts guide

### DIFF
--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -23,7 +23,7 @@ To follow this guide, install the Sensu [backend][4], make sure at least one Sen
 
 You'll also need your [PagerDuty API integration key][1] to set up the handler in this guide.
 
-The examples in this guide rely on the `check_cpu` check from [Monitor server resources with checks][3].
+The example in this guide relies on the `check_cpu` check from [Monitor server resources with checks][3].
 Before you begin, follow the instructions to [add the `sensu/check-cpu-usage`][28] dynamic runtime asset and the [`check_cpu`][29] check.
 
 ## Configure a Sensu entity

--- a/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.6/observability-pipeline/observe-process/send-slack-alerts.md
@@ -17,13 +17,22 @@ Pipelines are Sensu resources composed of [observation event][1] processing work
 You can use pipelines to send email alerts, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a pipeline and adding it to a check named `check_cpu`.
-If you don't already have this check in place, follow [Monitor server resources][2] to add the check.
 
-To follow this guide, install the Sensu [backend][17], make sure at least one Sensu [agent][23] is running, and install and configure [sensuctl][24].
+## Requirements
+
+To follow this guide, install the Sensu [backend][17], make sure at least one Sensu [agent][23] is running, and configure [sensuctl][24] to connect to the backend as the [`admin` user][25].
+
+The example in this guide relies on the `check_cpu` check from [Monitor server resources with checks][26].
+Before you begin, follow the instructions to [add the `sensu/check-cpu-usage`][27] dynamic runtime asset and the [`check_cpu`][28] check.
+
+You will also need a [Slack webhook][6] to complete this guide.
+If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
+If you're not yet a Slack admin, [create a new workspace][12] and then create and save your webhook.
+After you save your webhook, you can find the webhook URL under **Integration Settings**.
 
 ## Configure a Sensu entity
 
-Every Sensu agent has a defined set of [subscriptions][21] that determine which checks the agent will execute.
+Every Sensu agent has a defined set of subscriptions that determine which checks the agent will execute.
 For an agent to execute a specific check, you must specify the same subscription in the agent configuration and the check definition.
 To run the `check_cpu` check, you'll need a Sensu entity with the subscription `system`.
 
@@ -35,8 +44,8 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][20] command below.
-Then run the command to add the `system` [subscription][21] to your entity:
+Replace `<ENTITY_NAME>` with the name of your entity in the sensuctl command below.
+Then run the command to add the `system` subscription to your entity:
 
 {{< code shell >}}
 sensuctl entity update <ENTITY_NAME>
@@ -55,10 +64,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-[Dynamic runtime assets][13] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [sensu/sensu-slack-handler][14] dynamic runtime asset to power a `slack` handler.
+Dynamic runtime assets are shareable, reusable packages that help you deploy Sensu plugins.
+In this guide, you'll use the sensu/sensu-slack-handler dynamic runtime asset to power a `slack` handler.
 
-Use [`sensuctl asset add`][10] to register the [sensu/sensu-slack-handler][14] dynamic runtime asset:
+Use `sensuctl asset add` to register the sensu/sensu-slack-handler dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -77,19 +86,9 @@ it's invoked by another Sensu resource (ex. check). To add this runtime asset to
 resource, populate the "runtime_assets" field with ["sensu-slack-handler"].
 {{< /code >}}
 
-You can also download the latest dynamic runtime asset definition for your platform from [Bonsai][14] and register the asset with `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
-
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
-
-## Get a Slack webhook
-
-If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
-If you're not yet a Slack admin, [create a new workspace][12] and then create and save your webhook.
-
-After you save your webhook, you can find the webhook URL under **Integration Settings**.
 
 ## Create a handler
 
@@ -174,18 +173,12 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice protip %}}
-**PRO TIP**: You can also [view complete resource definitions in the Sensu web UI](../../../web-ui/view-manage-resources/#view-resource-data-in-the-web-ui).
-{{% /notice %}}
-
-You can share and reuse this handler like code &mdash; [save it to a file][15] and start building a [monitoring as code repository][16].
-
 ## Create a pipeline that includes the handler
 
-With your handler configured, you can add it to a [pipeline][8] workflow.
+With your handler configured, you can add it to a pipeline workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-For now, the pipeline includes only the `slack` handler and the built-in [not_silenced][22] event filter so that you receive an alert for every event the check generates (including events with OK status).
+For now, the pipeline includes only the `slack` handler and the built-in not_silenced event filter so that you receive an alert for every event the check generates (including events with OK status).
 To create the pipeline, run:
 
 {{< language-toggle >}}
@@ -246,7 +239,7 @@ EOF
 
 ## Assign the pipeline to a check
 
-To use the `cpu_check_alerts` pipeline, list it in a check definition's [pipelines array][18] (in this case, the `check_cpu` check created in [Monitor server resources][2]).
+To use the `cpu_check_alerts` pipeline, list it in a check definition's pipelines array.
 All the observability events that the check produces will be processed according to the pipeline's workflows.
 
 Assign your `cpu_check_alerts` pipeline to the `check_cpu` check to receive Slack alerts when the CPU usage of your system reaches the specific thresholds set in the check command.
@@ -390,14 +383,17 @@ After an event is handled, you should receive a message like this in Slack:
 {{< figure src="/images/go/send_slack_alerts/check_cpu_usage_example_alert.png" alt="Example Slack message" link="/images/go/send_slack_alerts/check_cpu_usage_example_alert.png" target="_blank" >}}
 
 Verify proper handler behavior with `sensu-backend` logs.
-Read [Troubleshoot Sensu][7] for log locations by platform.
 
 Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"event pipe handler executed","output":"","status":0`.
+
+{{% notice note %}}
+**NOTE**: Read [Troubleshoot Sensu](../../../operations/maintain-sensu/troubleshoot/#log-file-locations) for Sensu log locations by platform.
+{{% /notice %}}
 
 ## Add another event filter to the pipeline
 
 At this point, the `cpu_check_alerts` pipeline has probably sent quite a few Slack messages for events with OK (`0`) status.
-To receive alerts for events with *only* warning (`1`) or critical (`2`) status, add the built-in [is_incident][19] event filter to the pipeline:
+To receive alerts for events with *only* warning (`1`) or critical (`2`) status, add the built-in is_incident event filter to the pipeline:
 
 {{< language-toggle >}}
 
@@ -465,23 +461,24 @@ EOF
 
 Adding the is_incident filter to your pipeline should quickly reduce the number of alerts you receive in Slack.
 
-## Next steps
+## What's next
 
 Now that you know how to apply a pipeline to a check and take action on events, read the [pipelines reference][8] for in-depth documentation.
 Read [Route alerts with event filters][9] for a more complex example with multiple filters and handlers organized into several pipeline workflows.
 
-For more information about customizing your Slack alerts, read the [Sensu Slack Handler page in Bonsai][14].
+For more information about customizing your Slack alerts, read the [sensu/sensu-slack-handler page in Bonsai][14].
 
 Follow [Send PagerDuty alerts with Sensu][11] to configure a check that generates status events and a handler that sends Sensu alerts to PagerDuty for non-OK events.
+
+You can share and reuse Sensu resources like code, including the handler and pipeline you created in this guide &mdash; [save the resource definition to a file][15] and start building a [monitoring as code repository][16].
 
 
 [1]: ../../observe-events/events/
 [2]: ../../observe-schedule/monitor-server-resources/
 [3]: https://github.com/sensu/slack-handler
 [4]: https://golang.org/doc/install
-[5]: https://en.wikipedia.org/wiki/PATH_(variable)
 [6]: https://api.slack.com/incoming-webhooks
-[7]: ../../../operations/maintain-sensu/troubleshoot/
+[7]: ../../../operations/maintain-sensu/troubleshoot/#log-file-locations
 [8]: ../pipelines/
 [9]: ../../observe-filter/route-alerts/
 [10]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
@@ -499,3 +496,7 @@ Follow [Send PagerDuty alerts with Sensu][11] to configure a check that generate
 [22]: ../../observe-filter/filters/#built-in-filter-not_silenced
 [23]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [24]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[25]: ../../../operations/control-access/rbac/#default-users
+[26]: ../../observe-schedule/monitor-server-resources/
+[27]: ../../observe-schedule/monitor-server-resources/#register-the-sensucheck-cpu-usage-asset
+[28]: ../../observe-schedule/monitor-server-resources/#create-a-check-to-monitor-a-server

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -28,7 +28,7 @@ To follow this guide, install the Sensu [backend][4], make sure at least one Sen
 
 You'll also need your [PagerDuty API integration key][1] to set up the handler in this guide.
 
-The examples in this guide rely on the `check_cpu` check from [Monitor server resources with checks][3].
+The example in this guide relies on the `check_cpu` check from [Monitor server resources with checks][3].
 Before you begin, follow the instructions to [add the `sensu/check-cpu-usage`][28] dynamic runtime asset and the [`check_cpu`][29] check.
 
 ## Configure a Sensu entity

--- a/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.7/observability-pipeline/observe-process/send-slack-alerts.md
@@ -22,13 +22,22 @@ Pipelines are Sensu resources composed of [observation event][1] processing work
 You can use pipelines to send email alerts, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a pipeline and adding it to a check named `check_cpu`.
-If you don't already have this check in place, follow [Monitor server resources][2] to add the check.
 
-To follow this guide, install the Sensu [backend][17], make sure at least one Sensu [agent][23] is running, and install and configure [sensuctl][24].
+## Requirements
+
+To follow this guide, install the Sensu [backend][17], make sure at least one Sensu [agent][23] is running, and configure [sensuctl][24] to connect to the backend as the [`admin` user][25].
+
+The example in this guide relies on the `check_cpu` check from [Monitor server resources with checks][26].
+Before you begin, follow the instructions to [add the `sensu/check-cpu-usage`][27] dynamic runtime asset and the [`check_cpu`][28] check.
+
+You will also need a [Slack webhook][6] to complete this guide.
+If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
+If you're not yet a Slack admin, [create a new workspace][12] and then create and save your webhook.
+After you save your webhook, you can find the webhook URL under **Integration Settings**.
 
 ## Configure a Sensu entity
 
-Every Sensu agent has a defined set of [subscriptions][21] that determine which checks the agent will execute.
+Every Sensu agent has a defined set of subscriptions that determine which checks the agent will execute.
 For an agent to execute a specific check, you must specify the same subscription in the agent configuration and the check definition.
 To run the `check_cpu` check, you'll need a Sensu entity with the subscription `system`.
 
@@ -40,8 +49,8 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][20] command below.
-Then run the command to add the `system` [subscription][21] to your entity:
+Replace `<ENTITY_NAME>` with the name of your entity in the sensuctl command below.
+Then run the command to add the `system` subscription to your entity:
 
 {{< code shell >}}
 sensuctl entity update <ENTITY_NAME>
@@ -60,10 +69,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-[Dynamic runtime assets][13] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [sensu/sensu-slack-handler][14] dynamic runtime asset to power a `slack` handler.
+Dynamic runtime assets are shareable, reusable packages that help you deploy Sensu plugins.
+In this guide, you'll use the sensu/sensu-slack-handler dynamic runtime asset to power a `slack` handler.
 
-Use [`sensuctl asset add`][10] to register the [sensu/sensu-slack-handler][14] dynamic runtime asset:
+Use `sensuctl asset add` to register the sensu/sensu-slack-handler dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -82,19 +91,9 @@ it's invoked by another Sensu resource (ex. check). To add this runtime asset to
 resource, populate the "runtime_assets" field with ["sensu-slack-handler"].
 {{< /code >}}
 
-You can also download the latest dynamic runtime asset definition for your platform from [Bonsai][14] and register the asset with `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
-
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
-
-## Get a Slack webhook
-
-If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
-If you're not yet a Slack admin, [create a new workspace][12] and then create and save your webhook.
-
-After you save your webhook, you can find the webhook URL under **Integration Settings**.
 
 ## Create a handler
 
@@ -179,18 +178,12 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice protip %}}
-**PRO TIP**: You can also [view complete resource definitions in the Sensu web UI](../../../web-ui/view-manage-resources/#view-resource-data-in-the-web-ui).
-{{% /notice %}}
-
-You can share and reuse this handler like code &mdash; [save it to a file][15] and start building a [monitoring as code repository][16].
-
 ## Create a pipeline that includes the handler
 
-With your handler configured, you can add it to a [pipeline][8] workflow.
+With your handler configured, you can add it to a pipeline workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-For now, the pipeline includes only the `slack` handler and the built-in [not_silenced][22] event filter so that you receive an alert for every event the check generates (including events with OK status).
+For now, the pipeline includes only the `slack` handler and the built-in not_silenced event filter so that you receive an alert for every event the check generates (including events with OK status).
 To create the pipeline, run:
 
 {{< language-toggle >}}
@@ -251,7 +244,7 @@ EOF
 
 ## Assign the pipeline to a check
 
-To use the `cpu_check_alerts` pipeline, list it in a check definition's [pipelines array][18] (in this case, the `check_cpu` check created in [Monitor server resources][2]).
+To use the `cpu_check_alerts` pipeline, list it in a check definition's pipelines array.
 All the observability events that the check produces will be processed according to the pipeline's workflows.
 
 Assign your `cpu_check_alerts` pipeline to the `check_cpu` check to receive Slack alerts when the CPU usage of your system reaches the specific thresholds set in the check command.
@@ -395,14 +388,17 @@ After an event is handled, you should receive a message like this in Slack:
 {{< figure src="/images/go/send_slack_alerts/check_cpu_usage_example_alert.png" alt="Example Slack message" link="/images/go/send_slack_alerts/check_cpu_usage_example_alert.png" target="_blank" >}}
 
 Verify proper handler behavior with `sensu-backend` logs.
-Read [Troubleshoot Sensu][7] for log locations by platform.
 
 Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"event pipe handler executed","output":"","status":0`.
+
+{{% notice note %}}
+**NOTE**: Read [Troubleshoot Sensu](../../../operations/maintain-sensu/troubleshoot/#log-file-locations) for Sensu log locations by platform.
+{{% /notice %}}
 
 ## Add another event filter to the pipeline
 
 At this point, the `cpu_check_alerts` pipeline has probably sent quite a few Slack messages for events with OK (`0`) status.
-To receive alerts for events with *only* warning (`1`) or critical (`2`) status, add the built-in [is_incident][19] event filter to the pipeline:
+To receive alerts for events with *only* warning (`1`) or critical (`2`) status, add the built-in is_incident event filter to the pipeline:
 
 {{< language-toggle >}}
 
@@ -470,23 +466,24 @@ EOF
 
 Adding the is_incident filter to your pipeline should quickly reduce the number of alerts you receive in Slack.
 
-## Next steps
+## What's next
 
 Now that you know how to apply a pipeline to a check and take action on events, read the [pipelines reference][8] for in-depth documentation.
 Read [Route alerts with event filters][9] for a more complex example with multiple filters and handlers organized into several pipeline workflows.
 
-For more information about customizing your Slack alerts, read the [Sensu Slack Handler page in Bonsai][14].
+For more information about customizing your Slack alerts, read the [sensu/sensu-slack-handler page in Bonsai][14].
 
 Follow [Send PagerDuty alerts with Sensu][11] to configure a check that generates status events and a handler that sends Sensu alerts to PagerDuty for non-OK events.
+
+You can share and reuse Sensu resources like code, including the handler and pipeline you created in this guide &mdash; [save the resource definition to a file][15] and start building a [monitoring as code repository][16].
 
 
 [1]: ../../observe-events/events/
 [2]: ../../observe-schedule/monitor-server-resources/
 [3]: https://github.com/sensu/slack-handler
 [4]: https://golang.org/doc/install
-[5]: https://en.wikipedia.org/wiki/PATH_(variable)
 [6]: https://api.slack.com/incoming-webhooks
-[7]: ../../../operations/maintain-sensu/troubleshoot/
+[7]: ../../../operations/maintain-sensu/troubleshoot/#log-file-locations
 [8]: ../pipelines/
 [9]: ../../observe-filter/route-alerts/
 [10]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
@@ -504,3 +501,7 @@ Follow [Send PagerDuty alerts with Sensu][11] to configure a check that generate
 [22]: ../../observe-filter/filters/#built-in-filter-not_silenced
 [23]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [24]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[25]: ../../../operations/control-access/rbac/#default-users
+[26]: ../../observe-schedule/monitor-server-resources/
+[27]: ../../observe-schedule/monitor-server-resources/#register-the-sensucheck-cpu-usage-asset
+[28]: ../../observe-schedule/monitor-server-resources/#create-a-check-to-monitor-a-server

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -28,7 +28,7 @@ To follow this guide, install the Sensu [backend][4], make sure at least one Sen
 
 You'll also need your [PagerDuty API integration key][1] to set up the handler in this guide.
 
-The examples in this guide rely on the `check_cpu` check from [Monitor server resources with checks][3].
+The example in this guide relies on the `check_cpu` check from [Monitor server resources with checks][3].
 Before you begin, follow the instructions to [add the `sensu/check-cpu-usage`][28] dynamic runtime asset and the [`check_cpu`][29] check.
 
 ## Configure a Sensu entity

--- a/content/sensu-go/6.8/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.8/observability-pipeline/observe-process/send-slack-alerts.md
@@ -22,13 +22,22 @@ Pipelines are Sensu resources composed of [observation event][1] processing work
 You can use pipelines to send email alerts, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a pipeline and adding it to a check named `check_cpu`.
-If you don't already have this check in place, follow [Monitor server resources][2] to add the check.
 
-To follow this guide, install the Sensu [backend][17], make sure at least one Sensu [agent][23] is running, and install and configure [sensuctl][24].
+## Requirements
+
+To follow this guide, install the Sensu [backend][17], make sure at least one Sensu [agent][23] is running, and configure [sensuctl][24] to connect to the backend as the [`admin` user][25].
+
+The example in this guide relies on the `check_cpu` check from [Monitor server resources with checks][26].
+Before you begin, follow the instructions to [add the `sensu/check-cpu-usage`][27] dynamic runtime asset and the [`check_cpu`][28] check.
+
+You will also need a [Slack webhook][6] to complete this guide.
+If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
+If you're not yet a Slack admin, [create a new workspace][12] and then create and save your webhook.
+After you save your webhook, you can find the webhook URL under **Integration Settings**.
 
 ## Configure a Sensu entity
 
-Every Sensu agent has a defined set of [subscriptions][21] that determine which checks the agent will execute.
+Every Sensu agent has a defined set of subscriptions that determine which checks the agent will execute.
 For an agent to execute a specific check, you must specify the same subscription in the agent configuration and the check definition.
 To run the `check_cpu` check, you'll need a Sensu entity with the subscription `system`.
 
@@ -40,8 +49,8 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][20] command below.
-Then run the command to add the `system` [subscription][21] to your entity:
+Replace `<ENTITY_NAME>` with the name of your entity in the sensuctl command below.
+Then run the command to add the `system` subscription to your entity:
 
 {{< code shell >}}
 sensuctl entity update <ENTITY_NAME>
@@ -60,10 +69,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-[Dynamic runtime assets][13] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [sensu/sensu-slack-handler][14] dynamic runtime asset to power a `slack` handler.
+Dynamic runtime assets are shareable, reusable packages that help you deploy Sensu plugins.
+In this guide, you'll use the sensu/sensu-slack-handler dynamic runtime asset to power a `slack` handler.
 
-Use [`sensuctl asset add`][10] to register the [sensu/sensu-slack-handler][14] dynamic runtime asset:
+Use `sensuctl asset add` to register the sensu/sensu-slack-handler dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -82,19 +91,9 @@ it's invoked by another Sensu resource (ex. check). To add this runtime asset to
 resource, populate the "runtime_assets" field with ["sensu-slack-handler"].
 {{< /code >}}
 
-You can also download the latest dynamic runtime asset definition for your platform from [Bonsai][14] and register the asset with `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
-
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
-
-## Get a Slack webhook
-
-If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
-If you're not yet a Slack admin, [create a new workspace][12] and then create and save your webhook.
-
-After you save your webhook, you can find the webhook URL under **Integration Settings**.
 
 ## Create a handler
 
@@ -179,18 +178,12 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice protip %}}
-**PRO TIP**: You can also [view complete resource definitions in the Sensu web UI](../../../web-ui/view-manage-resources/#view-resource-data-in-the-web-ui).
-{{% /notice %}}
-
-You can share and reuse this handler like code &mdash; [save it to a file][15] and start building a [monitoring as code repository][16].
-
 ## Create a pipeline that includes the handler
 
-With your handler configured, you can add it to a [pipeline][8] workflow.
+With your handler configured, you can add it to a pipeline workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-For now, the pipeline includes only the `slack` handler and the built-in [not_silenced][22] event filter so that you receive an alert for every event the check generates (including events with OK status).
+For now, the pipeline includes only the `slack` handler and the built-in not_silenced event filter so that you receive an alert for every event the check generates (including events with OK status).
 To create the pipeline, run:
 
 {{< language-toggle >}}
@@ -251,7 +244,7 @@ EOF
 
 ## Assign the pipeline to a check
 
-To use the `cpu_check_alerts` pipeline, list it in a check definition's [pipelines array][18] (in this case, the `check_cpu` check created in [Monitor server resources][2]).
+To use the `cpu_check_alerts` pipeline, list it in a check definition's pipelines array.
 All the observability events that the check produces will be processed according to the pipeline's workflows.
 
 Assign your `cpu_check_alerts` pipeline to the `check_cpu` check to receive Slack alerts when the CPU usage of your system reaches the specific thresholds set in the check command.
@@ -395,14 +388,17 @@ After an event is handled, you should receive a message like this in Slack:
 {{< figure src="/images/go/send_slack_alerts/check_cpu_usage_example_alert.png" alt="Example Slack message" link="/images/go/send_slack_alerts/check_cpu_usage_example_alert.png" target="_blank" >}}
 
 Verify proper handler behavior with `sensu-backend` logs.
-Read [Troubleshoot Sensu][7] for log locations by platform.
 
 Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"event pipe handler executed","output":"","status":0`.
+
+{{% notice note %}}
+**NOTE**: Read [Troubleshoot Sensu](../../../operations/maintain-sensu/troubleshoot/#log-file-locations) for Sensu log locations by platform.
+{{% /notice %}}
 
 ## Add another event filter to the pipeline
 
 At this point, the `cpu_check_alerts` pipeline has probably sent quite a few Slack messages for events with OK (`0`) status.
-To receive alerts for events with *only* warning (`1`) or critical (`2`) status, add the built-in [is_incident][19] event filter to the pipeline:
+To receive alerts for events with *only* warning (`1`) or critical (`2`) status, add the built-in is_incident event filter to the pipeline:
 
 {{< language-toggle >}}
 
@@ -470,23 +466,24 @@ EOF
 
 Adding the is_incident filter to your pipeline should quickly reduce the number of alerts you receive in Slack.
 
-## Next steps
+## What's next
 
 Now that you know how to apply a pipeline to a check and take action on events, read the [pipelines reference][8] for in-depth documentation.
 Read [Route alerts with event filters][9] for a more complex example with multiple filters and handlers organized into several pipeline workflows.
 
-For more information about customizing your Slack alerts, read the [Sensu Slack Handler page in Bonsai][14].
+For more information about customizing your Slack alerts, read the [sensu/sensu-slack-handler page in Bonsai][14].
 
 Follow [Send PagerDuty alerts with Sensu][11] to configure a check that generates status events and a handler that sends Sensu alerts to PagerDuty for non-OK events.
+
+You can share and reuse Sensu resources like code, including the handler and pipeline you created in this guide &mdash; [save the resource definition to a file][15] and start building a [monitoring as code repository][16].
 
 
 [1]: ../../observe-events/events/
 [2]: ../../observe-schedule/monitor-server-resources/
 [3]: https://github.com/sensu/slack-handler
 [4]: https://golang.org/doc/install
-[5]: https://en.wikipedia.org/wiki/PATH_(variable)
 [6]: https://api.slack.com/incoming-webhooks
-[7]: ../../../operations/maintain-sensu/troubleshoot/
+[7]: ../../../operations/maintain-sensu/troubleshoot/#log-file-locations
 [8]: ../pipelines/
 [9]: ../../observe-filter/route-alerts/
 [10]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
@@ -504,3 +501,7 @@ Follow [Send PagerDuty alerts with Sensu][11] to configure a check that generate
 [22]: ../../observe-filter/filters/#built-in-filter-not_silenced
 [23]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [24]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[25]: ../../../operations/control-access/rbac/#default-users
+[26]: ../../observe-schedule/monitor-server-resources/
+[27]: ../../observe-schedule/monitor-server-resources/#register-the-sensucheck-cpu-usage-asset
+[28]: ../../observe-schedule/monitor-server-resources/#create-a-check-to-monitor-a-server

--- a/content/sensu-go/6.9/observability-pipeline/observe-process/send-pagerduty-alerts.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-process/send-pagerduty-alerts.md
@@ -28,7 +28,7 @@ To follow this guide, install the Sensu [backend][4], make sure at least one Sen
 
 You'll also need your [PagerDuty API integration key][1] to set up the handler in this guide.
 
-The examples in this guide rely on the `check_cpu` check from [Monitor server resources with checks][3].
+The example in this guide relies on the `check_cpu` check from [Monitor server resources with checks][3].
 Before you begin, follow the instructions to [add the `sensu/check-cpu-usage`][28] dynamic runtime asset and the [`check_cpu`][29] check.
 
 ## Configure a Sensu entity

--- a/content/sensu-go/6.9/observability-pipeline/observe-process/send-slack-alerts.md
+++ b/content/sensu-go/6.9/observability-pipeline/observe-process/send-slack-alerts.md
@@ -22,13 +22,22 @@ Pipelines are Sensu resources composed of [observation event][1] processing work
 You can use pipelines to send email alerts, create or resolve incidents (in PagerDuty, for example), or store metrics in a time-series database like InfluxDB.
 
 This guide will help you send alerts to Slack in the channel `monitoring` by configuring a pipeline and adding it to a check named `check_cpu`.
-If you don't already have this check in place, follow [Monitor server resources][2] to add the check.
 
-To follow this guide, install the Sensu [backend][17], make sure at least one Sensu [agent][23] is running, and install and configure [sensuctl][24].
+## Requirements
+
+To follow this guide, install the Sensu [backend][17], make sure at least one Sensu [agent][23] is running, and configure [sensuctl][24] to connect to the backend as the [`admin` user][25].
+
+The example in this guide relies on the `check_cpu` check from [Monitor server resources with checks][26].
+Before you begin, follow the instructions to [add the `sensu/check-cpu-usage`][27] dynamic runtime asset and the [`check_cpu`][28] check.
+
+You will also need a [Slack webhook][6] to complete this guide.
+If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
+If you're not yet a Slack admin, [create a new workspace][12] and then create and save your webhook.
+After you save your webhook, you can find the webhook URL under **Integration Settings**.
 
 ## Configure a Sensu entity
 
-Every Sensu agent has a defined set of [subscriptions][21] that determine which checks the agent will execute.
+Every Sensu agent has a defined set of subscriptions that determine which checks the agent will execute.
 For an agent to execute a specific check, you must specify the same subscription in the agent configuration and the check definition.
 To run the `check_cpu` check, you'll need a Sensu entity with the subscription `system`.
 
@@ -40,8 +49,8 @@ sensuctl entity list
 
 The `ID` in the response is the name of your entity.
 
-Replace `<ENTITY_NAME>` with the name of your entity in the [sensuctl][20] command below.
-Then run the command to add the `system` [subscription][21] to your entity:
+Replace `<ENTITY_NAME>` with the name of your entity in the sensuctl command below.
+Then run the command to add the `system` subscription to your entity:
 
 {{< code shell >}}
 sensuctl entity update <ENTITY_NAME>
@@ -60,10 +69,10 @@ The response should indicate `active (running)` for both the Sensu backend and a
 
 ## Register the dynamic runtime asset
 
-[Dynamic runtime assets][13] are shareable, reusable packages that help you deploy Sensu plugins.
-In this guide, you'll use the [sensu/sensu-slack-handler][14] dynamic runtime asset to power a `slack` handler.
+Dynamic runtime assets are shareable, reusable packages that help you deploy Sensu plugins.
+In this guide, you'll use the sensu/sensu-slack-handler dynamic runtime asset to power a `slack` handler.
 
-Use [`sensuctl asset add`][10] to register the [sensu/sensu-slack-handler][14] dynamic runtime asset:
+Use `sensuctl asset add` to register the sensu/sensu-slack-handler dynamic runtime asset:
 
 {{< code shell >}}
 sensuctl asset add sensu/sensu-slack-handler:1.5.0 -r sensu-slack-handler
@@ -82,19 +91,9 @@ it's invoked by another Sensu resource (ex. check). To add this runtime asset to
 resource, populate the "runtime_assets" field with ["sensu-slack-handler"].
 {{< /code >}}
 
-You can also download the latest dynamic runtime asset definition for your platform from [Bonsai][14] and register the asset with `sensuctl create --file filename.yml` or `sensuctl create --file filename.json`.
-
 {{% notice note %}}
 **NOTE**: Sensu does not download and install dynamic runtime asset builds onto the system until they are needed for command execution.
-Read the [asset reference](../../../plugins/assets#dynamic-runtime-asset-builds) for more information about dynamic runtime asset builds.
 {{% /notice %}}
-
-## Get a Slack webhook
-
-If you're already the admin of a Slack, visit `https://YOUR_WORKSPACE_NAME_HERE.slack.com/services/new/incoming-webhook` and follow the steps to add the Incoming WebHooks integration, choose a channel, and save the settings.
-If you're not yet a Slack admin, [create a new workspace][12] and then create and save your webhook.
-
-After you save your webhook, you can find the webhook URL under **Integration Settings**.
 
 ## Create a handler
 
@@ -179,18 +178,12 @@ spec:
 
 {{< /language-toggle >}}
 
-{{% notice protip %}}
-**PRO TIP**: You can also [view complete resource definitions in the Sensu web UI](../../../web-ui/view-manage-resources/#view-resource-data-in-the-web-ui).
-{{% /notice %}}
-
-You can share and reuse this handler like code &mdash; [save it to a file][15] and start building a [monitoring as code repository][16].
-
 ## Create a pipeline that includes the handler
 
-With your handler configured, you can add it to a [pipeline][8] workflow.
+With your handler configured, you can add it to a pipeline workflow.
 A single pipeline workflow can include one or more filters, one mutator, and one handler.
 
-For now, the pipeline includes only the `slack` handler and the built-in [not_silenced][22] event filter so that you receive an alert for every event the check generates (including events with OK status).
+For now, the pipeline includes only the `slack` handler and the built-in not_silenced event filter so that you receive an alert for every event the check generates (including events with OK status).
 To create the pipeline, run:
 
 {{< language-toggle >}}
@@ -251,7 +244,7 @@ EOF
 
 ## Assign the pipeline to a check
 
-To use the `cpu_check_alerts` pipeline, list it in a check definition's [pipelines array][18] (in this case, the `check_cpu` check created in [Monitor server resources][2]).
+To use the `cpu_check_alerts` pipeline, list it in a check definition's pipelines array.
 All the observability events that the check produces will be processed according to the pipeline's workflows.
 
 Assign your `cpu_check_alerts` pipeline to the `check_cpu` check to receive Slack alerts when the CPU usage of your system reaches the specific thresholds set in the check command.
@@ -395,14 +388,17 @@ After an event is handled, you should receive a message like this in Slack:
 {{< figure src="/images/go/send_slack_alerts/check_cpu_usage_example_alert.png" alt="Example Slack message" link="/images/go/send_slack_alerts/check_cpu_usage_example_alert.png" target="_blank" >}}
 
 Verify proper handler behavior with `sensu-backend` logs.
-Read [Troubleshoot Sensu][7] for log locations by platform.
 
 Whenever an event is being handled, a log entry is added with the message `"handler":"slack","level":"debug","msg":"sending event to handler"`, followed by a second log entry with the message `"msg":"event pipe handler executed","output":"","status":0`.
+
+{{% notice note %}}
+**NOTE**: Read [Troubleshoot Sensu](../../../operations/maintain-sensu/troubleshoot/#log-file-locations) for Sensu log locations by platform.
+{{% /notice %}}
 
 ## Add another event filter to the pipeline
 
 At this point, the `cpu_check_alerts` pipeline has probably sent quite a few Slack messages for events with OK (`0`) status.
-To receive alerts for events with *only* warning (`1`) or critical (`2`) status, add the built-in [is_incident][19] event filter to the pipeline:
+To receive alerts for events with *only* warning (`1`) or critical (`2`) status, add the built-in is_incident event filter to the pipeline:
 
 {{< language-toggle >}}
 
@@ -470,23 +466,24 @@ EOF
 
 Adding the is_incident filter to your pipeline should quickly reduce the number of alerts you receive in Slack.
 
-## Next steps
+## What's next
 
 Now that you know how to apply a pipeline to a check and take action on events, read the [pipelines reference][8] for in-depth documentation.
 Read [Route alerts with event filters][9] for a more complex example with multiple filters and handlers organized into several pipeline workflows.
 
-For more information about customizing your Slack alerts, read the [Sensu Slack Handler page in Bonsai][14].
+For more information about customizing your Slack alerts, read the [sensu/sensu-slack-handler page in Bonsai][14].
 
 Follow [Send PagerDuty alerts with Sensu][11] to configure a check that generates status events and a handler that sends Sensu alerts to PagerDuty for non-OK events.
+
+You can share and reuse Sensu resources like code, including the handler and pipeline you created in this guide &mdash; [save the resource definition to a file][15] and start building a [monitoring as code repository][16].
 
 
 [1]: ../../observe-events/events/
 [2]: ../../observe-schedule/monitor-server-resources/
 [3]: https://github.com/sensu/slack-handler
 [4]: https://golang.org/doc/install
-[5]: https://en.wikipedia.org/wiki/PATH_(variable)
 [6]: https://api.slack.com/incoming-webhooks
-[7]: ../../../operations/maintain-sensu/troubleshoot/
+[7]: ../../../operations/maintain-sensu/troubleshoot/#log-file-locations
 [8]: ../pipelines/
 [9]: ../../observe-filter/route-alerts/
 [10]: ../../../sensuctl/sensuctl-bonsai/#install-dynamic-runtime-asset-definitions
@@ -504,3 +501,7 @@ Follow [Send PagerDuty alerts with Sensu][11] to configure a check that generate
 [22]: ../../observe-filter/filters/#built-in-filter-not_silenced
 [23]: ../../../operations/deploy-sensu/install-sensu/#install-sensu-agents
 [24]: ../../../operations/deploy-sensu/install-sensu/#install-sensuctl
+[25]: ../../../operations/control-access/rbac/#default-users
+[26]: ../../observe-schedule/monitor-server-resources/
+[27]: ../../observe-schedule/monitor-server-resources/#register-the-sensucheck-cpu-usage-asset
+[28]: ../../observe-schedule/monitor-server-resources/#create-a-check-to-monitor-a-server


### PR DESCRIPTION
## Description
Improves https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/send-slack-alerts/ by revising the intro, adding a Requirements section and moving some content about webhooks there, and moving most links to the end of the doc in a What's next section.

## Motivation and Context
Closes https://github.com/sensu/sensu-docs/issues/4034
