### PR TITLE
Remove duplicate "use" typo in Secure Sensu

### DIFF
--- a/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
@@ -242,7 +242,7 @@ key-file: "/etc/sensu/tls/agent-key.pem"
 trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< /code >}}
 
-You can use use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
+You can use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
 However, deployments can also use the same certificates and keys for etcd peer and client communication, the HTTP API, and agent authentication without issues.
 
 ### Certificate revocation check

--- a/content/sensu-go/6.7/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/secure-sensu.md
@@ -242,7 +242,7 @@ key-file: "/etc/sensu/tls/agent-key.pem"
 trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< /code >}}
 
-You can use use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
+You can use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
 However, deployments can also use the same certificates and keys for etcd peer and client communication, the HTTP API, and agent authentication without issues.
 
 ### Certificate revocation check

--- a/content/sensu-go/6.8/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/secure-sensu.md
@@ -242,7 +242,7 @@ key-file: "/etc/sensu/tls/agent-key.pem"
 trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< /code >}}
 
-You can use use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
+You can use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
 However, deployments can also use the same certificates and keys for etcd peer and client communication, the HTTP API, and agent authentication without issues.
 
 ### Certificate revocation check

--- a/content/sensu-go/6.9/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.9/operations/deploy-sensu/secure-sensu.md
@@ -242,7 +242,7 @@ key-file: "/etc/sensu/tls/agent-key.pem"
 trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< /code >}}
 
-You can use use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
+You can use certificates for authentication that are distinct from other communication channels used by Sensu, like etcd or the API.
 However, deployments can also use the same certificates and keys for etcd peer and client communication, the HTTP API, and agent authentication without issues.
 
 ### Certificate revocation check


### PR DESCRIPTION
👋 hi!

## Description
Removes a duplicate "use" typo in the Secure Sensu page (in the last paragraph of https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication)

## Motivation and Context
Found this weekend while working on something else
