### PR TITLE
update stack 20 to 24

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/boot
+web: bin/start-nginx-static

--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
             "url": "urn:buildpack:heroku/nodejs"
         },
         {
-            "url": "https://github.com/sensu/heroku-buildpack-static.git"
+            "url": "urn:buildpack:heroku-community/nginx"
         }
       ]
 }

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,0 +1,253 @@
+daemon off;
+# stay attached to the dyno process, run in Procfile / web
+
+pid /app/nginx.pid;
+# /app is $HOME & working directory of Heroku dyno
+
+error_log stderr info;
+# As documented for Nginx, but we still see error during start-up in log:
+# >  nginx: [alert] could not open error log file: open() "./logs/error.log"
+
+worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
+# Heroku dynos have at least 4 cores.
+
+events {
+	use epoll;
+	accept_mutex on;
+	worker_connections <%= ENV['NGINX_WORKER_CONNECTIONS'] || 1024 %>;
+}
+
+http {
+	gzip on;
+	gzip_comp_level 2;
+	gzip_min_length 512;
+	gzip_proxied any; # Heroku router sends Via header
+
+	server_tokens off;
+
+	log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
+	access_log /dev/stdout l2met;
+	# Remote IP, request path, HTTP status, & timestamp are all logged by Heroku Router, so not useful to include here.
+
+	include mime.types;
+	default_type application/octet-stream;
+	sendfile on;
+
+	client_body_timeout <%= ENV['NGINX_CLIENT_BODY_TIMEOUT'] || 5 %>;
+	# Must read the body in 5 seconds.
+
+	server {
+		listen <%= ENV["PORT"] %>;
+		server_name _;
+		keepalive_timeout 5;
+		client_max_body_size <%= ENV['NGINX_CLIENT_MAX_BODY_SIZE'] || 1 %>M;
+
+		# force portless redirect host
+        set $redirect_host $host;
+
+        if ($http_host ~* "^([^:]+)(:\d+)?$") {
+          set $redirect_host $1;
+        }
+
+		## Document root
+		root /app/public;
+
+		if ($http_x_forwarded_proto != "https") {
+          return 301 https://$redirect_host$request_uri;
+        }
+
+        error_page 404 /404.html;
+
+
+
+         # === BEGIN REDIRECT RULES ===
+        rewrite ^/sensu-core/0\.19/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/2\.0/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/uchiwa/0\.3/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/sensu-enterprise/3\.[0-8]/?(\.*)?$ https://$redirect_host/sensu-enterprise/latest/$1 permanent;
+        #rewrite ^/sensu-go/6\.13/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 redirect;
+        rewrite ^/sensu-go/6\.13/(.*)$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/plugins/?(\.*)?$ https://$redirect_host/sensu-go/latest/plugins permanent;
+        rewrite ^/sensu-core/1\.[0-9]/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.89/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.0/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.59/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.7/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.29/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/uchiwa/2\.4/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.99/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.49/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/uchiwa/3\.4/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.39/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.69/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.9/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.4/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.79/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.99/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.9/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/0\.6/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.8/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.1/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.69/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.59/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.29/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.3/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.6/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.2/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.39/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.7/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.5/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.8/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.0/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.19/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.1/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.9/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.0/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.29/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.4/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.79/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.2/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.3/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.8/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.7/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.6/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.89/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.49/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.39/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.69/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.59/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.99/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.29/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.79/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.19/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/0\.09/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.1/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.2/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.3/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.4/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.5/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.6/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.7/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.8/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/1\.9/?(\.*)?$ https://$redirect_host/sensu-core/latest/$1 permanent;
+        rewrite ^/sensu-core/2\.0/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-core/2\.1/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.0/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.1/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.2/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.3/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.4/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.5/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.6/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.7/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.8/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/1\.9/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/2\.0/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/2\.1/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/2\.2/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/2\.3/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/2\.4/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/uchiwa/2\.5/?(\.*)?$ https://$redirect_host/uchiwa/latest/$1 permanent;
+        rewrite ^/sensu-go/latest/guides/create-a-ready-only-user/?$ https://$redirect_host/sensu-go/latest/operations/control-access/create-read-only-user permanent;
+        rewrite ^/sensu-go/6\.13/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 redirect;
+        rewrite ^/sensu-go/6\.[0-9]/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.20/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.21/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.22/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.23/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.24/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.25/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.26/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.27/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.28/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.29/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/sensu-go/5\.30/?(\.*)?$ https://$redirect_host/sensu-go/latest/$1 permanent;
+        rewrite ^/plugins/?(\.*)?$ https://$redirect_host/sensu-go/latest/plugins permanent;
+        rewrite ^/sensu-go/latest/guides/securing-sensu/?$ https://$redirect_host/sensu-go/latest/operations/deploy-sensu/secure-sensu permanent;
+        rewrite ^/sensu-go/5\.20/.*/guides/securing-sensu/?$ https://$redirect_host/sensu-go/latest/operations/deploy-sensu/secure-sensu permanent;
+        rewrite ^/sensu-go/5\.21/.*/guides/securing-sensu/?$ https://$redirect_host/sensu-go/latest/operations/deploy-sensu/secure-sensu permanent;
+        rewrite ^/sensu-go/5\.22/.*/guides/securing-sensu/?$ https://$redirect_host/sensu-go/latest/operations/deploy-sensu/secure-sensu permanent;
+        rewrite ^/sensu-go/5\.23/.*/guides/securing-sensu/?$ https://$redirect_host/sensu-go/latest/operations/deploy-sensu/secure-sensu permanent;
+        rewrite ^/sensu-go/latest/guides/troubleshooting/?$ https://$redirect_host/sensu-go/latest/operations/maintain-sensu/troubleshoot permanent;
+        rewrite ^/sensu-go/5\.20/.*/guides/troubleshooting/?$ https://$redirect_host/sensu-go/latest/operations/maintain-sensu/troubleshoot permanent;
+        rewrite ^/sensu-go/5\.21/.*/guides/troubleshooting/?$ https://$redirect_host/sensu-go/latest/operations/maintain-sensu/troubleshoot permanent;
+        rewrite ^/sensu-go/latest/reference/events/?$ https://$redirect_host/sensu-go/latest/observability-pipeline/observe-events/events permanent;
+        rewrite ^/sensu-go/latest/learn/sandbox/?$ https://$redirect_host/sensu-go/latest/learn permanent;
+        rewrite ^/sensu-go/6\.[0-9]/learn/sandbox/?$ https://$redirect_host/sensu-go/latest/learn permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/apikeys/?$ https://$redirect_host/sensu-go/latest/api/core/apikeys/$1 permanent;
+        rewrite ^/sensu-go/latest/api/apikeys/?$ https://$redirect_host/sensu-go/latest/api/core/apikeys/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/assets/?$ https://$redirect_host/sensu-go/latest/api/core/assets/$1 permanent;
+        rewrite ^/sensu-go/latest/api/assets/?$ https://$redirect_host/sensu-go/latest/api/core/assets/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/checks/?$ https://$redirect_host/sensu-go/latest/api/core/checks/$1 permanent;
+        rewrite ^/sensu-go/latest/api/checks/?$ https://$redirect_host/sensu-go/latest/api/core/checks/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/cluster/?$ https://$redirect_host/sensu-go/latest/api/core/cluster/$1 permanent;
+        rewrite ^/sensu-go/latest/api/cluster/?$ https://$redirect_host/sensu-go/latest/api/core/cluster/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/entities/?$ https://$redirect_host/sensu-go/latest/api/core/entities/$1 permanent;
+        rewrite ^/sensu-go/latest/api/entities/?$ https://$redirect_host/sensu-go/latest/api/core/entities/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/events/?$ https://$redirect_host/sensu-go/latest/api/core/events/$1 permanent;
+        rewrite ^/sensu-go/latest/api/events/?$ https://$redirect_host/sensu-go/latest/api/core/events/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/filters/?$ https://$redirect_host/sensu-go/latest/api/core/filters/$1 permanent;
+        rewrite ^/sensu-go/latest/api/filters/?$ https://$redirect_host/sensu-go/latest/api/core/filters/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/handlers/?$ https://$redirect_host/sensu-go/latest/api/core/handlers/$1 permanent;
+        rewrite ^/sensu-go/latest/api/handlers/?$ https://$redirect_host/sensu-go/latest/api/core/handlers/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/hooks/?$ https://$redirect_host/sensu-go/latest/api/core/hooks/$1 permanent;
+        rewrite ^/sensu-go/latest/api/hooks/?$ https://$redirect_host/sensu-go/latest/api/core/hooks/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/mutators/?$ https://$redirect_host/sensu-go/latest/api/core/mutators/$1 permanent;
+        rewrite ^/sensu-go/latest/api/mutators/?$ https://$redirect_host/sensu-go/latest/api/core/mutators/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/namespaces/?$ https://$redirect_host/sensu-go/latest/api/core/namespaces/$1 permanent;
+        rewrite ^/sensu-go/latest/api/namespaces/?$ https://$redirect_host/sensu-go/latest/api/core/namespaces/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/pipeline-resource/?$ https://$redirect_host/sensu-go/latest/api/core/pipelines/$1 permanent;
+        rewrite ^/sensu-go/latest/api/pipeline-resource/?$ https://$redirect_host/sensu-go/latest/api/core/pipelines/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/role-bindings/?$ https://$redirect_host/sensu-go/latest/api/core/rolebindings/$1 permanent;
+        rewrite ^/sensu-go/latest/api/role-bindings/?$ https://$redirect_host/sensu-go/latest/api/core/rolebindings/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/roles/?$ https://$redirect_host/sensu-go/latest/api/core/roles/$1 permanent;
+        rewrite ^/sensu-go/latest/api/roles/?$ https://$redirect_host/sensu-go/latest/api/core/roles/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/silenced/?$ https://$redirect_host/sensu-go/latest/api/core/silenced/$1 permanent;
+        rewrite ^/sensu-go/latest/api/silenced/?$ https://$redirect_host/sensu-go/latest/api/core/silenced/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/tessen/?$ https://$redirect_host/sensu-go/latest/api/core/tessen/$1 permanent;
+        rewrite ^/sensu-go/latest/api/tessen/?$ https://$redirect_host/sensu-go/latest/api/core/tessen/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/users/?$ https://$redirect_host/sensu-go/latest/api/core/users/$1 permanent;
+        rewrite ^/sensu-go/latest/api/users/?$ https://$redirect_host/sensu-go/latest/api/core/users/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/authproviders/?$ https://$redirect_host/sensu-go/latest/api/enterprise/authproviders/$1 permanent;
+        rewrite ^/sensu-go/latest/api/authproviders/?$ https://$redirect_host/sensu-go/latest/api/enterprise/authproviders/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/business-service-monitoring/?$ https://$redirect_host/sensu-go/latest/api/enterprise/business-service-monitoring/$1 permanent;
+        rewrite ^/sensu-go/latest/api/business-service-monitoring/?$ https://$redirect_host/sensu-go/latest/api/enterprise/business-service-monitoring/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/federation/?$ https://$redirect_host/sensu-go/latest/api/enterprise/federation/$1 permanent;
+        rewrite ^/sensu-go/latest/api/federation/?$ https://$redirect_host/sensu-go/latest/api/enterprise/federation/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/pipeline/?$ https://$redirect_host/sensu-go/latest/api/enterprise/pipeline/$1 permanent;
+        rewrite ^/sensu-go/latest/api/pipeline/?$ https://$redirect_host/sensu-go/latest/api/enterprise/pipeline/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/prune/?$ https://$redirect_host/sensu-go/latest/api/enterprise/prune/$1 permanent;
+        rewrite ^/sensu-go/latest/api/prune/?$ https://$redirect_host/sensu-go/latest/api/enterprise/prune/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/searches/?$ https://$redirect_host/sensu-go/latest/api/enterprise/searches/$1 permanent;
+        rewrite ^/sensu-go/latest/api/searches/?$ https://$redirect_host/sensu-go/latest/api/enterprise/searches/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/secrets/?$ https://$redirect_host/sensu-go/latest/api/enterprise/secrets/$1 permanent;
+        rewrite ^/sensu-go/latest/api/secrets/?$ https://$redirect_host/sensu-go/latest/api/enterprise/secrets/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/datastore/?$ https://$redirect_host/sensu-go/latest/api/enterprise/datastore/$1 permanent;
+        rewrite ^/sensu-go/latest/api/datastore/?$ https://$redirect_host/sensu-go/latest/api/enterprise/datastore/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/webconfig/?$ https://$redirect_host/sensu-go/latest/api/enterprise/webconfig/$1 permanent;
+        rewrite ^/sensu-go/latest/api/webconfig/?$ https://$redirect_host/sensu-go/latest/api/enterprise/webconfig/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/auth/?$ https://$redirect_host/sensu-go/latest/api/other/auth/$1 permanent;
+        rewrite ^/sensu-go/latest/api/auth/?$ https://$redirect_host/sensu-go/latest/api/other/auth/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/health/?$ https://$redirect_host/sensu-go/latest/api/other/health/$1 permanent;
+        rewrite ^/sensu-go/latest/api/health/?$ https://$redirect_host/sensu-go/latest/api/other/health/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/license/?$ https://$redirect_host/sensu-go/latest/api/other/license/$1 permanent;
+        rewrite ^/sensu-go/latest/api/license/?$ https://$redirect_host/sensu-go/latest/api/other/license/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/metrics/?$ https://$redirect_host/sensu-go/latest/api/other/metrics/$1 permanent;
+        rewrite ^/sensu-go/latest/api/metrics/?$ https://$redirect_host/sensu-go/latest/api/other/metrics/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-6]/api/version/?$ https://$redirect_host/sensu-go/latest/api/other/version/$1 permanent;
+        rewrite ^/sensu-go/latest/api/version/?$ https://$redirect_host/sensu-go/latest/api/other/version/$1 permanent;
+        rewrite ^/sensu-go/6\.7/web-ui/sensu-catalog/?$ https://$redirect_host/sensu-go/6.7/catalog/sensu-catalog/$1 permanent;
+        rewrite ^/sensu-go/6\.8/web-ui/sensu-catalog/?$ https://$redirect_host/sensu-go/6.8/catalog/sensu-catalog/$1 permanent;
+        rewrite ^/sensu-go/6\.9/web-ui/sensu-catalog/?$ https://$redirect_host/sensu-go/6.9/catalog/sensu-catalog/$1 permanent;
+        rewrite ^/sensu-go/latest/web-ui/sensu-catalog/?$ https://$redirect_host/sensu-go/latest/catalog/sensu-catalog/$1 permanent;
+        rewrite ^/sensu-go/6\.[3-7]/plugins/supported-integrations/?(\.*)?$ https://$redirect_host/sensu-go/latest/plugins/featured-integrations/$1 permanent;
+        rewrite ^/sensu-go/latest/plugins/supported-integrations/?(\.*)?$ https://$redirect_host/sensu-go/latest/plugins/featured-integrations/$1 permanent;
+        rewrite ^/sensu-go/latest/guides/install-check-executables-with-assets/?(\.*)?$ https://$redirect_host/sensu-go/latest/plugins/use-assets-to-install-plugins/$1 permanent;
+        rewrite ^/sensu-go/latest/reference/assets/?(\.*)?$ https://$redirect_host/sensu-go/latest/plugins/assets/$1 permanent;
+        # === END REDIRECT RULES ===
+
+        location / {
+          try_files $uri $uri/ /404.html;
+        }
+	}
+}

--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -204,7 +204,7 @@
           {{ if isset .Page.Params "product" }}
             'version:{{ .Page.Params.version }}'
           {{ else }}
-            'version:6.12',
+            'version:6.13',
             'version:1.0',
             'version:2.16',
             'version:1.9',

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -34,7 +34,7 @@
       <meta name="docsearch:version" content="{{ .Page.Params.version }}" />
     {{ end}}
 
-    {{ if not (eq .Params.version "6.12") }}
+    {{ if not (eq .Params.version "6.13") }}
     <meta name="robots" content="noindex">
     {{ end }}
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! -->
<!--- If you haven't yet, please read the contributing guide at: -->
<!--- https://github.com/sensu/sensu-docs/blob/main/CONTRIBUTING.md -->
<!--- Provide a general summary of your changes in the Title above. -->

## Description
updating heroku stack 20 to stack 24 due to deprecation of stack 20 by heroku on april 30th 2025

## Motivation and Context
moved to nginx based buildpack, static buildpack is not supported in stack 24

## Review Instructions
use "heroku login" to login to heroku cli and then continue with below steps

heroku buildpacks:clear -a sensu-docs-stage
heroku buildpacks:set heroku/nodejs -a sensu-docs-stage
heroku buildpacks:add --app sensu-docs-stage heroku-community/nginx
Above steps will clear any buildpacks first, then it will set nodejs as buildpack and then finally add nginx support to serve the requests.
