### PR TITLE
Correct typo SENSU_KEEPALIVE_INTERNAL

### DIFF
--- a/content/sensu-go/6.12/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.12/observability-pipeline/observe-schedule/agent.md
@@ -1188,7 +1188,7 @@ keepalive-handlers:
 description          | Number of seconds between keepalive events.
 type                 | Integer
 default              | `20`
-environment variable   | `SENSU_KEEPALIVE_INTERNAL`
+environment variable   | `SENSU_KEEPALIVE_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-interval 30{{< /code >}}
 agent.yml config file example | {{< code shell >}}


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/main/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Correct typo `SENSU_KEEPALIVE_INTERNAL` to `SENSU_KEEPALIVE_INTERVAL`.

## Motivation and Context
I searched the docs for `keepalive_interval` and found nothing, which was confusing, and then I noticed this typo. I also verified that this is correct [in source](https://github.com/sensu/sensu-go/blob/3b6b79dbc6be264d26939b60aa160784cdc691a8/agent/cmd/start.go#L53) and not also wrong there.