### PR TITLE
Example key key name

### DIFF
--- a/content/sensu-go/6.6/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/generate-certificates.md
@@ -191,7 +191,7 @@ In our example with [three backends][18], the directory listing for `/etc/sensu/
 
 {{< code text >}}
 /etc/sensu/tls/
-├── backend-1.example.com-key.pem
+├── backend-1-key.example.com.pem
 ├── backend-1.example.com.pem
 ├── backend-1.example.com.csr
 ├── backend-2-key.example.com.pem
@@ -263,7 +263,7 @@ To continue the example with [three backends][18], the directory listing for `/e
 ├── agent-key.pem
 ├── agent.pem
 ├── agent.csr
-├── backend-1.example.com-key.pem
+├── backend-1-key.example.com.pem
 ├── backend-1.example.com.pem
 ├── backend-1.example.com.csr
 ├── backend-2-key.example.com.pem

--- a/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
@@ -231,8 +231,7 @@ To enable agent mTLS authentication:
 2. Add the following configuration options and values to the backend configuration `/etc/sensu/backend.yml`:
 {{< code yml >}}
 agent-auth-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-agent-auth-key-file: "/etc/sensu/tls/backend-1-key
-.example.com.pem"
+agent-auth-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 agent-auth-trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< /code >}}
 

--- a/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.6/operations/deploy-sensu/secure-sensu.md
@@ -39,13 +39,13 @@ To properly secure etcd communication, replace the default configuration option 
 1. Replace the placeholder with the path to your certificate and key for the `etcd-cert-file` and `etcd-key-file` to secure client communication:
 {{< code yml >}}
 etcd-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-etcd-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+etcd-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 2. Replace the placeholder with the path to your certificate and key for the `etcd-peer-cert-file` and `etcd-peer-key-file` to secure cluster communication:
 {{< code yml >}}
 etcd-peer-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-etcd-peer-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+etcd-peer-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 3. Replace the placeholder with the path to your `ca.pem` certificate for the `etcd-trusted-ca-file` and `etcd-peer-trusted-ca-file` to secure communication with the etcd client server and between etcd cluster members:
@@ -93,7 +93,7 @@ Configure the following backend secure sockets layer (SSL) attributes in `/etc/s
 {{< code yml >}}
 trusted-ca-file: "/etc/sensu/tls/ca.pem"
 cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 2. Set the `insecure-skip-tls-verify` configuration option to `false`:
@@ -231,7 +231,8 @@ To enable agent mTLS authentication:
 2. Add the following configuration options and values to the backend configuration `/etc/sensu/backend.yml`:
 {{< code yml >}}
 agent-auth-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-agent-auth-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+agent-auth-key-file: "/etc/sensu/tls/backend-1-key
+.example.com.pem"
 agent-auth-trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< /code >}}
 

--- a/content/sensu-go/6.7/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/generate-certificates.md
@@ -191,7 +191,7 @@ In our example with [three backends][18], the directory listing for `/etc/sensu/
 
 {{< code text >}}
 /etc/sensu/tls/
-├── backend-1.example.com-key.pem
+├── backend-1-key.example.com.pem
 ├── backend-1.example.com.pem
 ├── backend-1.example.com.csr
 ├── backend-2-key.example.com.pem
@@ -263,7 +263,7 @@ To continue the example with [three backends][18], the directory listing for `/e
 ├── agent-key.pem
 ├── agent.pem
 ├── agent.csr
-├── backend-1.example.com-key.pem
+├── backend-1-key.example.com.pem
 ├── backend-1.example.com.pem
 ├── backend-1.example.com.csr
 ├── backend-2-key.example.com.pem

--- a/content/sensu-go/6.7/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.7/operations/deploy-sensu/secure-sensu.md
@@ -39,13 +39,13 @@ To properly secure etcd communication, replace the default configuration option 
 1. Replace the placeholder with the path to your certificate and key for the `etcd-cert-file` and `etcd-key-file` to secure client communication:
 {{< code yml >}}
 etcd-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-etcd-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+etcd-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 2. Replace the placeholder with the path to your certificate and key for the `etcd-peer-cert-file` and `etcd-peer-key-file` to secure cluster communication:
 {{< code yml >}}
 etcd-peer-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-etcd-peer-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+etcd-peer-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 3. Replace the placeholder with the path to your `ca.pem` certificate for the `etcd-trusted-ca-file` and `etcd-peer-trusted-ca-file` to secure communication with the etcd client server and between etcd cluster members:
@@ -93,7 +93,7 @@ Configure the following backend secure sockets layer (SSL) attributes in `/etc/s
 {{< code yml >}}
 trusted-ca-file: "/etc/sensu/tls/ca.pem"
 cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 2. Set the `insecure-skip-tls-verify` configuration option to `false`:
@@ -231,7 +231,7 @@ To enable agent mTLS authentication:
 2. Add the following configuration options and values to the backend configuration `/etc/sensu/backend.yml`:
 {{< code yml >}}
 agent-auth-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-agent-auth-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+agent-auth-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 agent-auth-trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< /code >}}
 

--- a/content/sensu-go/6.8/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/generate-certificates.md
@@ -191,7 +191,7 @@ In our example with [three backends][18], the directory listing for `/etc/sensu/
 
 {{< code text >}}
 /etc/sensu/tls/
-├── backend-1.example.com-key.pem
+├── backend-1-key.example.com.pem
 ├── backend-1.example.com.pem
 ├── backend-1.example.com.csr
 ├── backend-2-key.example.com.pem
@@ -263,7 +263,7 @@ To continue the example with [three backends][18], the directory listing for `/e
 ├── agent-key.pem
 ├── agent.pem
 ├── agent.csr
-├── backend-1.example.com-key.pem
+├── backend-1-key.example.com.pem
 ├── backend-1.example.com.pem
 ├── backend-1.example.com.csr
 ├── backend-2-key.example.com.pem

--- a/content/sensu-go/6.8/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.8/operations/deploy-sensu/secure-sensu.md
@@ -39,13 +39,13 @@ To properly secure etcd communication, replace the default configuration option 
 1. Replace the placeholder with the path to your certificate and key for the `etcd-cert-file` and `etcd-key-file` to secure client communication:
 {{< code yml >}}
 etcd-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-etcd-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+etcd-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 2. Replace the placeholder with the path to your certificate and key for the `etcd-peer-cert-file` and `etcd-peer-key-file` to secure cluster communication:
 {{< code yml >}}
 etcd-peer-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-etcd-peer-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+etcd-peer-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 3. Replace the placeholder with the path to your `ca.pem` certificate for the `etcd-trusted-ca-file` and `etcd-peer-trusted-ca-file` to secure communication with the etcd client server and between etcd cluster members:
@@ -93,7 +93,7 @@ Configure the following backend secure sockets layer (SSL) attributes in `/etc/s
 {{< code yml >}}
 trusted-ca-file: "/etc/sensu/tls/ca.pem"
 cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 2. Set the `insecure-skip-tls-verify` configuration option to `false`:
@@ -231,7 +231,7 @@ To enable agent mTLS authentication:
 2. Add the following configuration options and values to the backend configuration `/etc/sensu/backend.yml`:
 {{< code yml >}}
 agent-auth-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-agent-auth-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+agent-auth-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 agent-auth-trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< /code >}}
 

--- a/content/sensu-go/6.9/operations/deploy-sensu/generate-certificates.md
+++ b/content/sensu-go/6.9/operations/deploy-sensu/generate-certificates.md
@@ -191,7 +191,7 @@ In our example with [three backends][18], the directory listing for `/etc/sensu/
 
 {{< code text >}}
 /etc/sensu/tls/
-├── backend-1.example.com-key.pem
+├── backend-1-key.example.com.pem
 ├── backend-1.example.com.pem
 ├── backend-1.example.com.csr
 ├── backend-2-key.example.com.pem
@@ -263,7 +263,7 @@ To continue the example with [three backends][18], the directory listing for `/e
 ├── agent-key.pem
 ├── agent.pem
 ├── agent.csr
-├── backend-1.example.com-key.pem
+├── backend-1-key.example.com.pem
 ├── backend-1.example.com.pem
 ├── backend-1.example.com.csr
 ├── backend-2-key.example.com.pem

--- a/content/sensu-go/6.9/operations/deploy-sensu/secure-sensu.md
+++ b/content/sensu-go/6.9/operations/deploy-sensu/secure-sensu.md
@@ -39,13 +39,13 @@ To properly secure etcd communication, replace the default configuration option 
 1. Replace the placeholder with the path to your certificate and key for the `etcd-cert-file` and `etcd-key-file` to secure client communication:
 {{< code yml >}}
 etcd-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-etcd-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+etcd-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 2. Replace the placeholder with the path to your certificate and key for the `etcd-peer-cert-file` and `etcd-peer-key-file` to secure cluster communication:
 {{< code yml >}}
 etcd-peer-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-etcd-peer-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+etcd-peer-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 3. Replace the placeholder with the path to your `ca.pem` certificate for the `etcd-trusted-ca-file` and `etcd-peer-trusted-ca-file` to secure communication with the etcd client server and between etcd cluster members:
@@ -93,7 +93,7 @@ Configure the following backend secure sockets layer (SSL) attributes in `/etc/s
 {{< code yml >}}
 trusted-ca-file: "/etc/sensu/tls/ca.pem"
 cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 {{< /code >}}
 
 2. Set the `insecure-skip-tls-verify` configuration option to `false`:
@@ -231,7 +231,7 @@ To enable agent mTLS authentication:
 2. Add the following configuration options and values to the backend configuration `/etc/sensu/backend.yml`:
 {{< code yml >}}
 agent-auth-cert-file: "/etc/sensu/tls/backend-1.example.com.pem"
-agent-auth-key-file: "/etc/sensu/tls/backend-1.example.com-key.pem"
+agent-auth-key-file: "/etc/sensu/tls/backend-1-key.example.com.pem"
 agent-auth-trusted-ca-file: "/etc/sensu/tls/ca.pem"
 {{< /code >}}
 


### PR DESCRIPTION
## Description
Corrects name of key file for example backend 1 so that it is consistent with the naming convention used for key files for the other example backends.

From:
`backend-1.example.com-key.pem`

To:
`backend-1-key.example.com.pem`
