### PR TITLE
Update node.js 18 instead of 20

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -5,7 +5,7 @@ on: push
 
 jobs:
   build-site:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node-version: [16,18]

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [12,18]
+        node-version: [14,18]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16]
+        node-version: [18,20]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18,20]
+        node-version: [16,18]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [16,18]
+        node-version: [12,18]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint-json.yml
+++ b/.github/workflows/lint-json.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   validate-json:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -5,7 +5,7 @@ on: push
 
 jobs:
   validate-yaml:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hugo-cli": "^0.11.1"
   },
   "engines": {
-    "node": ">= 12 <= 16"
+    "node": ">= 18 <= 20 "
   },
   "browserslist": [
     "defaults"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hugo-cli": "^0.11.1"
   },
   "engines": {
-    "node": ">= 18 <= 20 "
+    "node": ">= 16 <= 18 "
   },
   "browserslist": [
     "defaults"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hugo-cli": "^0.11.1"
   },
   "engines": {
-    "node": ">= 12 <= 18 "
+    "node": ">= 14 <= 18 "
   },
   "browserslist": [
     "defaults"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hugo-cli": "^0.11.1"
   },
   "engines": {
-    "node": ">= 16 <= 18 "
+    "node": ">= 12 <= 18 "
   },
   "browserslist": [
     "defaults"


### PR DESCRIPTION
Closed #4213 

**Changed**
1. Node.js version from [14,16] to [14,18] to avoid build-site warnings related to deprecation of node.js 16
2. Changed Ubuntu version to 24.04  from :latest as warning saying "ubuntu-24.04 will be used henceforth"

**Testing**
No warning with the build checks
