### PR TITLE
Fixed typos in agent.md

### DIFF
--- a/content/sensu-go/6.13/observability-pipeline/observe-schedule/agent.md
+++ b/content/sensu-go/6.13/observability-pipeline/observe-schedule/agent.md
@@ -1027,7 +1027,7 @@ retry-multiplier: 2.0{{< /code >}}
 
 <a id="strip-networks"></a>
 
-| subscriptions |      |
+| strip-networks |      |
 ----------------|------
 description     | When set to `true`, prevents network information from being collected by the Sensu agent.
 type            | Boolean
@@ -1188,7 +1188,7 @@ keepalive-handlers:
 description          | Number of seconds between keepalive events.
 type                 | Integer
 default              | `20`
-environment variable   | `SENSU_KEEPALIVE_INTERNAL`
+environment variable   | `SENSU_KEEPALIVE_INTERVAL`
 command line example   | {{< code shell >}}
 sensu-agent start --keepalive-interval 30{{< /code >}}
 agent.yml config file example | {{< code shell >}}


### PR DESCRIPTION
## Description
The stated environment variable for keepalive-interval was incorrect, and the table header for strip-networks was also incorrect.

## Motivation and Context
The incorrectly stated environment variable is misleading, and the incorrect table header is confusing.