### PR TITLE
Update Python version to 3.8 for json linter

### DIFF
--- a/.github/workflows/lint-json.yml
+++ b/.github/workflows/lint-json.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 2.7
+          python-version: 3.8
 
       - name: Lint JSON files
         working-directory: ./tests


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/main/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->
Update Python version to 3.8 for json linter since 2.7 is not supported anymore.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->
GitHub action was not working.

## Review Instructions
<!--- Optional -->
