### PR TITLE
Correct spelling of RESORUCE to RESOURCE in create-manage-resources.md

### DIFF
--- a/content/sensu-go/6.11/sensuctl/create-manage-resources.md
+++ b/content/sensu-go/6.11/sensuctl/create-manage-resources.md
@@ -43,7 +43,7 @@ If you use YAML, separate the resource definitions by a line with three hyphens:
 If you use wrapped JSON, separate the resources *without* a comma.
 
 {{% notice note %}}
-**NOTE**: You can also use the `sensuctl <RESORUCE_TYPE> create` command to create resources with sensuctl.
+**NOTE**: You can also use the `sensuctl <RESOURCE_TYPE> create` command to create resources with sensuctl.
 Read [Use the create subcommand](#use-the-create-subcommand) for more information and an example.
 {{% /notice %}}
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/main/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: "Closes #555" -->

## Review Instructions
<!--- Optional -->
