### PR TITLE
DOCS-1644 - 6.14.1 release notes

### DIFF
--- a/content/sensu-go/6.14/release-notes.md
+++ b/content/sensu-go/6.14/release-notes.md
@@ -9,6 +9,7 @@ version: "6.14"
 menu: "sensu-go-6.14"
 ---
 
+- [6.14.1 release notes](#6141-release-notes)
 - [6.14.0 release notes](#6140-release-notes)
 - [6.13.1 release notes](#6131-release-notes)
 - [6.13.0 release notes](#6130-release-notes)
@@ -117,6 +118,23 @@ PATCH versions include backward-compatible bug fixes.
 ### Upgrading
 
 Read the [upgrade guide][1] for information about upgrading to the latest version of Sensu Go.
+
+---
+
+## 6.14.1 release notes
+
+**May 21, 2025** &mdash; The latest release of Sensu Go, version 6.14.1, is now available for download.
+
+**FIXES**
+
+- WebSocket handshake compatibility in mixed-version deployments:
+    - In v6.14.0, FIPS 140-3 compliance changes modified the WebSocket handshake implementation for both FIPS and non-FIPS builds, changing the hashing algorithm in shared code from SHA-1 to SHA-256. As a result, environments running mixed versions of agents and backends, for example, a v6.14.0 backend paired with an older agent, or vice versa could experience failed WebSocket handshakes due to the algorithm mismatch. 
+    - This fix restores the original SHA-1 behavior for non-FIPS builds while retaining SHA-256 for FIPS 140-3 builds.
+    - This fix also restores the compatibility for mixed-version non-FIPS deployments while preserving the required cryptographic behavior for FIPS environments.
+
+- ANSI formatting in the Event Summary page:
+    - In v6.14.0, upgrading Node.js from 14.x to 20.x introduced unintended ANSI escape code rendering in the Event Summary page, causing some text to appear mangled or improperly formatted. 
+    - This fix restores correct text rendering and display behavior in the Event Summary UI.
 
 ---
 

--- a/content/sensu-go/6.14/release-notes.md
+++ b/content/sensu-go/6.14/release-notes.md
@@ -136,6 +136,7 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
     - In v6.14.0, upgrading Node.js from 14.x to 20.x introduced unintended ANSI escape code rendering in the Event Summary page, causing some text to appear mangled or improperly formatted. 
     - This fix restores correct text rendering and display behavior in the Event Summary UI.
 
+
 ---
 
 # 6.14.0 release notes

--- a/content/sensu-go/6.14/release-notes.md
+++ b/content/sensu-go/6.14/release-notes.md
@@ -136,7 +136,6 @@ Read the [upgrade guide][1] for information about upgrading to the latest versio
     - In v6.14.0, upgrading Node.js from 14.x to 20.x introduced unintended ANSI escape code rendering in the Event Summary page, causing some text to appear mangled or improperly formatted. 
     - This fix restores correct text rendering and display behavior in the Event Summary UI.
 
-
 ---
 
 # 6.14.0 release notes

--- a/content/sensu-go/6.14/versions.md
+++ b/content/sensu-go/6.14/versions.md
@@ -24,7 +24,7 @@ This table lists the supported versions of Sensu Go with links to active documen
 
 | Version | Release date     | Status    |     |
 | ------- |   -------------- | --------- | --- |
-6.14.1 | [May 21, 2026][104] | Supported | <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-14_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a>
+6.14.1 | [May 21, 2026][104] | Supported | <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-14-1_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a>
 6.14.0 | [April 15, 2026][103] | Supported | <!-- <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-14_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a> -->
 6.13.1 | [October 29, 2025][102] | Supported |  <!-- <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-13_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a> -->
 6.13.0 | [April 3, 2025][101] | Supported | <!-- <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-13_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a> -->

--- a/content/sensu-go/6.14/versions.md
+++ b/content/sensu-go/6.14/versions.md
@@ -24,10 +24,11 @@ This table lists the supported versions of Sensu Go with links to active documen
 
 | Version | Release date     | Status    |     |
 | ------- |   -------------- | --------- | --- |
+6.14.1 | [May 21, 2026][104] | Supported | <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-14_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a>
 6.14.0 | [April 15, 2026][103] | Supported | <!-- <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-14_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a> -->
 6.13.1 | [October 29, 2025][102] | Supported |  <!-- <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-13_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a> -->
 6.13.0 | [April 3, 2025][101] | Supported | <!-- <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-13_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a> -->
-6.12.0 | [November 13, 2024][100] | Supported | <!-- <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-12_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a> -->
+6.12.0 | [November 13, 2024][100] |  Not supported | <!-- <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-12_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a> -->
 6.11.0 | [January 31, 2024][99] | Not supported | <!-- <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-11_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a> -->
 6.10.0 | [May 23, 2023][98] | Not supported | <!-- <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-10_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a> -->
 6.9.2 | [March 8, 2023][97] | Not supported | <a href="https://sensu-docs.s3.amazonaws.com/pdfs/sensu-go-6-9_sensu-docs.pdf"><img src="/images/download-icon.png" width="30" height="30" title="Download Offline Docs" alt="Download Offline Docs"></a>
@@ -225,3 +226,4 @@ This table lists the supported versions of Sensu Go with links to active documen
 [101]: https://docs.sensu.io/sensu-go/latest/release-notes/#6130-release-notes
 [102]: https://docs.sensu.io/sensu-go/latest/release-notes/#6131-release-notes
 [103]: https://docs.sensu.io/sensu-go/latest/release-notes/#6140-release-notes
+[104]: https://docs.sensu.io/sensu-go/latest/release-notes/#6141-release-notes


### PR DESCRIPTION
## Description
This PR adds release notes for the Sensu Go 6.14.1 release.

## Motivation and Context
Ticket - https://sumologic.atlassian.net/browse/DOCS-1644

## Review Instructions
Review the content for sensu go v6.14.1 [here](https://github.com/sensu/sensu-docs/pull/4237/changes). In addition, you can also build the site locally and review the release notes.
