### PR TITLE
Fix redirect for 6.11 and links in Catalog page

### DIFF
--- a/content/sensu-go/6.11/catalog/sensu-catalog.md
+++ b/content/sensu-go/6.11/catalog/sensu-catalog.md
@@ -39,7 +39,7 @@ Sensu curates, tests, and maintains the Catalog integrations, and installation f
 
 ## Find integrations
 
-Find integrations in the Sensu Catalog by browsing [alphabetized][15], [categorized][16], and [metadata-based][17] lists.
+Find integrations in the Sensu Catalog by browsing [alphabetized][16], [categorized][17], and [metadata-based][18] lists.
 You can also [search][19] the Sensu Catalog based on integration metadata.
 
 ### Browse the alphabetized list

--- a/static.json
+++ b/static.json
@@ -39,7 +39,7 @@
             "url": "/sensu-go/latest/operations/control-access/create-read-only-user",
             "status": 301
         },
-        "~ ^/sensu-go/6.111/?((?<=\/).*)?$": {
+        "~ ^/sensu-go/6.11/?((?<=\/).*)?$": {
             "url": "/sensu-go/latest/$1",
             "status": 302
         },


### PR DESCRIPTION
## Description
- In static.json, fixes typo in regex for redirecting 6.11 > latest
- In https://docs.sensu.io/sensu-go/latest/catalog/sensu-catalog/#find-integrations, fixes links to alphabetized, categorized, and metadata-based sections

## Motivation and Context
- Links for 6.11 are displaying a 404 instead of redirecting to latest
- Links in published Catalog page are incorrect
